### PR TITLE
Support multiple agent frameworks including Cargo AI and Mastra

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -1,2 +1,19 @@
 # Agents
-Place your agent JSON files here.
+
+This folder holds your agent definitions. Tembo Agent Studio supports two
+declarative, file-based formats out of the box:
+
+- **Pydantic AI `AgentSpec` (YAML or JSON)** — the canonical, primary format.
+  New starter templates and the v0.2 chat-to-PR authoring engine target this
+  format. Example: [`hello-world.yaml`](./hello-world.yaml).
+
+- **Cargo AI JSON** — supported as an import path and as a runnable format.
+  Useful if you already have Cargo AI agents on disk. Example:
+  [`hello-world.json`](./hello-world.json).
+
+Pick whichever format fits the agent. Both live next to each other in the
+repo, both diff cleanly in a pull request, and both run through the same
+TAS runtime.
+
+For the format decision and rationale, see
+[`../context/0.1/AGENT_FORMAT.md`](../context/0.1/AGENT_FORMAT.md).

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,19 +1,28 @@
 # Agents
 
-This folder holds your agent definitions. Tembo Agent Studio supports two
-declarative, file-based formats out of the box:
+This folder holds your agent definitions. Tembo Agent Studio supports
+multiple formats.
 
-- **Pydantic AI `AgentSpec` (YAML or JSON)** — the canonical, primary format.
-  New starter templates and the v0.2 chat-to-PR authoring engine target this
-  format. Example: [`hello-world.yaml`](./hello-world.yaml).
+**Declarative defaults — ship as v0.1 starters:**
 
-- **Cargo AI JSON** — supported as an import path and as a runnable format.
-  Useful if you already have Cargo AI agents on disk. Example:
-  [`hello-world.json`](./hello-world.json).
+- **Pydantic AI `AgentSpec` (YAML or JSON)** — the canonical declarative
+  default. Best fit for non-engineer authoring and the v0.2 chat-to-PR
+  loop. Example: [`hello-world.yaml`](./hello-world.yaml).
 
-Pick whichever format fits the agent. Both live next to each other in the
-repo, both diff cleanly in a pull request, and both run through the same
-TAS runtime.
+- **Cargo AI JSON** — alternate declarative default. Single-file, locally
+  runnable, supports the "hatch to native binary" story.
+  Example: [`hello-world.json`](./hello-world.json).
 
-For the format decision and rationale, see
+**Code-defined frameworks — first-class supported:**
+
+- **LangGraph**, **OpenAI Agents SDK**, **Mastra**, **CrewAI**, and
+  **Pydantic AI's code mode** are all supported runtimes. Complex agents
+  often need custom tools, durable execution, or tight integration with a
+  host application — those use cases want code, not a YAML file.
+
+Pick whichever format fits the agent. The PR policy engine (review-required
+vs YOLO auto-merge, per agent) handles governance regardless of format.
+
+For the full format decision, the v0.1 ship list, and the development-vs-
+production policy model, see
 [`../context/0.1/AGENT_FORMAT.md`](../context/0.1/AGENT_FORMAT.md).

--- a/agents/hello-world.yaml
+++ b/agents/hello-world.yaml
@@ -1,0 +1,15 @@
+# Sample agent — Pydantic AI `AgentSpec` (YAML).
+# This is the canonical, primary format for Tembo Agent Studio agents.
+# See ../context/0.1/AGENT_FORMAT.md for the format decision.
+#
+# Load in code with:
+#   from pydantic_ai import Agent
+#   agent = Agent.from_file('agents/hello-world.yaml')
+model: anthropic:claude-opus-4-6
+name: hello-world
+description: Sample agent — friendly greeter used to verify a workspace runs.
+instructions: |
+  You are a friendly agent.
+  Greet the user warmly and answer briefly.
+model_settings:
+  max_tokens: 512

--- a/bin/tembo-agent-studio.js
+++ b/bin/tembo-agent-studio.js
@@ -17,7 +17,8 @@ program.command('onboard').description('Bootstrap').option('--yes').action(async
   await fs.writeFile('docker-compose.yml', 'version: \'3.8\'\nservices:\n  tas:\n    image: node:20-alpine\n    working_dir: /app\n    volumes:\n      - .:/app\n    ports:\n      - "3000:3000"\n    command: npm start\n    environment:\n      - NODE_ENV=production\n');
   await fs.writeFile('.env.example', '# Tembo Agent Studio\nTEMBO_API_KEY=your_key\nGITHUB_TOKEN=your_token\nDATABASE_URL=sqlite:./tas.db\nPORT=3000\n');
   await fs.writeJson('agents/hello-world.json', {name:"hello-world",description:"Sample",instructions:"You are a friendly agent.",triggers:{schedule:"0 9 * * *"}}, {spaces:2});
-  await fs.writeFile('agents/README.md', '# Agents\n\nPlace your agent JSON files here.\n');
+  await fs.writeFile('agents/hello-world.yaml', '# Sample agent — Pydantic AI `AgentSpec` (YAML).\n# This is the canonical, primary format for Tembo Agent Studio agents.\n# See ../context/0.1/AGENT_FORMAT.md for the format decision.\nmodel: anthropic:claude-opus-4-6\nname: hello-world\ndescription: Sample agent — friendly greeter used to verify a workspace runs.\ninstructions: |\n  You are a friendly agent.\n  Greet the user warmly and answer briefly.\nmodel_settings:\n  max_tokens: 512\n');
+  await fs.writeFile('agents/README.md', '# Agents\n\nTAS supports two declarative agent formats:\n\n- **Pydantic AI `AgentSpec` (YAML or JSON)** — canonical, primary format. See `hello-world.yaml`.\n- **Cargo AI JSON** — supported import format. See `hello-world.json`.\n\nSee `../context/0.1/AGENT_FORMAT.md` for the format decision.\n');
   console.log(chalk.green('✅ Done!'));
   console.log('Next: cp .env.example .env && docker compose up -d');
 });

--- a/context/0.1/AGENT_FORMAT.md
+++ b/context/0.1/AGENT_FORMAT.md
@@ -1,0 +1,127 @@
+# Agent Format Decision (v0.1)
+
+> **Status:** Accepted — May 2026.
+> **Scope:** Applies from v0.1 onward. Revisable on a phase boundary if a customer pilot surfaces a blocker.
+
+## TL;DR
+
+TAS supports two declarative, file-based agent formats starting in v0.1:
+
+1. **[Pydantic AI `AgentSpec`](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/)** (YAML or JSON) — the **canonical, primary** format. New starter templates, the v0.2 chat-to-PR authoring engine, and v0.3+ tooling target this format first.
+2. **[Cargo AI](https://cargo-ai.org/) JSON** — supported as an **import path** and as a runnable format in its own right. Customers who already have Cargo AI agents do not need to convert them by hand to use TAS.
+
+Everything else (LangGraph, OpenAI Agents SDK, Mastra, CrewAI, Vercel AI SDK, AutoGen, Semantic Kernel, etc.) is intentionally **not** a supported authoring format in v0.1. Code-defined agents may be runnable in later phases, but the v0.1 promise is single-file, declarative, diff-native.
+
+## Why this matters
+
+The root `README.md` makes four commitments that this decision has to honor:
+
+1. Git is the system of record.
+2. Every change is reviewable as a diff.
+3. Adaptation is allowed; drift is governed.
+4. Self-hostable first.
+
+The v0.2 phase doc adds a fifth constraint that hits the format hardest: **non-engineers must be able to drive changes** through chat-to-PR, and **reviewers must be able to read the diff**. That single line eliminates most of the agent-framework landscape.
+
+If the diff for "the customer-reply agent should also handle quote requests" is a non-trivial change to a Python state graph or a TypeScript module, a PM cannot review it and an EM cannot approve it on their phone. The format itself has to make that diff small and human-readable.
+
+## What we evaluated
+
+| Option | Format | Maturity | Diff-native? | Verdict |
+| --- | --- | --- | --- | --- |
+| **Pydantic AI `AgentSpec`** | YAML / JSON, single file, schema-validated | 17k stars, backed by Pydantic team, weekly releases | Yes | **Primary** |
+| **Cargo AI** | Single JSON file, JSON Logic for branching, Rust runtime | ~4 stars, pre-1.0, single maintainer, MIT, local-first | Yes | **Supported import** |
+| **LangGraph** | Python code (graph) | 32k stars, durable execution, LangSmith observability | No (code diff) | Not authored, possibly runnable later |
+| **OpenAI Agents SDK** | Python code, sibling JS/TS | 26k stars, multi-provider, sandbox agents | No (code diff) | Not authored, possibly runnable later |
+| **Mastra** | TypeScript code | 24k stars, Apache-2.0 with `ee/` source-available tier | No (code diff) | Not authored; license model also collides with the "self-hostable first" principle |
+| **CrewAI** | YAML for agents + tasks, but a Python `crew.py` is required | 51k stars, standalone, strong community | Partial — orchestration is still code | Not authored |
+| **Vercel AI SDK** | TypeScript primitives (`ToolLoopAgent`) | 24k stars, provider routing, great UI hooks | No | Building-block, not a format |
+| **AutoGen / AG2** | Python | Microsoft Research, multi-agent conversation | No | Skip for v0.1 |
+| **Semantic Kernel** | C# / Python / Java | Microsoft, .NET-leaning | No | Skip for v0.1 |
+| **Google ADK** | Python, Google-cloud-flavored | Newer | No | Skip for v0.1 |
+| **AGNTCY / draft agent-spec standards** | Spec | Pre-1.0, in flux | Not yet shippable | Track, do not adopt |
+
+## Why Pydantic AI `AgentSpec` is the primary format
+
+1. **It is genuinely declarative.** An agent is one YAML or JSON file containing `model`, `instructions`, `capabilities`, `output_schema`, `deps_schema`, and `model_settings`. `Agent.from_file('agent.yaml')` is the entire constructor. That is exactly the shape TAS needs to put into a Git repo and review as a diff.
+2. **Schema-validated by design.** `deps_schema` and `output_schema` are real JSON Schemas. v0.4's governance phase is going to want exactly this kind of guardrail (a CI check can block diffs that break the contract before a human reviews them).
+3. **Companion JSON Schema for editor autocompletion.** `AgentSpec.to_file()` emits a JSON Schema sidecar that the YAML Language Server picks up. v0.2's review UX gets autocomplete and inline validation in any modern editor for free.
+4. **Model-agnostic out of the box.** OpenAI, Anthropic, Google, xAI, Bedrock, Cerebras, Cohere, Groq, Hugging Face, Mistral, Ollama, OpenRouter — plus a documented path for custom models. Cargo AI is currently OpenAI/Codex + Ollama. We need the broad coverage for early pilots.
+5. **Observability is included.** `instrument: true` lights up Pydantic Logfire (OpenTelemetry under the hood). v0.3's per-agent operational dashboard becomes a configuration concern, not a build concern.
+6. **MCP, A2A, durable execution, and evals all exist.** Each one maps directly to a later TAS phase (`MCP` → v0.5 corrections, `durable execution` → long-running v0.5+ workflows, `evals` → v0.4 governance signals).
+7. **Maintainer signal is strong.** 17k stars, a clear backer (Pydantic Inc.), weekly-ish releases, used by the OpenAI SDK, Google ADK, Anthropic SDK, LangChain, LlamaIndex, CrewAI, and others for validation. The "what if this project goes away?" risk is low.
+8. **Authoring is allowed to stay in code, too.** The same library supports code-defined agents. A customer who *does* want to author in Python gets the same runtime; their PR is just a `.py` diff instead of a `.yaml` diff. The format choice does not constrain power users.
+
+## Why Cargo AI is supported, not dropped
+
+1. **It is also genuinely declarative.** A Cargo AI agent is a single JSON file with `inputs`, `agent_schema`, `actions`, and `run`. The mental model overlaps heavily with `AgentSpec`, so a converter is a one-week mapping, not a rewrite.
+2. **Honoring existing assets.** The original 0.1 plan referenced Cargo AI explicitly; some early customers may already have Cargo AI agents on disk. Forcing them to convert by hand to evaluate TAS is the wrong opening move.
+3. **The "hatch to native binary" story is genuinely useful** for some self-hosted scenarios where the agent should ship as a single executable.
+4. **JSON Logic in `actions[].logic` is reviewable** — a PM can read a condition like `{"==": [{"var": "needs_follow_up"}, true]}` without learning Python.
+5. **Optionality is cheap here.** Importer + runner support is a small surface area. If Cargo AI's community grows, we are well-positioned. If it stalls, we have lost almost nothing.
+
+## Why we did not lead with Cargo AI alone
+
+This was the founder-preferred path on the way in, so it deserves an explicit answer.
+
+- **Maturity.** ~4 GitHub stars, one maintainer (`analyzer1`), pre-1.0. A v0.1 customer asking "what happens if that project stops shipping?" has no good answer when it is our *only* supported format.
+- **Ecosystem gaps.** No first-party MCP server library, no third-party tool registry, no built-in evaluators, no observability story beyond stdout. v0.3 and v0.4 would have to build all of that ourselves.
+- **Hireability and recognition.** Almost no engineers have heard of Cargo AI. Customers comparing TAS against a CrewAI- or LangGraph-flavored competitor will pattern-match.
+- **Authoring verbosity.** The Cargo AI JSON is structurally rich (`runtime_vars`, named inputs, JSON Logic actions), which is great for execution but verbose for "PM wants a 1-line tweak" diffs.
+- **Bundling risk.** Tying TAS's format to a pre-1.0 third-party project ties our exit bar (`10 consecutive successful runs over a week`) to their stability. Pydantic AI on a recent release gives us a much shorter path to that bar.
+
+## Why we did not pick a code-first framework
+
+LangGraph, OpenAI Agents SDK, Mastra, and Vercel AI SDK are excellent runtimes. They are not a good fit for the **v0.2 chat-to-PR** authoring loop because:
+
+- A non-engineer cannot read a Python state graph or a TypeScript module as a review.
+- A coding agent producing diffs against complex code is more error-prone than producing diffs against a typed YAML schema.
+- The "one file = one agent" mental model breaks down once an agent's behavior is spread across multiple modules, configs, and helper functions.
+
+We expect to **run** code-defined agents eventually (the Pydantic AI library itself supports them), but authoring them in chat-to-PR is not a v0.1–v0.2 promise.
+
+## Why we did not pick CrewAI specifically
+
+CrewAI's YAML covers role/goal/backstory/tasks, but the orchestration always lives in a Python `crew.py`. So changing an agent's *behavior* is usually a code change in practice, which puts it back in the "code-first" bucket above. The YAML-only surface is too thin for what TAS needs.
+
+## What this means concretely for each phase
+
+### v0.1 — Foundation
+- Starter templates ship as Pydantic AI `AgentSpec` YAML.
+- `import` flow accepts both Cargo AI JSON and Pydantic AI `AgentSpec` YAML/JSON.
+- Both formats run successfully end-to-end.
+- A documented converter exists (Cargo AI JSON → `AgentSpec` YAML). Customers can opt to convert on import or keep the original.
+
+### v0.2 — Authoring velocity
+- The Tembo coding agent produces `AgentSpec` YAML diffs as its primary output.
+- For agents that originated as Cargo AI JSON, the coding agent edits them in-place in Cargo AI JSON (we do not auto-convert on edit; that would defeat the diff-readability point).
+- Linters reject malformed specs against the JSON Schema sidecar before the human review.
+
+### v0.3 — Operational surface
+- `instrument: true` is the default for new `AgentSpec` agents; this drives the per-agent dashboard with no extra wiring.
+- Per-agent operational dashboards read from Logfire / OpenTelemetry traces.
+
+### v0.4 — Governance depth
+- `output_schema` and `deps_schema` deltas are first-class signals in the audit timeline ("schema-breaking change" gets its own badge).
+- Eval suites (`pydantic_evals` or equivalent) can be referenced from the spec and run on PR.
+
+### v0.5 — Adaptive intelligence
+- Corrections-to-PR produce `AgentSpec` diffs by default (smallest, most reviewable surface).
+- Variant proposals are new spec files, not branches inside a file.
+
+### v0.6 — Mycelium
+- Patterns are exchanged as `AgentSpec` fragments (typed, schema-validated, provenance-bearing), not as opaque blobs.
+
+## Open questions
+
+- Should the v0.1 converter (Cargo AI JSON → `AgentSpec` YAML) be one-way only, or round-trippable? Lossless round-tripping is hard because the two formats have different action models (JSON Logic + run-steps vs. capabilities + tools).
+- Do we ship a default observability backend in v0.1 (Logfire-compatible OTel collector) or wait for v0.3? Leaning: defer, but make `instrument: true` always work against any OTel endpoint the customer points us at.
+- What is the right home for the JSON Schema sidecar in the workspace repo? `agents/.schemas/` is the current proposal — keeps it out of agent listings while staying versioned alongside the agents themselves.
+
+## References
+
+- [Pydantic AI `AgentSpec` docs](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/)
+- [Pydantic AI repository](https://github.com/pydantic/pydantic-ai)
+- [Cargo AI homepage](https://cargo-ai.org/)
+- [Cargo AI repository](https://github.com/analyzer1/cargo-ai)
+- [LangGraph](https://github.com/langchain-ai/langgraph), [OpenAI Agents SDK](https://github.com/openai/openai-agents-python), [CrewAI](https://github.com/crewAIInc/crewAI), [Mastra](https://github.com/mastra-ai/mastra), [Vercel AI SDK](https://github.com/vercel/ai) — surveyed and not adopted as authoring formats for v0.1.

--- a/context/0.1/AGENT_FORMAT.md
+++ b/context/0.1/AGENT_FORMAT.md
@@ -1,127 +1,175 @@
 # Agent Format Decision (v0.1)
 
-> **Status:** Accepted — May 2026.
+> **Status:** Accepted — May 2026. Supersedes the earlier "declarative-only" framing.
 > **Scope:** Applies from v0.1 onward. Revisable on a phase boundary if a customer pilot surfaces a blocker.
 
 ## TL;DR
 
-TAS supports two declarative, file-based agent formats starting in v0.1:
+TAS supports **multiple agent formats** from v0.1. Two are first-class defaults; the rest are first-class supported:
 
-1. **[Pydantic AI `AgentSpec`](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/)** (YAML or JSON) — the **canonical, primary** format. New starter templates, the v0.2 chat-to-PR authoring engine, and v0.3+ tooling target this format first.
-2. **[Cargo AI](https://cargo-ai.org/) JSON** — supported as an **import path** and as a runnable format in its own right. Customers who already have Cargo AI agents do not need to convert them by hand to use TAS.
+| Tier | Format | Why this tier |
+| --- | --- | --- |
+| **Default (declarative)** | [Pydantic AI `AgentSpec`](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/) (YAML / JSON) | Single-file, schema-validated, model-agnostic, broad ecosystem. Best fit for chat-to-PR authoring and for non-engineer reviewers when an org has those workflows turned on. |
+| **Default (declarative)** | [Cargo AI](https://cargo-ai.org/) JSON | Single-file, runnable as a native binary, structurally similar to `AgentSpec`. Honors existing assets; useful when a customer wants the "hatch to executable" story. |
+| **Supported (code)** | [LangGraph](https://github.com/langchain-ai/langgraph) (Python/TS) | Industry-standard for stateful, long-running, durable agents. Real customer need. |
+| **Supported (code)** | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) (Python + JS/TS) | Lightweight, multi-provider, growing fast, sandbox agents. Real customer need. |
+| **Supported (code)** | [Mastra](https://github.com/mastra-ai/mastra) (TypeScript) | First-class for TS-shop customers, integrates with Next.js / React stacks the same way TAS's own UI does. |
+| **Supported (code)** | [CrewAI](https://github.com/crewAIInc/crewAI) (Python + YAML) | Multi-agent orchestration with strong community traction. |
+| **Track, do not adopt** | AGNTCY drafts, Semantic Kernel, Google ADK, AutoGen / AG2, Vercel AI SDK primitives | Either too early, too platform-coupled, or building blocks rather than complete agent formats. |
 
-Everything else (LangGraph, OpenAI Agents SDK, Mastra, CrewAI, Vercel AI SDK, AutoGen, Semantic Kernel, etc.) is intentionally **not** a supported authoring format in v0.1. Code-defined agents may be runnable in later phases, but the v0.1 promise is single-file, declarative, diff-native.
+The change from the earlier draft: **complex agents will need custom code, and TAS should host that code, not push it out.** A senior engineer building a stateful multi-tool agent in LangGraph or a TS shop building one with Mastra is a customer we want, not one we tell to come back when we ship a declarative format that covers their case.
+
+## What changed in this revision
+
+The previous version of this ADR argued that all agents must be authored in a declarative YAML/JSON file, because the v0.2 chat-to-PR loop needs reviewers to read the diff. Two things break that argument:
+
+1. **YOLO mode is real.** Per `context/0.2/`, organizations choose the trust level per agent: review-required for customer-facing, YOLO auto-merge on green CI for low-stakes internal automations. The "reviewer must read the diff" gate only applies to review-required mode. For an agent under development with YOLO on, the diff readability question is moot — CI is the gate, not a human.
+
+2. **Production review applies to *any* artifact.** Once an agent ships to production, the org's review policy applies whether the file is YAML or Python. A senior engineer reviewing a LangGraph PR is doing the same governed thing as a PM reviewing an `AgentSpec` YAML PR; the artifact differs, the discipline doesn't.
+
+So the right axis isn't "declarative vs code." The right axes are:
+
+- **Lifecycle stage** — development (YOLO defaults allowed) vs production (review-required defaults, RBAC, audit signals).
+- **Author skill** — a PM editing instructions vs a senior engineer wiring a custom tool chain.
+- **Agent complexity** — a prompt-and-schema agent vs a stateful multi-tool durable workflow.
+
+Different combinations want different formats. TAS's job is to host all of them under the same governance plane, not to legislate which one is "right."
 
 ## Why this matters
 
-The root `README.md` makes four commitments that this decision has to honor:
+The root `README.md` operating principles still hold:
 
 1. Git is the system of record.
 2. Every change is reviewable as a diff.
 3. Adaptation is allowed; drift is governed.
 4. Self-hostable first.
 
-The v0.2 phase doc adds a fifth constraint that hits the format hardest: **non-engineers must be able to drive changes** through chat-to-PR, and **reviewers must be able to read the diff**. That single line eliminates most of the agent-framework landscape.
+None of these say the diff must be readable by a non-engineer. They say:
 
-If the diff for "the customer-reply agent should also handle quote requests" is a non-trivial change to a Python state graph or a TypeScript module, a PM cannot review it and an EM cannot approve it on their phone. The format itself has to make that diff small and human-readable.
+- The artifact must live in Git. **Code satisfies this.**
+- Changes must be reviewable. **Code is reviewable — that's what code review is.**
+- Governance applies to *every* change. **The policy engine doesn't care about format.**
+- Self-hostability is about the control plane, not the agent runtime.
 
-## What we evaluated
+The previous ADR conflated "reviewable" with "reviewable by a non-engineer." That was wrong. The system supports both modes because the customer mix supports both modes.
 
-| Option | Format | Maturity | Diff-native? | Verdict |
+## What we evaluated, restated
+
+| Option | Format | Maturity | Best for | Tier |
 | --- | --- | --- | --- | --- |
-| **Pydantic AI `AgentSpec`** | YAML / JSON, single file, schema-validated | 17k stars, backed by Pydantic team, weekly releases | Yes | **Primary** |
-| **Cargo AI** | Single JSON file, JSON Logic for branching, Rust runtime | ~4 stars, pre-1.0, single maintainer, MIT, local-first | Yes | **Supported import** |
-| **LangGraph** | Python code (graph) | 32k stars, durable execution, LangSmith observability | No (code diff) | Not authored, possibly runnable later |
-| **OpenAI Agents SDK** | Python code, sibling JS/TS | 26k stars, multi-provider, sandbox agents | No (code diff) | Not authored, possibly runnable later |
-| **Mastra** | TypeScript code | 24k stars, Apache-2.0 with `ee/` source-available tier | No (code diff) | Not authored; license model also collides with the "self-hostable first" principle |
-| **CrewAI** | YAML for agents + tasks, but a Python `crew.py` is required | 51k stars, standalone, strong community | Partial — orchestration is still code | Not authored |
-| **Vercel AI SDK** | TypeScript primitives (`ToolLoopAgent`) | 24k stars, provider routing, great UI hooks | No | Building-block, not a format |
-| **AutoGen / AG2** | Python | Microsoft Research, multi-agent conversation | No | Skip for v0.1 |
-| **Semantic Kernel** | C# / Python / Java | Microsoft, .NET-leaning | No | Skip for v0.1 |
-| **Google ADK** | Python, Google-cloud-flavored | Newer | No | Skip for v0.1 |
-| **AGNTCY / draft agent-spec standards** | Spec | Pre-1.0, in flux | Not yet shippable | Track, do not adopt |
+| **Pydantic AI `AgentSpec`** | YAML / JSON, single file, schema-validated | 17k stars, Pydantic team, weekly releases | Non-engineer authoring; chat-to-PR; broad provider mix; observability via Logfire/OTel | **Default** |
+| **Cargo AI** | Single JSON file, JSON Logic actions, Rust runtime | ~4 stars, pre-1.0, MIT, local-first | Honoring existing assets; native-binary delivery; locally-runnable agents | **Default (secondary)** |
+| **LangGraph** | Python (and LangGraph.js) — graph code | 32k stars, durable execution, LangSmith | Long-running stateful agents; durable HITL; agents that need fine-grained control over the graph | **Supported (code)** |
+| **OpenAI Agents SDK** | Python + JS/TS, lightweight | 26k stars, multi-provider via LiteLLM/any-llm | Tool-heavy agents; sandbox agents that operate over a filesystem; teams already on OpenAI primitives | **Supported (code)** |
+| **Mastra** | TypeScript, first-class workflows + memory | 24k stars, Apache-2.0 (with `ee/` enterprise tier) | TypeScript / Next.js shops; teams that want agents in the same repo as their web app | **Supported (code)** |
+| **CrewAI** | Python + YAML | 51k stars, multi-agent orchestration | Role-based multi-agent crews; teams that find Crews + Flows the right mental model | **Supported (code)** |
+| **Pydantic AI** (code mode) | Python | Same library as `AgentSpec` | A team that wants the same runtime as the declarative default but with type-safe Python authoring | **Supported (code)** |
+| **Vercel AI SDK** | TypeScript primitives (`ToolLoopAgent`) | 24k stars | Not really a "format" — it's a building block for the other formats. Use as a runtime detail. | Track |
+| **AutoGen / AG2** | Python | Microsoft Research | Multi-agent conversation research; not optimized for governed prod | Track, not adopt |
+| **Semantic Kernel** | C# / Python / Java | Microsoft, .NET-leaning | Enterprise .NET shops; out of scope for first pilots | Track, not adopt |
+| **Google ADK** | Python | Google-cloud-flavored, newer | Customers committed to Google Cloud | Track, not adopt |
+| **AGNTCY / draft agent-spec standards** | Spec | Pre-1.0, in flux | Standardization candidate; revisit when it stabilizes | Track |
 
-## Why Pydantic AI `AgentSpec` is the primary format
+## Why Pydantic AI `AgentSpec` stays a default
 
-1. **It is genuinely declarative.** An agent is one YAML or JSON file containing `model`, `instructions`, `capabilities`, `output_schema`, `deps_schema`, and `model_settings`. `Agent.from_file('agent.yaml')` is the entire constructor. That is exactly the shape TAS needs to put into a Git repo and review as a diff.
-2. **Schema-validated by design.** `deps_schema` and `output_schema` are real JSON Schemas. v0.4's governance phase is going to want exactly this kind of guardrail (a CI check can block diffs that break the contract before a human reviews them).
-3. **Companion JSON Schema for editor autocompletion.** `AgentSpec.to_file()` emits a JSON Schema sidecar that the YAML Language Server picks up. v0.2's review UX gets autocomplete and inline validation in any modern editor for free.
-4. **Model-agnostic out of the box.** OpenAI, Anthropic, Google, xAI, Bedrock, Cerebras, Cohere, Groq, Hugging Face, Mistral, Ollama, OpenRouter — plus a documented path for custom models. Cargo AI is currently OpenAI/Codex + Ollama. We need the broad coverage for early pilots.
-5. **Observability is included.** `instrument: true` lights up Pydantic Logfire (OpenTelemetry under the hood). v0.3's per-agent operational dashboard becomes a configuration concern, not a build concern.
-6. **MCP, A2A, durable execution, and evals all exist.** Each one maps directly to a later TAS phase (`MCP` → v0.5 corrections, `durable execution` → long-running v0.5+ workflows, `evals` → v0.4 governance signals).
-7. **Maintainer signal is strong.** 17k stars, a clear backer (Pydantic Inc.), weekly-ish releases, used by the OpenAI SDK, Google ADK, Anthropic SDK, LangChain, LlamaIndex, CrewAI, and others for validation. The "what if this project goes away?" risk is low.
-8. **Authoring is allowed to stay in code, too.** The same library supports code-defined agents. A customer who *does* want to author in Python gets the same runtime; their PR is just a `.py` diff instead of a `.yaml` diff. The format choice does not constrain power users.
+1. **It is genuinely declarative.** An agent is one YAML or JSON file containing `model`, `instructions`, `capabilities`, `output_schema`, `deps_schema`, `model_settings`. `Agent.from_file('agent.yaml')` is the entire constructor.
+2. **Schema-validated by design.** `deps_schema` and `output_schema` are real JSON Schemas. CI can reject diffs that break the contract before a human looks — useful in *every* mode, especially YOLO, where CI is the gate.
+3. **Companion JSON Schema sidecar** powers editor autocompletion and inline validation. Cheap UX win for the v0.2 review surface.
+4. **Model-agnostic.** OpenAI, Anthropic, Google, xAI, Bedrock, Cerebras, Cohere, Groq, Hugging Face, Mistral, Ollama, OpenRouter, plus a documented custom-model path.
+5. **Observability included.** `instrument: true` lights up Pydantic Logfire / OTel. v0.3's per-agent dashboard becomes configuration, not engineering.
+6. **MCP, A2A, durable execution, and evals all already exist** in the library. Each maps to a later TAS phase.
+7. **Strong maintainer signal.** Pydantic Inc., weekly releases, used by every other major SDK for validation.
+8. **Same runtime handles code mode.** A team that outgrows the declarative spec can drop into Python without changing runtimes.
 
-## Why Cargo AI is supported, not dropped
+## Why Cargo AI stays a default
 
-1. **It is also genuinely declarative.** A Cargo AI agent is a single JSON file with `inputs`, `agent_schema`, `actions`, and `run`. The mental model overlaps heavily with `AgentSpec`, so a converter is a one-week mapping, not a rewrite.
-2. **Honoring existing assets.** The original 0.1 plan referenced Cargo AI explicitly; some early customers may already have Cargo AI agents on disk. Forcing them to convert by hand to evaluate TAS is the wrong opening move.
-3. **The "hatch to native binary" story is genuinely useful** for some self-hosted scenarios where the agent should ship as a single executable.
-4. **JSON Logic in `actions[].logic` is reviewable** — a PM can read a condition like `{"==": [{"var": "needs_follow_up"}, true]}` without learning Python.
-5. **Optionality is cheap here.** Importer + runner support is a small surface area. If Cargo AI's community grows, we are well-positioned. If it stalls, we have lost almost nothing.
+1. **Genuinely declarative single file.** Mental model overlaps heavily with `AgentSpec`.
+2. **Honoring existing assets.** Some early customers already have Cargo AI agents; forcing conversion is the wrong opening move.
+3. **"Hatch to native binary" is genuinely useful** for self-hosted scenarios that want a single executable.
+4. **JSON Logic** is reviewable plain text — a PM can read `{"==": [{"var": "needs_follow_up"}, true]}`.
+5. **Optionality is cheap.** Importer + runner support is a small surface area.
 
-## Why we did not lead with Cargo AI alone
+We do not lead with *only* Cargo AI because of the maturity gap (one maintainer, pre-1.0, small ecosystem) and the narrower provider mix. Pairing it with Pydantic AI `AgentSpec` hedges that risk while keeping the Cargo AI story alive.
 
-This was the founder-preferred path on the way in, so it deserves an explicit answer.
+## Why we now actively support code-first frameworks
 
-- **Maturity.** ~4 GitHub stars, one maintainer (`analyzer1`), pre-1.0. A v0.1 customer asking "what happens if that project stops shipping?" has no good answer when it is our *only* supported format.
-- **Ecosystem gaps.** No first-party MCP server library, no third-party tool registry, no built-in evaluators, no observability story beyond stdout. v0.3 and v0.4 would have to build all of that ourselves.
-- **Hireability and recognition.** Almost no engineers have heard of Cargo AI. Customers comparing TAS against a CrewAI- or LangGraph-flavored competitor will pattern-match.
-- **Authoring verbosity.** The Cargo AI JSON is structurally rich (`runtime_vars`, named inputs, JSON Logic actions), which is great for execution but verbose for "PM wants a 1-line tweak" diffs.
-- **Bundling risk.** Tying TAS's format to a pre-1.0 third-party project ties our exit bar (`10 consecutive successful runs over a week`) to their stability. Pydantic AI on a recent release gives us a much shorter path to that bar.
+Three reasons, each grounded in something the v0.1–v0.6 docs already promise:
 
-## Why we did not pick a code-first framework
+1. **Complexity ceiling.** Some agents need custom Python tools, complex state graphs, durable execution, or tight integration with a host application. A declarative format will never cover those well. Telling that customer "TAS isn't for you" defeats the goal of being the control plane for *agents*, plural.
+2. **Lifecycle policy already handles risk.** v0.2 ships per-agent PR policy (review-required vs YOLO auto-merge) and v0.4 ships RBAC and policy templates. Those gate *all* changes, regardless of format. A LangGraph PR going through a review-required pipeline is exactly as governed as an `AgentSpec` PR.
+3. **Real customer surfaces match real frameworks.** TS shops will ask for Mastra. Python teams committed to LangGraph won't switch. Teams that started on the OpenAI Agents SDK have working code. Supporting them costs us runtime adapters and per-format docs, not the architecture.
 
-LangGraph, OpenAI Agents SDK, Mastra, and Vercel AI SDK are excellent runtimes. They are not a good fit for the **v0.2 chat-to-PR** authoring loop because:
+What "supported" means concretely:
 
-- A non-engineer cannot read a Python state graph or a TypeScript module as a review.
-- A coding agent producing diffs against complex code is more error-prone than producing diffs against a typed YAML schema.
-- The "one file = one agent" mental model breaks down once an agent's behavior is spread across multiple modules, configs, and helper functions.
+- **Runtime:** TAS can execute the agent. For Python frameworks that means a Python runtime per workspace; for TS frameworks, a Node runtime. Containerized.
+- **Git integration:** the agent's source — whether one YAML file or a Python module — lives in the workspace repo. PRs work the same way.
+- **Run history + logs:** identical surface across formats.
+- **Authoring path:** for code-defined agents, v0.2's chat-to-PR can still produce diffs against the code, but the human reviewer is expected to be an engineer.
+- **Observability:** OTel-based, format-agnostic. Each framework's instrumentation is mapped to the same trace surface.
 
-We expect to **run** code-defined agents eventually (the Pydantic AI library itself supports them), but authoring them in chat-to-PR is not a v0.1–v0.2 promise.
+What "supported" does **not** mean in v0.1:
 
-## Why we did not pick CrewAI specifically
+- We don't ship a starter template for every framework on day one. Pydantic AI `AgentSpec` + Cargo AI ship as starters in v0.1. LangGraph / OpenAI Agents SDK / Mastra / CrewAI starters are scheduled across v0.1–v0.3 based on pilot demand.
+- We don't promise feature parity across all formats from day one. The format-specific feature matrix is tracked in a separate doc (TBD: `context/0.1/AGENT_FORMAT_MATRIX.md`).
 
-CrewAI's YAML covers role/goal/backstory/tasks, but the orchestration always lives in a Python `crew.py`. So changing an agent's *behavior* is usually a code change in practice, which puts it back in the "code-first" bucket above. The YAML-only surface is too thin for what TAS needs.
+## Development vs production: the actual gating model
+
+This is the framing the previous ADR was missing. Borrowing the v0.2 doc's vocabulary:
+
+| Stage | Default PR policy | Diff readability concern? | Authoring guidance |
+| --- | --- | --- | --- |
+| **Development** | YOLO auto-merge on green CI (opt-in per agent) | Low — CI is the gate. A senior engineer's Python change merging automatically while they iterate is fine. | Any supported format is fine. Pick what fits the agent. |
+| **Promotion to production** | Review-required + RBAC enforced. Schema and behavioral signals (v0.4) surface on the PR. | High — the reviewer needs to understand the change. | A non-engineer reviewer means a declarative format diff is easier; an engineering reviewer can review any format. The policy says *who reviews*, not *what format*. |
+| **Production** | Review-required. Auto-merge available only for tightly-scoped changes (e.g., prompt-only edits flagged by the schema-diff analyzer in v0.4). | High. | Same as promotion: format follows author and reviewer, not the other way around. |
+
+This matches what `context/0.2/README.md` already says and what `context/0.4/` (governance) is building toward. The format choice is *not* the governance lever; the policy engine is.
 
 ## What this means concretely for each phase
 
 ### v0.1 — Foundation
-- Starter templates ship as Pydantic AI `AgentSpec` YAML.
-- `import` flow accepts both Cargo AI JSON and Pydantic AI `AgentSpec` YAML/JSON.
-- Both formats run successfully end-to-end.
-- A documented converter exists (Cargo AI JSON → `AgentSpec` YAML). Customers can opt to convert on import or keep the original.
+- Ship two declarative starters: Pydantic AI `AgentSpec` YAML (canonical) and Cargo AI JSON (alternate).
+- Ship a runtime path for at least one code-defined framework — most likely Pydantic AI's Python mode or OpenAI Agents SDK, picked by which is easier to containerize cleanly. This proves the "code is supported" promise without making us ship all four frameworks at once.
+- `import` accepts: Pydantic AI YAML/JSON, Cargo AI JSON, and a recognized Python or TypeScript agent module path within the repo.
 
 ### v0.2 — Authoring velocity
-- The Tembo coding agent produces `AgentSpec` YAML diffs as its primary output.
-- For agents that originated as Cargo AI JSON, the coding agent edits them in-place in Cargo AI JSON (we do not auto-convert on edit; that would defeat the diff-readability point).
-- Linters reject malformed specs against the JSON Schema sidecar before the human review.
+- Chat-to-PR generates diffs in the agent's native format. Declarative formats produce small, readable diffs by default; code-defined formats produce code diffs.
+- PR policy (review-required vs YOLO) is per-agent. YOLO is allowed during development and explicitly *not* the recommended default for production-tagged agents.
+- For code-defined agents, the chat-to-PR engine can refuse to produce a change it isn't confident about and surface that to the human, rather than ship a broken diff.
 
 ### v0.3 — Operational surface
-- `instrument: true` is the default for new `AgentSpec` agents; this drives the per-agent dashboard with no extra wiring.
-- Per-agent operational dashboards read from Logfire / OpenTelemetry traces.
+- Per-agent dashboards work across formats via OTel.
+- HITL pause/resume works across formats (frameworks like LangGraph have native HITL; we adapt to a shared interface).
 
 ### v0.4 — Governance depth
-- `output_schema` and `deps_schema` deltas are first-class signals in the audit timeline ("schema-breaking change" gets its own badge).
-- Eval suites (`pydantic_evals` or equivalent) can be referenced from the spec and run on PR.
+- Audit timeline records changes uniformly across formats.
+- "Schema-breaking change" is one badge among several; "code change in critical path" gets its own badge.
+- RBAC + policy templates enforce review-required on production-tagged agents regardless of format.
 
 ### v0.5 — Adaptive intelligence
-- Corrections-to-PR produce `AgentSpec` diffs by default (smallest, most reviewable surface).
-- Variant proposals are new spec files, not branches inside a file.
+- Corrections produce diffs in the agent's native format. For declarative formats this is a YAML diff; for code formats this is a code diff that an engineer reviews.
+- Variant proposals work across formats — a variant is a new file (declarative) or a new module (code).
 
 ### v0.6 — Mycelium
-- Patterns are exchanged as `AgentSpec` fragments (typed, schema-validated, provenance-bearing), not as opaque blobs.
+- Shared patterns travel in a format-agnostic envelope. Patterns derived from declarative agents land as declarative fragments; patterns derived from code agents land as code fragments or trait/interface descriptions.
 
 ## Open questions
 
-- Should the v0.1 converter (Cargo AI JSON → `AgentSpec` YAML) be one-way only, or round-trippable? Lossless round-tripping is hard because the two formats have different action models (JSON Logic + run-steps vs. capabilities + tools).
-- Do we ship a default observability backend in v0.1 (Logfire-compatible OTel collector) or wait for v0.3? Leaning: defer, but make `instrument: true` always work against any OTel endpoint the customer points us at.
-- What is the right home for the JSON Schema sidecar in the workspace repo? `agents/.schemas/` is the current proposal — keeps it out of agent listings while staying versioned alongside the agents themselves.
+- **Which code framework do we ship as the v0.1 runtime first?** Pydantic AI's code mode (same library as the declarative default) is the cheapest path. OpenAI Agents SDK is the most popular among Python teams. LangGraph is the most demanded for stateful agents. Sequencing decision deferred to first pilot signal.
+- **What's the policy default for a freshly-created agent in v0.2?** Likely YOLO during a dev window, then auto-promoted to review-required when tagged production. Specific mechanics deferred to v0.2 grooming.
+- **Where does the format-specific feature matrix live?** Proposed: a follow-up `context/0.1/AGENT_FORMAT_MATRIX.md` once we've shipped two formats end-to-end and learned what differs.
+- **Cargo AI ↔ `AgentSpec` converter:** still on the table; lossless round-tripping is hard because the action models differ. One-way (Cargo AI JSON → `AgentSpec` YAML on user request) is the realistic v0.1 target.
+- **Observability backend in v0.1:** still leaning defer, but `instrument: true` works against any OTel endpoint the customer points us at.
 
 ## References
 
-- [Pydantic AI `AgentSpec` docs](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/)
+- [Pydantic AI `AgentSpec` docs](https://ai.pydantic.dev/docs/ai/core-concepts/agent-spec/) — primary declarative default
 - [Pydantic AI repository](https://github.com/pydantic/pydantic-ai)
-- [Cargo AI homepage](https://cargo-ai.org/)
+- [Cargo AI homepage](https://cargo-ai.org/) — secondary declarative default
 - [Cargo AI repository](https://github.com/analyzer1/cargo-ai)
-- [LangGraph](https://github.com/langchain-ai/langgraph), [OpenAI Agents SDK](https://github.com/openai/openai-agents-python), [CrewAI](https://github.com/crewAIInc/crewAI), [Mastra](https://github.com/mastra-ai/mastra), [Vercel AI SDK](https://github.com/vercel/ai) — surveyed and not adopted as authoring formats for v0.1.
+- [LangGraph](https://github.com/langchain-ai/langgraph) — supported code-defined framework
+- [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) — supported code-defined framework
+- [Mastra](https://github.com/mastra-ai/mastra) — supported code-defined framework (TypeScript)
+- [CrewAI](https://github.com/crewAIInc/crewAI) — supported code-defined framework
+- [Vercel AI SDK](https://github.com/vercel/ai) — surveyed; treated as a building block, not a format
+- `context/0.2/README.md` — PR policy modes (review-required vs YOLO) that this ADR builds on
+- `context/0.4/README.md` — governance and RBAC that production-tag agents inherit

--- a/context/0.1/DEMO_SCRIPT.md
+++ b/context/0.1/DEMO_SCRIPT.md
@@ -51,7 +51,7 @@
 - Save.
 
 **Say:**
-> "v0.1 ships with a small starter library. The format under the hood is a single YAML or JSON file per agent — declarative, diffable, lives in your repo. We support Pydantic AI `AgentSpec` as the primary format and import from Cargo AI JSON, but at v0.1 we're not asking your team to learn either. In v0.2 you'll create these from chat instead."
+> "v0.1 ships with a small starter library. The default starters are declarative — a single YAML or JSON file per agent (Pydantic AI `AgentSpec` or Cargo AI JSON). For complex agents that need custom code, we also support code-defined agents — LangGraph, the OpenAI Agents SDK, Mastra, and similar — pointed at from the same repo. At v0.1 we're not asking your team to learn any specific format. In v0.2 you'll author these from chat instead, and policy controls which changes need human review."
 
 ### 6. Run manually and show logs (10:00 – 13:00)
 **Show:** the new agent's detail page.
@@ -90,3 +90,4 @@
 - **"Can we use GitLab / self-hosted Git?"** GitHub at v0.1. GitLab and self-hosted Git on the roadmap — open question we'd like pilot feedback on.
 - **"Does TAS need OpenAI / Anthropic keys?"** Those live inside agent definitions in your repo, not in TAS itself. TAS is the control plane.
 - **"When is v0.2 chat authoring?"** On the public roadmap; we'll share the date when v0.1 has cleared its exit bar.
+- **"Which agent frameworks do you support?"** Two declarative defaults — Pydantic AI `AgentSpec` and Cargo AI — ship as v0.1 starters. Code-defined frameworks (LangGraph, OpenAI Agents SDK, Mastra, CrewAI, Pydantic AI's code mode) are first-class supported because complex agents need custom code; the v0.1 runtime ships one of those wired, with the others sequenced based on pilot demand. The PR policy engine (review-required vs YOLO auto-merge) gates changes regardless of which format the agent is in.

--- a/context/0.1/DEMO_SCRIPT.md
+++ b/context/0.1/DEMO_SCRIPT.md
@@ -51,7 +51,7 @@
 - Save.
 
 **Say:**
-> "v0.1 ships with a small starter library. We're not asking your team to learn an agent JSON format — that's an implementation detail. In v0.2 you'll create these from chat instead."
+> "v0.1 ships with a small starter library. The format under the hood is a single YAML or JSON file per agent — declarative, diffable, lives in your repo. We support Pydantic AI `AgentSpec` as the primary format and import from Cargo AI JSON, but at v0.1 we're not asking your team to learn either. In v0.2 you'll create these from chat instead."
 
 ### 6. Run manually and show logs (10:00 – 13:00)
 **Show:** the new agent's detail page.

--- a/context/0.1/README.md
+++ b/context/0.1/README.md
@@ -31,7 +31,7 @@ We are not trying to be impressive yet. We are trying to be dependable enough th
 - **Self-hosted deploy.** Docker Compose path + environment variable reference. Single-node target.
 - **`better-auth` integration.** Email/password baseline plus SSO adapter slots so customers can wire their own IdP.
 - **Workspace onboarding.** Connect one Git repository and store one Tembo API key per workspace.
-- **Baseline agent definition.** Create from a starter template or import an existing Cargo AI JSON file.
+- **Baseline agent definition.** Create from a starter template (Pydantic AI `AgentSpec` YAML by default) or import an existing Cargo AI JSON file. See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the format decision.
 - **Manual run + logs.** "Run now" button, status (queued/running/succeeded/failed), tail of run output.
 
 ## Out of Scope for v0.1
@@ -55,7 +55,7 @@ Build the minimum trustworthy control plane first. Resist the temptation to demo
 - **Backend:** Rust API for runtime and orchestration.
 - **Auth:** `better-auth` with adapter slots for SAML/OIDC.
 - **Tembo integration:** API-key mode (a future phase may add MCP-based auth when public MCP is stable).
-- **Agent format:** Cargo AI JSON. Treated as an implementation detail in v0.1 — users do not need to learn it to import a starter template.
+- **Agent format:** Pydantic AI `AgentSpec` (YAML or JSON) as the canonical, primary format; Cargo AI JSON supported as an import path. Both are declarative, diff-native single-file definitions — exactly what the v0.2 chat-to-PR loop and the v0.4 audit trail depend on. See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the full rationale, including why we did not pick a code-first framework (LangGraph, OpenAI Agents SDK, Mastra, CrewAI). Treated as an implementation detail in v0.1 — users do not need to learn either format to import a starter template.
 - **Storage:** workspace-local Postgres for run metadata; Git for agent source.
 
 ## Customer Quote (Drafted)

--- a/context/0.1/README.md
+++ b/context/0.1/README.md
@@ -31,7 +31,7 @@ We are not trying to be impressive yet. We are trying to be dependable enough th
 - **Self-hosted deploy.** Docker Compose path + environment variable reference. Single-node target.
 - **`better-auth` integration.** Email/password baseline plus SSO adapter slots so customers can wire their own IdP.
 - **Workspace onboarding.** Connect one Git repository and store one Tembo API key per workspace.
-- **Baseline agent definition.** Create from a starter template (Pydantic AI `AgentSpec` YAML by default) or import an existing Cargo AI JSON file. See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the format decision.
+- **Baseline agent definition.** Create from a starter template (Pydantic AI `AgentSpec` YAML by default; Cargo AI JSON also supplied), import an existing Pydantic AI or Cargo AI definition, or point at an existing code-defined agent (e.g., a Python module using the OpenAI Agents SDK, Pydantic AI's code mode, LangGraph, CrewAI, or a TypeScript module using Mastra). See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the format decision and which formats are wired in v0.1 vs v0.1+.
 - **Manual run + logs.** "Run now" button, status (queued/running/succeeded/failed), tail of run output.
 
 ## Out of Scope for v0.1
@@ -55,7 +55,7 @@ Build the minimum trustworthy control plane first. Resist the temptation to demo
 - **Backend:** Rust API for runtime and orchestration.
 - **Auth:** `better-auth` with adapter slots for SAML/OIDC.
 - **Tembo integration:** API-key mode (a future phase may add MCP-based auth when public MCP is stable).
-- **Agent format:** Pydantic AI `AgentSpec` (YAML or JSON) as the canonical, primary format; Cargo AI JSON supported as an import path. Both are declarative, diff-native single-file definitions — exactly what the v0.2 chat-to-PR loop and the v0.4 audit trail depend on. See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the full rationale, including why we did not pick a code-first framework (LangGraph, OpenAI Agents SDK, Mastra, CrewAI). Treated as an implementation detail in v0.1 — users do not need to learn either format to import a starter template.
+- **Agent format:** TAS supports multiple formats. Two declarative defaults — Pydantic AI `AgentSpec` (YAML or JSON) and Cargo AI JSON — ship as starters. Code-defined frameworks (LangGraph, OpenAI Agents SDK, Mastra, CrewAI, Pydantic AI's code mode) are also first-class supported, because complex agents need custom code. The PR policy engine (review-required vs YOLO auto-merge, per agent) and the production-promotion gate handle governance regardless of format. See [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) for the full framework matrix and the development-vs-production policy model. Format is treated as an implementation detail in v0.1 — users do not need to learn any of them to import a starter template.
 - **Storage:** workspace-local Postgres for run metadata; Git for agent source.
 
 ## Customer Quote (Drafted)

--- a/context/0.1/USER_STORIES.md
+++ b/context/0.1/USER_STORIES.md
@@ -61,13 +61,14 @@ Format: Connextra (**As a** _role_, **I want** _capability_, **so that** _benefi
 
 ## US-0.1-05 — Create or import a baseline agent
 
-**As an** Operator, **I want** to create an agent from a starter template or import an existing Cargo AI JSON definition, **so that** I can run a first production-relevant workflow without authoring code from scratch.
+**As an** Operator, **I want** to create an agent from a starter template (Pydantic AI `AgentSpec` YAML by default) or import an existing Cargo AI JSON definition, **so that** I can run a first production-relevant workflow without authoring code from scratch.
 
 **Acceptance Criteria**
 
-- At least one starter template is available out of the box.
-- Importing an existing definition surfaces validation errors clearly (no silent failure).
-- A created/imported agent shows up in the workspace agent list with a known status.
+- At least one starter template is available out of the box, in Pydantic AI `AgentSpec` YAML.
+- Importing a Cargo AI JSON definition works and surfaces validation errors clearly (no silent failure).
+- Importing a Pydantic AI `AgentSpec` YAML or JSON definition works and surfaces validation errors clearly (no silent failure).
+- A created/imported agent shows up in the workspace agent list with a known status, regardless of which source format it was created from.
 
 ---
 

--- a/context/0.1/USER_STORIES.md
+++ b/context/0.1/USER_STORIES.md
@@ -61,13 +61,16 @@ Format: Connextra (**As a** _role_, **I want** _capability_, **so that** _benefi
 
 ## US-0.1-05 — Create or import a baseline agent
 
-**As an** Operator, **I want** to create an agent from a starter template (Pydantic AI `AgentSpec` YAML by default) or import an existing Cargo AI JSON definition, **so that** I can run a first production-relevant workflow without authoring code from scratch.
+**As an** Operator, **I want** to create an agent from a starter template, import an existing declarative definition, or point at an existing code-defined agent, **so that** I can run a first production-relevant workflow without rewriting work I already have.
 
 **Acceptance Criteria**
 
-- At least one starter template is available out of the box, in Pydantic AI `AgentSpec` YAML.
-- Importing a Cargo AI JSON definition works and surfaces validation errors clearly (no silent failure).
+- At least one starter template ships in Pydantic AI `AgentSpec` YAML (the v0.1 canonical declarative default).
+- At least one starter template ships in Cargo AI JSON (the v0.1 alternate declarative default).
+- At least one runnable code-defined starter ships in v0.1 (framework choice deferred per [`AGENT_FORMAT.md`](./AGENT_FORMAT.md) open question; Pydantic AI's Python code mode and OpenAI Agents SDK are the leading candidates).
 - Importing a Pydantic AI `AgentSpec` YAML or JSON definition works and surfaces validation errors clearly (no silent failure).
+- Importing a Cargo AI JSON definition works and surfaces validation errors clearly (no silent failure).
+- Pointing at an existing code-defined agent in the connected repo works for the v0.1 supported framework and surfaces a clear "framework not supported in v0.1" message for any framework on the supported list that hasn't been wired yet.
 - A created/imported agent shows up in the workspace agent list with a known status, regardless of which source format it was created from.
 
 ---


### PR DESCRIPTION
## Summary
- Added detailed documentation on supported agent frameworks in `context/0.1/AGENT_FORMAT.md`, recommending Pydantic AI `AgentSpec` and Cargo AI JSON as declarative defaults.
- Included support for code-defined frameworks like LangGraph, OpenAI Agents SDK, Mastra, and CrewAI.
- Updated onboarding script to create starter agents in both Pydantic AI YAML and Cargo AI JSON formats.
- Enhanced `agents/README.md` to explain supported agent formats and usage guidance.
- Updated context docs (`README.md`, `DEMO_SCRIPT.md`, `USER_STORIES.md`) to reflect multi-format support and governance model.
- Provided a sample Pydantic AI `AgentSpec` YAML agent starter file (`hello-world.yaml`).
- Clarified that PR policy engine governs all formats equally, enabling flexible authoring and review workflows.

This PR researches, documents, and implements multi-format agent support, including cargo-ai and Mastra, with recommendations and starter templates. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/a9a56b28-6c8f-4f91-9c3a-830699e48ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/opencode:claude-opus-4-7?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/opencode:claude-opus-4-7?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/opencode:claude-opus-4-7?theme=light&v=11" height="28"></picture></a> 