### PR TITLE
fix(auth): refuse insecure placeholder BETTER_AUTH_SECRET at runtime

### DIFF
--- a/web/src/lib/auth-secret.test.ts
+++ b/web/src/lib/auth-secret.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { INSECURE_PLACEHOLDER_SECRET, resolveAuthSecret } from "./auth-secret";
+
+// Security exit-bar: a real deployment must never sign sessions with the
+// public in-repo placeholder. We model the two phases via DATABASE_URL —
+// absent during `next build`, always present when serving requests.
+
+describe("resolveAuthSecret", () => {
+  it("returns the configured secret when set to a real value", () => {
+    expect(
+      resolveAuthSecret({
+        BETTER_AUTH_SECRET: "a-real-strong-secret",
+        DATABASE_URL: "postgres://db",
+      }),
+    ).toBe("a-real-strong-secret");
+  });
+
+  it("throws at runtime when the secret is missing", () => {
+    expect(() =>
+      resolveAuthSecret({ DATABASE_URL: "postgres://db" }),
+    ).toThrow(/BETTER_AUTH_SECRET/);
+  });
+
+  it("throws at runtime when the secret is the in-repo placeholder", () => {
+    expect(() =>
+      resolveAuthSecret({
+        BETTER_AUTH_SECRET: INSECURE_PLACEHOLDER_SECRET,
+        DATABASE_URL: "postgres://db",
+      }),
+    ).toThrow(/placeholder/);
+  });
+
+  it("tolerates a missing secret at build time (no DATABASE_URL)", () => {
+    expect(resolveAuthSecret({})).toBe(INSECURE_PLACEHOLDER_SECRET);
+  });
+});

--- a/web/src/lib/auth-secret.ts
+++ b/web/src/lib/auth-secret.ts
@@ -1,0 +1,32 @@
+// The literal value that this module used to silently fall back to when
+// BETTER_AUTH_SECRET was unset. It lives in the public repo, so anyone
+// could use it to forge session tokens — it must be *rejected*, never
+// accepted, as real signing material.
+export const INSECURE_PLACEHOLDER_SECRET =
+  "dev-only-insecure-secret-replace-via-env-BETTER_AUTH_SECRET";
+
+// `next build` evaluates the auth module to collect page data with no
+// runtime env present — notably no DATABASE_URL (see auth.ts). A real
+// deployment always has DATABASE_URL, so its presence is our "we are
+// serving requests" signal: at runtime a missing or placeholder secret
+// must fail loudly instead of silently signing sessions with a value
+// that's public in the repository.
+type AuthSecretEnv = {
+  BETTER_AUTH_SECRET?: string;
+  DATABASE_URL?: string;
+};
+
+export function resolveAuthSecret(env?: AuthSecretEnv): string {
+  const source = env ?? process.env;
+  const secret = source.BETTER_AUTH_SECRET;
+  if (secret && secret !== INSECURE_PLACEHOLDER_SECRET) return secret;
+  if (source.DATABASE_URL != null) {
+    throw new Error(
+      "BETTER_AUTH_SECRET is missing or set to the insecure in-repo " +
+        "placeholder. Generate a strong unique secret (openssl rand -base64 " +
+        "32) and set it in the environment — refusing to sign sessions with " +
+        "a public default.",
+    );
+  }
+  return INSECURE_PLACEHOLDER_SECRET;
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { APIError } from "better-auth/api";
 import { genericOAuth } from "better-auth/plugins";
 import { Pool } from "pg";
 
+import { resolveAuthSecret } from "@/lib/auth-secret";
 import { genericOAuthConfigs } from "@/lib/auth-providers";
 import { isInstanceAdminEmail } from "@/lib/config";
 import {
@@ -15,9 +16,9 @@ import {
 // and the build environment legitimately has no DATABASE_URL. Misconfigured
 // runtimes will fail loudly on the first request instead.
 const databaseUrl = process.env.DATABASE_URL ?? "postgres://placeholder";
-const secret =
-  process.env.BETTER_AUTH_SECRET ??
-  "dev-only-insecure-secret-replace-via-env-BETTER_AUTH_SECRET";
+// Never fall back to a usable default secret: a missing/placeholder secret
+// at runtime would let anyone with the (public) repo forge sessions.
+const secret = resolveAuthSecret();
 
 const googleClientId = process.env.GOOGLE_CLIENT_ID;
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;


### PR DESCRIPTION
## Summary
Fixes #38 (Critical — session forgery).

`web/src/lib/auth.ts` silently fell back to a hardcoded secret — `"dev-only-insecure-secret-replace-via-env-BETTER_AUTH_SECRET"` — when `BETTER_AUTH_SECRET` was unset. better-auth signs session tokens with that secret, so anyone who reads the (public) repo could forge valid sessions for any user on a deployment that forgot to set the env var. Unlike a bad `DATABASE_URL`, the bad secret booted successfully and looked healthy.

## Changes
- Add `web/src/lib/auth-secret.ts` with `resolveAuthSecret()`: returns the configured secret, but **throws** when it's missing or equals the in-repo placeholder *while serving requests*.
- The build-vs-runtime distinction reuses the assumption this file already documented — `next build` collects page data with no `DATABASE_URL`, while a real deployment always has one. So the guard keys off `DATABASE_URL` presence: tolerate a missing secret during build, fail loudly at runtime.
- Wire `auth.ts` to use it; drop the insecure default.
- Add `auth-secret.test.ts` covering all four cases (real secret, missing at runtime, placeholder at runtime, missing at build).

## Test plan
- [x] `pnpm exec vitest run` — 22/22 pass (4 new)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint` on changed files — clean
- [ ] Deploy smoke: confirm a runtime with no/placeholder `BETTER_AUTH_SECRET` now refuses to boot, and a properly configured one is unaffected.