### PR TITLE
Fix owner_user_id mass-assignment

### DIFF
--- a/web/src/app/[workspace]/automations/actions.test.ts
+++ b/web/src/app/[workspace]/automations/actions.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  redirect: vi.fn((path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`);
+  }),
+}));
+
+vi.mock("@/lib/audit-db", () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+  authorizeWorkspace: vi.fn(),
+  DENIED_MESSAGE: "You don't have permission to do that.",
+}));
+
+vi.mock("@/lib/automations-api", () => ({
+  createAutomation: vi.fn(),
+  deleteAutomation: vi.fn(),
+  getAutomation: vi.fn(),
+  updateAutomation: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace", () => ({
+  userIsMember: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace-agents", () => ({
+  getAgentByName: vi.fn(),
+}));
+
+import {
+  createAutomationAction,
+  updateAutomationAction,
+} from "./actions";
+import {
+  createAutomation,
+  getAutomation,
+  updateAutomation,
+} from "@/lib/automations-api";
+import { authorizeWorkspace } from "@/lib/auth-server";
+import { userIsMember } from "@/lib/workspace";
+import { getAgentByName } from "@/lib/workspace-agents";
+
+const mockAuthorizeWorkspace = vi.mocked(authorizeWorkspace);
+const mockCreateAutomation = vi.mocked(createAutomation);
+const mockGetAutomation = vi.mocked(getAutomation);
+const mockUpdateAutomation = vi.mocked(updateAutomation);
+const mockUserIsMember = vi.mocked(userIsMember);
+const mockGetAgentByName = vi.mocked(getAgentByName);
+
+const workspace = {
+  id: "ws-1",
+  slug: "demo",
+  name: "Demo",
+  createdBy: "creator",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+  faviconKind: "default-tembo" as const,
+};
+
+const existingAutomation = {
+  id: "automation-1",
+  workspaceId: workspace.id,
+  name: "Nightly run",
+  agentName: "agent",
+  cron: "0 0 * * *",
+  inputMessage: "Run",
+  enabled: true,
+  lastFiredAt: null,
+  lastFireError: null,
+  createdBy: "creator",
+  createdByName: null,
+  createdByEmail: null,
+  ownerUserId: "current-owner",
+  ownerUserName: null,
+  ownerUserEmail: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+function automationForm(overrides: Record<string, string> = {}) {
+  const formData = new FormData();
+  const values = {
+    workspace: workspace.slug,
+    name: "Nightly run",
+    agent: "agent",
+    cron: "0 0 * * *",
+    input_message: "Run",
+    owner_user_id: "current-owner",
+    ...overrides,
+  };
+  for (const [key, value] of Object.entries(values)) {
+    formData.set(key, value);
+  }
+  formData.set("enabled", "on");
+  return formData;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthorizeWorkspace.mockResolvedValue({
+    ok: true,
+    workspace,
+    userId: "creator",
+    role: "operator",
+  });
+  mockGetAgentByName.mockResolvedValue({
+    agent: { ok: true, spec: { name: "agent" } },
+    raw: "",
+  } as unknown as Awaited<ReturnType<typeof getAgentByName>>);
+});
+
+describe("automation owner validation", () => {
+  it("rejects create when owner_user_id is not a workspace member", async () => {
+    mockUserIsMember.mockResolvedValue(false);
+
+    const result = await createAutomationAction(
+      {},
+      automationForm({ owner_user_id: "victim-user" }),
+    );
+
+    expect(result.error).toMatch(/workspace member/);
+    expect(mockUserIsMember).toHaveBeenCalledWith(workspace.id, "victim-user");
+    expect(mockCreateAutomation).not.toHaveBeenCalled();
+  });
+
+  it("rejects update when owner_user_id is not a workspace member", async () => {
+    mockGetAutomation.mockResolvedValue(existingAutomation);
+    mockUserIsMember.mockResolvedValue(false);
+
+    const formData = automationForm({
+      id: existingAutomation.id,
+      owner_user_id: "victim-user",
+    });
+
+    const result = await updateAutomationAction({}, formData);
+
+    expect(result.error).toMatch(/workspace member/);
+    expect(mockUserIsMember).toHaveBeenCalledWith(workspace.id, "victim-user");
+    expect(mockUpdateAutomation).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/[workspace]/automations/actions.ts
+++ b/web/src/app/[workspace]/automations/actions.ts
@@ -15,6 +15,7 @@ import {
   updateAutomation,
 } from "@/lib/automations-api";
 import { validateCron } from "@/lib/cron";
+import { userIsMember } from "@/lib/workspace";
 import { getAgentByName } from "@/lib/workspace-agents";
 
 export type AutomationFormState = {
@@ -22,7 +23,7 @@ export type AutomationFormState = {
   fieldErrors?: Partial<Record<"name" | "agent" | "cron", string>>;
 };
 
-const EMPTY: AutomationFormState = {};
+const INVALID_OWNER_MESSAGE = "Choose a workspace member to run this automation.";
 
 // Both create and update share these field-level checks.
 type ParsedForm = {
@@ -65,6 +66,14 @@ async function validate(
   return null;
 }
 
+async function validateOwnerUserId(
+  workspaceId: string,
+  ownerUserId: string,
+): Promise<AutomationFormState | null> {
+  if (await userIsMember(workspaceId, ownerUserId)) return null;
+  return { error: INVALID_OWNER_MESSAGE };
+}
+
 export async function createAutomationAction(
   _prev: AutomationFormState,
   formData: FormData,
@@ -81,9 +90,12 @@ export async function createAutomationAction(
   if (invalid) return invalid;
 
   // Owner defaults to the creator when the form leaves the picker
-  // blank. Real workspace-member validation can land later — for v0.3
-  // we just trust the dropdown's value (or fall back to self).
+  // blank. Scheduled runs use this user's per-user credentials, so
+  // never trust the posted picker value without a membership check.
   const ownerUserId = parsed.ownerUserId || userId;
+  const invalidOwner = await validateOwnerUserId(workspace.id, ownerUserId);
+  if (invalidOwner) return invalidOwner;
+
   const created = await createAutomation({
     workspaceId: workspace.id,
     name: parsed.name,
@@ -136,6 +148,10 @@ export async function updateAutomationAction(
   const invalid = await validate(workspace.id, parsed);
   if (invalid) return invalid;
 
+  const ownerUserId = parsed.ownerUserId || existing.ownerUserId;
+  const invalidOwner = await validateOwnerUserId(workspace.id, ownerUserId);
+  if (invalidOwner) return invalidOwner;
+
   await updateAutomation({
     id,
     name: parsed.name,
@@ -147,7 +163,7 @@ export async function updateAutomationAction(
     // (e.g. an older client). The form's hidden default value should
     // always send the current owner so the edit doesn't accidentally
     // re-assign.
-    ownerUserId: parsed.ownerUserId || existing.ownerUserId,
+    ownerUserId,
   });
 
   await writeAuditEvent({
@@ -162,7 +178,7 @@ export async function updateAutomationAction(
       name: parsed.name,
       cron: parsed.cron,
       enabled: parsed.enabled,
-      ownerUserId: parsed.ownerUserId || existing.ownerUserId,
+      ownerUserId,
       agentChanged: existing.agentName !== parsed.agentName,
       previousAgent: existing.agentName,
     },
@@ -233,6 +249,7 @@ export async function toggleAutomationAction(formData: FormData): Promise<void> 
   if (!auth.ok) notFound();
   const { workspace, userId } = auth;
   if (workspace.id !== existing.workspaceId) notFound();
+  if (await validateOwnerUserId(workspace.id, existing.ownerUserId)) notFound();
 
   await updateAutomation({
     id,
@@ -256,4 +273,3 @@ export async function toggleAutomationAction(formData: FormData): Promise<void> 
   revalidatePath(`/${workspaceSlug}/automations`);
   revalidatePath(`/${workspaceSlug}/agents/${encodeURIComponent(existing.agentName)}`);
 }
-


### PR DESCRIPTION
## Summary
Validate owner_user_id is a workspace member before create/update automation to prevent impersonation.

- Added validateOwnerUserId to check membership.
- Used validateOwnerUserId in createAutomationAction and updateAutomationAction.
- Added test cases to reject non-members as owner_user_id.
- Added check in toggleAutomationAction to reject invalid owner_user_id.

This fixes a high severity security issue allowing operators to run automations as other users. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/075e43a6-dc67-43d8-b47d-3b89e65c6130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> 