### PR TITLE
Fix missing role check in connectRepoAction

### DIFF
--- a/web/src/app/onboarding/repo/actions.ts
+++ b/web/src/app/onboarding/repo/actions.ts
@@ -2,12 +2,10 @@
 
 import { redirect } from "next/navigation";
 
+import { authorizeWorkspace } from "@/lib/auth-server";
 import { ensureRepoReadme } from "@/lib/repo-init";
-import { getServerSession } from "@/lib/session";
 import {
   connectWorkspaceRepo,
-  getWorkspaceBySlug,
-  userIsMember,
   type ConnectWorkspaceRepoError,
 } from "@/lib/workspace";
 
@@ -34,20 +32,18 @@ export async function connectRepoAction(
   _prev: ConnectRepoFormState,
   formData: FormData,
 ): Promise<ConnectRepoFormState> {
-  const session = await getServerSession();
-  if (!session) redirect("/");
-
   const slug = String(formData.get("workspace") ?? "");
   const repo = String(formData.get("repo") ?? "").trim();
   const token = String(formData.get("token") ?? "").trim();
 
-  const workspace = await getWorkspaceBySlug(slug);
-  if (!workspace) redirect("/onboarding");
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (!auth.ok) {
+    if (auth.reason === "no-workspace") redirect("/onboarding");
+    redirect("/");
+  }
+  const { workspace, userId } = auth;
 
-  const isMember = await userIsMember(workspace.id, session.user.id);
-  if (!isMember) redirect("/");
-
-  const result = await connectWorkspaceRepo(workspace.id, session.user.id, {
+  const result = await connectWorkspaceRepo(workspace.id, userId, {
     repo,
     token,
   });


### PR DESCRIPTION
Replaced session and member check with authorizeWorkspace(slug, "workspace_admin") in connectRepoAction to enforce admin role.

- Removed getServerSession and userIsMember usage.
- Added authorizeWorkspace import and usage.
- Redirects updated based on authorization result.
- Ensures only workspace_admin can connect/overwrite repo and GitHub PAT.

This fixes a high severity security issue allowing viewers to overwrite workspace repo and token. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/72612515-d383-4e17-8527-6d5e5abf56d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> 