### PR TITLE
Support Pydantic AI and Cargo AI agent formats

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -1,2 +1,19 @@
 # Agents
-Place your agent JSON files here.
+
+This folder holds your agent definitions. Tembo Agent Studio supports two
+declarative, file-based formats out of the box:
+
+- **Pydantic AI `AgentSpec` (YAML or JSON)** — the canonical, primary format.
+  New starter templates and the v0.2 chat-to-PR authoring engine target this
+  format. Example: [`hello-world.yaml`](./hello-world.yaml).
+
+- **Cargo AI JSON** — supported as an import path and as a runnable format.
+  Useful if you already have Cargo AI agents on disk. Example:
+  [`hello-world.json`](./hello-world.json).
+
+Pick whichever format fits the agent. Both live next to each other in the
+repo, both diff cleanly in a pull request, and both run through the same
+TAS runtime.
+
+For the format decision and rationale, see
+[`../context/0.1/AGENT_FORMAT.md`](../context/0.1/AGENT_FORMAT.md).

--- a/agents/hello-world.yaml
+++ b/agents/hello-world.yaml
@@ -1,0 +1,15 @@
+# Sample agent — Pydantic AI `AgentSpec` (YAML).
+# This is the canonical, primary format for Tembo Agent Studio agents.
+# See ../context/0.1/AGENT_FORMAT.md for the format decision.
+#
+# Load in code with:
+#   from pydantic_ai import Agent
+#   agent = Agent.from_file('agents/hello-world.yaml')
+model: anthropic:claude-opus-4-6
+name: hello-world
+description: Sample agent — friendly greeter used to verify a workspace runs.
+instructions: |
+  You are a friendly agent.
+  Greet the user warmly and answer briefly.
+model_settings:
+  max_tokens: 512

--- a/bin/tembo-agent-studio.js
+++ b/bin/tembo-agent-studio.js
@@ -17,7 +17,8 @@ program.command('onboard').description('Bootstrap').option('--yes').action(async
   await fs.writeFile('docker-compose.yml', 'version: \'3.8\'\nservices:\n  tas:\n    image: node:20-alpine\n    working_dir: /app\n    volumes:\n      - .:/app\n    ports:\n      - "3000:3000"\n    command: npm start\n    environment:\n      - NODE_ENV=production\n');
   await fs.writeFile('.env.example', '# Tembo Agent Studio\nTEMBO_API_KEY=your_key\nGITHUB_TOKEN=your_token\nDATABASE_URL=sqlite:./tas.db\nPORT=3000\n');
   await fs.writeJson('agents/hello-world.json', {name:"hello-world",description:"Sample",instructions:"You are a friendly agent.",triggers:{schedule:"0 9 * * *"}}, {spaces:2});
-  await fs.writeFile('agents/README.md', '# Agents\n\nPlace your agent JSON files here.\n');
+  await fs.writeFile('agents/hello-world.yaml', '# Sample agent — Pydantic AI `AgentSpec` (YAML).\n# This is the canonical, primary format for Tembo Agent Studio agents.\n# See ../context/0.1/AGENT_FORMAT.md for the format decision.\nmodel: anthropic:claude-opus-4-6\nname: hello-world\ndescription: Sample agent — friendly greeter used to verify a workspace runs.\ninstructions: |\n  You are a friendly agent.\n  Greet the user warmly and answer briefly.\nmodel_settings:\n  max_tokens: 512\n');
+  await fs.writeFile('agents/README.md', '# Agents\n\nTAS supports two declarative agent formats:\n\n- **Pydantic AI `AgentSpec` (YAML or JSON)** — canonical, primary format. See `hello-world.yaml`.\n- **Cargo AI JSON** — supported import format. See `hello-world.json`.\n\nSee `../context/0.1/AGENT_FORMAT.md` for the format decision.\n');
   console.log(chalk.green('✅ Done!'));
   console.log('Next: cp .env.example .env && docker compose up -d');
 });

--- a/context/0.1/AGENT_FORMAT.md
+++ b/context/0.1/AGENT_FORMAT.md
@@ -1,0 +1,127 @@
+# Agent Format Decision (v0.1)
+
+> **Status:** Accepted — May 2026.
+> **Scope:** Applies from v0.1 onward. Revisable on a phase boundary if a customer pilot surfaces a blocker.
+
+## TL;DR
+
+TAS supports two declarative, file-based agent formats starting in v0.1:
+
+1. **[Pydantic AI `AgentSpec`](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/)** (YAML or JSON) — the **canonical, primary** format. New starter templates, the v0.2 chat-to-PR authoring engine, and v0.3+ tooling target this format first.
+2. **[Cargo AI](https://cargo-ai.org/) JSON** — supported as an **import path** and as a runnable format in its own right. Customers who already have Cargo AI agents do not need to convert them by hand to use TAS.
+
+Everything else (LangGraph, OpenAI Agents SDK, Mastra, CrewAI, Vercel AI SDK, AutoGen, Semantic Kernel, etc.) is intentionally **not** a supported authoring format in v0.1. Code-defined agents may be runnable in later phases, but the v0.1 promise is single-file, declarative, diff-native.
+
+## Why this matters
+
+The root `README.md` makes four commitments that this decision has to honor:
+
+1. Git is the system of record.
+2. Every change is reviewable as a diff.
+3. Adaptation is allowed; drift is governed.
+4. Self-hostable first.
+
+The v0.2 phase doc adds a fifth constraint that hits the format hardest: **non-engineers must be able to drive changes** through chat-to-PR, and **reviewers must be able to read the diff**. That single line eliminates most of the agent-framework landscape.
+
+If the diff for "the customer-reply agent should also handle quote requests" is a non-trivial change to a Python state graph or a TypeScript module, a PM cannot review it and an EM cannot approve it on their phone. The format itself has to make that diff small and human-readable.
+
+## What we evaluated
+
+| Option | Format | Maturity | Diff-native? | Verdict |
+| --- | --- | --- | --- | --- |
+| **Pydantic AI `AgentSpec`** | YAML / JSON, single file, schema-validated | 17k stars, backed by Pydantic team, weekly releases | Yes | **Primary** |
+| **Cargo AI** | Single JSON file, JSON Logic for branching, Rust runtime | ~4 stars, pre-1.0, single maintainer, MIT, local-first | Yes | **Supported import** |
+| **LangGraph** | Python code (graph) | 32k stars, durable execution, LangSmith observability | No (code diff) | Not authored, possibly runnable later |
+| **OpenAI Agents SDK** | Python code, sibling JS/TS | 26k stars, multi-provider, sandbox agents | No (code diff) | Not authored, possibly runnable later |
+| **Mastra** | TypeScript code | 24k stars, Apache-2.0 with `ee/` source-available tier | No (code diff) | Not authored; license model also collides with the "self-hostable first" principle |
+| **CrewAI** | YAML for agents + tasks, but a Python `crew.py` is required | 51k stars, standalone, strong community | Partial — orchestration is still code | Not authored |
+| **Vercel AI SDK** | TypeScript primitives (`ToolLoopAgent`) | 24k stars, provider routing, great UI hooks | No | Building-block, not a format |
+| **AutoGen / AG2** | Python | Microsoft Research, multi-agent conversation | No | Skip for v0.1 |
+| **Semantic Kernel** | C# / Python / Java | Microsoft, .NET-leaning | No | Skip for v0.1 |
+| **Google ADK** | Python, Google-cloud-flavored | Newer | No | Skip for v0.1 |
+| **AGNTCY / draft agent-spec standards** | Spec | Pre-1.0, in flux | Not yet shippable | Track, do not adopt |
+
+## Why Pydantic AI `AgentSpec` is the primary format
+
+1. **It is genuinely declarative.** An agent is one YAML or JSON file containing `model`, `instructions`, `capabilities`, `output_schema`, `deps_schema`, and `model_settings`. `Agent.from_file('agent.yaml')` is the entire constructor. That is exactly the shape TAS needs to put into a Git repo and review as a diff.
+2. **Schema-validated by design.** `deps_schema` and `output_schema` are real JSON Schemas. v0.4's governance phase is going to want exactly this kind of guardrail (a CI check can block diffs that break the contract before a human reviews them).
+3. **Companion JSON Schema for editor autocompletion.** `AgentSpec.to_file()` emits a JSON Schema sidecar that the YAML Language Server picks up. v0.2's review UX gets autocomplete and inline validation in any modern editor for free.
+4. **Model-agnostic out of the box.** OpenAI, Anthropic, Google, xAI, Bedrock, Cerebras, Cohere, Groq, Hugging Face, Mistral, Ollama, OpenRouter — plus a documented path for custom models. Cargo AI is currently OpenAI/Codex + Ollama. We need the broad coverage for early pilots.
+5. **Observability is included.** `instrument: true` lights up Pydantic Logfire (OpenTelemetry under the hood). v0.3's per-agent operational dashboard becomes a configuration concern, not a build concern.
+6. **MCP, A2A, durable execution, and evals all exist.** Each one maps directly to a later TAS phase (`MCP` → v0.5 corrections, `durable execution` → long-running v0.5+ workflows, `evals` → v0.4 governance signals).
+7. **Maintainer signal is strong.** 17k stars, a clear backer (Pydantic Inc.), weekly-ish releases, used by the OpenAI SDK, Google ADK, Anthropic SDK, LangChain, LlamaIndex, CrewAI, and others for validation. The "what if this project goes away?" risk is low.
+8. **Authoring is allowed to stay in code, too.** The same library supports code-defined agents. A customer who *does* want to author in Python gets the same runtime; their PR is just a `.py` diff instead of a `.yaml` diff. The format choice does not constrain power users.
+
+## Why Cargo AI is supported, not dropped
+
+1. **It is also genuinely declarative.** A Cargo AI agent is a single JSON file with `inputs`, `agent_schema`, `actions`, and `run`. The mental model overlaps heavily with `AgentSpec`, so a converter is a one-week mapping, not a rewrite.
+2. **Honoring existing assets.** The original 0.1 plan referenced Cargo AI explicitly; some early customers may already have Cargo AI agents on disk. Forcing them to convert by hand to evaluate TAS is the wrong opening move.
+3. **The "hatch to native binary" story is genuinely useful** for some self-hosted scenarios where the agent should ship as a single executable.
+4. **JSON Logic in `actions[].logic` is reviewable** — a PM can read a condition like `{"==": [{"var": "needs_follow_up"}, true]}` without learning Python.
+5. **Optionality is cheap here.** Importer + runner support is a small surface area. If Cargo AI's community grows, we are well-positioned. If it stalls, we have lost almost nothing.
+
+## Why we did not lead with Cargo AI alone
+
+This was the founder-preferred path on the way in, so it deserves an explicit answer.
+
+- **Maturity.** ~4 GitHub stars, one maintainer (`analyzer1`), pre-1.0. A v0.1 customer asking "what happens if that project stops shipping?" has no good answer when it is our *only* supported format.
+- **Ecosystem gaps.** No first-party MCP server library, no third-party tool registry, no built-in evaluators, no observability story beyond stdout. v0.3 and v0.4 would have to build all of that ourselves.
+- **Hireability and recognition.** Almost no engineers have heard of Cargo AI. Customers comparing TAS against a CrewAI- or LangGraph-flavored competitor will pattern-match.
+- **Authoring verbosity.** The Cargo AI JSON is structurally rich (`runtime_vars`, named inputs, JSON Logic actions), which is great for execution but verbose for "PM wants a 1-line tweak" diffs.
+- **Bundling risk.** Tying TAS's format to a pre-1.0 third-party project ties our exit bar (`10 consecutive successful runs over a week`) to their stability. Pydantic AI on a recent release gives us a much shorter path to that bar.
+
+## Why we did not pick a code-first framework
+
+LangGraph, OpenAI Agents SDK, Mastra, and Vercel AI SDK are excellent runtimes. They are not a good fit for the **v0.2 chat-to-PR** authoring loop because:
+
+- A non-engineer cannot read a Python state graph or a TypeScript module as a review.
+- A coding agent producing diffs against complex code is more error-prone than producing diffs against a typed YAML schema.
+- The "one file = one agent" mental model breaks down once an agent's behavior is spread across multiple modules, configs, and helper functions.
+
+We expect to **run** code-defined agents eventually (the Pydantic AI library itself supports them), but authoring them in chat-to-PR is not a v0.1–v0.2 promise.
+
+## Why we did not pick CrewAI specifically
+
+CrewAI's YAML covers role/goal/backstory/tasks, but the orchestration always lives in a Python `crew.py`. So changing an agent's *behavior* is usually a code change in practice, which puts it back in the "code-first" bucket above. The YAML-only surface is too thin for what TAS needs.
+
+## What this means concretely for each phase
+
+### v0.1 — Foundation
+- Starter templates ship as Pydantic AI `AgentSpec` YAML.
+- `import` flow accepts both Cargo AI JSON and Pydantic AI `AgentSpec` YAML/JSON.
+- Both formats run successfully end-to-end.
+- A documented converter exists (Cargo AI JSON → `AgentSpec` YAML). Customers can opt to convert on import or keep the original.
+
+### v0.2 — Authoring velocity
+- The Tembo coding agent produces `AgentSpec` YAML diffs as its primary output.
+- For agents that originated as Cargo AI JSON, the coding agent edits them in-place in Cargo AI JSON (we do not auto-convert on edit; that would defeat the diff-readability point).
+- Linters reject malformed specs against the JSON Schema sidecar before the human review.
+
+### v0.3 — Operational surface
+- `instrument: true` is the default for new `AgentSpec` agents; this drives the per-agent dashboard with no extra wiring.
+- Per-agent operational dashboards read from Logfire / OpenTelemetry traces.
+
+### v0.4 — Governance depth
+- `output_schema` and `deps_schema` deltas are first-class signals in the audit timeline ("schema-breaking change" gets its own badge).
+- Eval suites (`pydantic_evals` or equivalent) can be referenced from the spec and run on PR.
+
+### v0.5 — Adaptive intelligence
+- Corrections-to-PR produce `AgentSpec` diffs by default (smallest, most reviewable surface).
+- Variant proposals are new spec files, not branches inside a file.
+
+### v0.6 — Mycelium
+- Patterns are exchanged as `AgentSpec` fragments (typed, schema-validated, provenance-bearing), not as opaque blobs.
+
+## Open questions
+
+- Should the v0.1 converter (Cargo AI JSON → `AgentSpec` YAML) be one-way only, or round-trippable? Lossless round-tripping is hard because the two formats have different action models (JSON Logic + run-steps vs. capabilities + tools).
+- Do we ship a default observability backend in v0.1 (Logfire-compatible OTel collector) or wait for v0.3? Leaning: defer, but make `instrument: true` always work against any OTel endpoint the customer points us at.
+- What is the right home for the JSON Schema sidecar in the workspace repo? `agents/.schemas/` is the current proposal — keeps it out of agent listings while staying versioned alongside the agents themselves.
+
+## References
+
+- [Pydantic AI `AgentSpec` docs](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/)
+- [Pydantic AI repository](https://github.com/pydantic/pydantic-ai)
+- [Cargo AI homepage](https://cargo-ai.org/)
+- [Cargo AI repository](https://github.com/analyzer1/cargo-ai)
+- [LangGraph](https://github.com/langchain-ai/langgraph), [OpenAI Agents SDK](https://github.com/openai/openai-agents-python), [CrewAI](https://github.com/crewAIInc/crewAI), [Mastra](https://github.com/mastra-ai/mastra), [Vercel AI SDK](https://github.com/vercel/ai) — surveyed and not adopted as authoring formats for v0.1.

--- a/context/0.1/DEMO_SCRIPT.md
+++ b/context/0.1/DEMO_SCRIPT.md
@@ -51,7 +51,7 @@
 - Save.
 
 **Say:**
-> "v0.1 ships with a small starter library. We're not asking your team to learn an agent JSON format — that's an implementation detail. In v0.2 you'll create these from chat instead."
+> "v0.1 ships with a small starter library. The format under the hood is a single YAML or JSON file per agent — declarative, diffable, lives in your repo. We support Pydantic AI `AgentSpec` as the primary format and import from Cargo AI JSON, but at v0.1 we're not asking your team to learn either. In v0.2 you'll create these from chat instead."
 
 ### 6. Run manually and show logs (10:00 – 13:00)
 **Show:** the new agent's detail page.

--- a/context/0.1/README.md
+++ b/context/0.1/README.md
@@ -31,7 +31,7 @@ We are not trying to be impressive yet. We are trying to be dependable enough th
 - **Self-hosted deploy.** Docker Compose path + environment variable reference. Single-node target.
 - **`better-auth` integration.** Email/password baseline plus SSO adapter slots so customers can wire their own IdP.
 - **Workspace onboarding.** Connect one Git repository and store one Tembo API key per workspace.
-- **Baseline agent definition.** Create from a starter template or import an existing Cargo AI JSON file.
+- **Baseline agent definition.** Create from a starter template (Pydantic AI `AgentSpec` YAML by default) or import an existing Cargo AI JSON file. See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the format decision.
 - **Manual run + logs.** "Run now" button, status (queued/running/succeeded/failed), tail of run output.
 
 ## Out of Scope for v0.1
@@ -55,7 +55,7 @@ Build the minimum trustworthy control plane first. Resist the temptation to demo
 - **Backend:** Rust API for runtime and orchestration.
 - **Auth:** `better-auth` with adapter slots for SAML/OIDC.
 - **Tembo integration:** API-key mode (a future phase may add MCP-based auth when public MCP is stable).
-- **Agent format:** Cargo AI JSON. Treated as an implementation detail in v0.1 — users do not need to learn it to import a starter template.
+- **Agent format:** Pydantic AI `AgentSpec` (YAML or JSON) as the canonical, primary format; Cargo AI JSON supported as an import path. Both are declarative, diff-native single-file definitions — exactly what the v0.2 chat-to-PR loop and the v0.4 audit trail depend on. See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the full rationale, including why we did not pick a code-first framework (LangGraph, OpenAI Agents SDK, Mastra, CrewAI). Treated as an implementation detail in v0.1 — users do not need to learn either format to import a starter template.
 - **Storage:** workspace-local Postgres for run metadata; Git for agent source.
 
 ## Customer Quote (Drafted)

--- a/context/0.1/USER_STORIES.md
+++ b/context/0.1/USER_STORIES.md
@@ -61,13 +61,14 @@ Format: Connextra (**As a** _role_, **I want** _capability_, **so that** _benefi
 
 ## US-0.1-05 — Create or import a baseline agent
 
-**As an** Operator, **I want** to create an agent from a starter template or import an existing Cargo AI JSON definition, **so that** I can run a first production-relevant workflow without authoring code from scratch.
+**As an** Operator, **I want** to create an agent from a starter template (Pydantic AI `AgentSpec` YAML by default) or import an existing Cargo AI JSON definition, **so that** I can run a first production-relevant workflow without authoring code from scratch.
 
 **Acceptance Criteria**
 
-- At least one starter template is available out of the box.
-- Importing an existing definition surfaces validation errors clearly (no silent failure).
-- A created/imported agent shows up in the workspace agent list with a known status.
+- At least one starter template is available out of the box, in Pydantic AI `AgentSpec` YAML.
+- Importing a Cargo AI JSON definition works and surfaces validation errors clearly (no silent failure).
+- Importing a Pydantic AI `AgentSpec` YAML or JSON definition works and surfaces validation errors clearly (no silent failure).
+- A created/imported agent shows up in the workspace agent list with a known status, regardless of which source format it was created from.
 
 ---
 


### PR DESCRIPTION
- Added detailed agent format decision document `context/0.1/AGENT_FORMAT.md` explaining why Pydantic AI `AgentSpec` is primary and Cargo AI JSON is supported.
- Updated onboarding script to create a Pydantic AI `AgentSpec` YAML starter agent and updated agents README to explain supported formats.
- Added a sample Pydantic AI `AgentSpec` YAML agent `agents/hello-world.yaml`.
- Updated documentation in multiple places (`context/0.1/README.md`, `context/0.1/USER_STORIES.md`, `context/0.1/DEMO_SCRIPT.md`) to reflect support for both Pydantic AI `AgentSpec` and Cargo AI JSON formats.
- Clarified that v0.1 supports these two declarative, diff-native, single-file agent formats, with Pydantic AI `AgentSpec` as the canonical format and Cargo AI JSON as an import path.
- Explained rationale for not supporting code-first frameworks like Mastra in v0.1 in the format decision document.
- Ensured all changes emphasize that users do not need to learn these formats in v0.1, as they are implementation details, with chat-to-PR authoring coming in v0.2.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/a9a56b28-6c8f-4f91-9c3a-830699e48ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/opencode:claude-opus-4-7?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/opencode:claude-opus-4-7?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/opencode:claude-opus-4-7?theme=light&v=11" height="28"></picture></a> 