### PR TITLE
Fix SSRF and token exfiltration

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -55,6 +55,7 @@ async fn main() -> anyhow::Result<()> {
     let internal_token = auth::InternalToken::from_env()?;
     let http = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(120))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .context("failed to build reqwest client")?;
 

--- a/api/src/native_oauth.rs
+++ b/api/src/native_oauth.rs
@@ -27,6 +27,7 @@ use anyhow::{anyhow, Context};
 use chrono::{DateTime, Duration, Utc};
 use serde::Deserialize;
 use sqlx::PgPool;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::crypto::MasterKey;
 
@@ -34,6 +35,8 @@ use crate::crypto::MasterKey;
 /// so a token can't die mid-run between the sweep and the agent's
 /// first tool call.
 const REFRESH_SKEW_SECS: i64 = 120;
+const ATTIO_MCP_ORIGIN: &str = "https://mcp.attio.com";
+const ATTIO_OAUTH_ORIGINS: &[&str] = &["https://app.attio.com"];
 
 #[derive(Deserialize)]
 struct ProtectedResourceMeta {
@@ -136,7 +139,7 @@ async fn refresh_one(
 
     // Public client (token_endpoint_auth_method=none) → no secret.
     let res = http
-        .post(&token_endpoint)
+        .post(token_endpoint)
         .header("Accept", "application/json")
         .form(&[
             ("grant_type", "refresh_token"),
@@ -181,8 +184,9 @@ async fn refresh_one(
         .refresh_token
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| refresh_token.to_string());
-    let expires_at: Option<DateTime<Utc>> =
-        token.expires_in.map(|secs| Utc::now() + Duration::seconds(secs));
+    let expires_at: Option<DateTime<Utc>> = token
+        .expires_in
+        .map(|secs| Utc::now() + Duration::seconds(secs));
 
     // Same JSON shape as the web `ConnectionCredentials` / what
     // saveNativeConnection persists, so a blob written here round-trips
@@ -223,16 +227,19 @@ async fn refresh_one(
 async fn discover_token_endpoint(
     http: &reqwest::Client,
     mcp_url: &str,
-) -> anyhow::Result<String> {
-    let origin = reqwest::Url::parse(mcp_url)
-        .context("bad mcp_server_url")?
-        .origin()
-        .ascii_serialization();
+) -> anyhow::Result<reqwest::Url> {
+    let mcp_url = parse_trusted_https_url(mcp_url, "mcp_server_url")?;
+    assert_public_endpoint_host(&mcp_url, "mcp_server_url").await?;
+    let origin = mcp_url.origin().ascii_serialization();
+    let allowed_oauth_origins = allowed_oauth_origins_for_mcp_origin(&origin).ok_or_else(|| {
+        anyhow!("mcp_server_url origin is not in the native-MCP provider allowlist")
+    })?;
 
     // RFC 9728: protected-resource metadata lives at the origin.
-    let pr_url = format!("{origin}/.well-known/oauth-protected-resource");
+    let pr_url = reqwest::Url::parse(&format!("{origin}/.well-known/oauth-protected-resource"))
+        .context("failed to build protected-resource metadata URL")?;
     let pr: ProtectedResourceMeta = http
-        .get(&pr_url)
+        .get(pr_url)
         .header("Accept", "application/json")
         .send()
         .await
@@ -243,17 +250,23 @@ async fn discover_token_endpoint(
         .await
         .context("protected-resource metadata not JSON")?;
 
-    let as_base = pr
+    let as_base_raw = pr
         .authorization_servers
         .and_then(|v| v.into_iter().next())
         .ok_or_else(|| anyhow!("no authorization_servers in protected-resource metadata"))?;
+    let as_base = parse_trusted_oauth_url(
+        &as_base_raw,
+        allowed_oauth_origins,
+        "authorization server URL",
+    )?;
+    assert_public_endpoint_host(&as_base, "authorization server URL").await?;
 
-    let as_meta_url = format!(
-        "{}/.well-known/oauth-authorization-server",
-        as_base.trim_end_matches('/')
-    );
+    let mut as_meta_url = as_base;
+    as_meta_url.set_path("/.well-known/oauth-authorization-server");
+    as_meta_url.set_query(None);
+    as_meta_url.set_fragment(None);
     let asm: AuthServerMeta = http
-        .get(&as_meta_url)
+        .get(as_meta_url)
         .header("Accept", "application/json")
         .send()
         .await
@@ -264,7 +277,174 @@ async fn discover_token_endpoint(
         .await
         .context("authorization-server metadata not JSON")?;
 
-    asm.token_endpoint
+    let token_endpoint = asm
+        .token_endpoint
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| anyhow!("authorization-server metadata missing token_endpoint"))
+        .ok_or_else(|| anyhow!("authorization-server metadata missing token_endpoint"))?;
+    let token_endpoint =
+        parse_trusted_oauth_url(&token_endpoint, allowed_oauth_origins, "token endpoint")?;
+    assert_public_endpoint_host(&token_endpoint, "token endpoint").await?;
+    Ok(token_endpoint)
+}
+
+fn allowed_oauth_origins_for_mcp_origin(origin: &str) -> Option<&'static [&'static str]> {
+    match origin {
+        ATTIO_MCP_ORIGIN => Some(ATTIO_OAUTH_ORIGINS),
+        _ => None,
+    }
+}
+
+fn parse_trusted_oauth_url(
+    raw_url: &str,
+    allowed_origins: &[&str],
+    label: &str,
+) -> anyhow::Result<reqwest::Url> {
+    let url = parse_trusted_https_url(raw_url, label)?;
+    let origin = url.origin().ascii_serialization();
+    if !allowed_origins.iter().any(|allowed| *allowed == origin) {
+        return Err(anyhow!("{label} is not on an allowed provider origin"));
+    }
+    Ok(url)
+}
+
+fn parse_trusted_https_url(raw_url: &str, label: &str) -> anyhow::Result<reqwest::Url> {
+    let url =
+        reqwest::Url::parse(raw_url).with_context(|| format!("{label} is not a valid URL"))?;
+    if url.scheme() != "https" {
+        return Err(anyhow!("{label} must use https"));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(anyhow!("{label} must not include credentials"));
+    }
+    let host = url
+        .host_str()
+        .filter(|host| !host.is_empty())
+        .ok_or_else(|| anyhow!("{label} must include a host"))?;
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if !is_public_ip(ip) {
+            return Err(anyhow!("{label} resolves to a non-public IP address"));
+        }
+    }
+    Ok(url)
+}
+
+async fn assert_public_endpoint_host(url: &reqwest::Url, label: &str) -> anyhow::Result<()> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("{label} must include a host"))?;
+    if host.parse::<IpAddr>().is_ok() {
+        return Ok(());
+    }
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| anyhow!("{label} must include a known port"))?;
+    let mut addrs = tokio::net::lookup_host((host, port))
+        .await
+        .with_context(|| format!("{label} DNS lookup failed"))?;
+    let mut saw_addr = false;
+    for addr in &mut addrs {
+        saw_addr = true;
+        if !is_public_ip(addr.ip()) {
+            return Err(anyhow!(
+                "{label} resolves to a non-public IP address ({})",
+                addr.ip()
+            ));
+        }
+    }
+    if !saw_addr {
+        return Err(anyhow!("{label} did not resolve to any IP addresses"));
+    }
+    Ok(())
+}
+
+fn is_public_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_public_ipv4(ip),
+        IpAddr::V6(ip) => is_public_ipv6(ip),
+    }
+}
+
+fn is_public_ipv4(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    !matches!(
+        octets,
+        [0, _, _, _]
+            | [10, _, _, _]
+            | [100, 64..=127, _, _]
+            | [127, _, _, _]
+            | [169, 254, _, _]
+            | [172, 16..=31, _, _]
+            | [192, 0, 0, _]
+            | [192, 0, 2, _]
+            | [192, 168, _, _]
+            | [198, 18..=19, _, _]
+            | [198, 51, 100, _]
+            | [203, 0, 113, _]
+            | [224..=239, _, _, _]
+            | [240..=255, _, _, _]
+    )
+}
+
+fn is_public_ipv6(ip: Ipv6Addr) -> bool {
+    if let Some(mapped) = ip.to_ipv4_mapped() {
+        return is_public_ipv4(mapped);
+    }
+
+    let segments = ip.segments();
+    let first = segments[0];
+    !(ip.is_unspecified()
+        || ip.is_loopback()
+        || (first & 0xfe00) == 0xfc00
+        || (first & 0xffc0) == 0xfe80
+        || (first & 0xff00) == 0xff00
+        || (segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 0)
+        || (segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 0x0001)
+        || (segments[0] == 0x0100 && segments[1] == 0)
+        || (segments[0] == 0x2001 && segments[1] <= 0x01ff)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_private_and_metadata_ipv4() {
+        assert!(!is_public_ip("127.0.0.1".parse().unwrap()));
+        assert!(!is_public_ip("169.254.169.254".parse().unwrap()));
+        assert!(!is_public_ip("10.1.2.3".parse().unwrap()));
+        assert!(is_public_ip("8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn blocks_private_ipv6() {
+        assert!(!is_public_ip("::1".parse().unwrap()));
+        assert!(!is_public_ip("fc00::1".parse().unwrap()));
+        assert!(!is_public_ip("fe80::1".parse().unwrap()));
+        assert!(!is_public_ip("::ffff:169.254.169.254".parse().unwrap()));
+        assert!(is_public_ip("2606:4700:4700::1111".parse().unwrap()));
+    }
+
+    #[test]
+    fn enforces_https_and_allowed_oauth_origin() {
+        assert!(parse_trusted_oauth_url(
+            "https://app.attio.com/oidc/token",
+            ATTIO_OAUTH_ORIGINS,
+            "token endpoint"
+        )
+        .is_ok());
+        assert!(parse_trusted_oauth_url(
+            "http://app.attio.com/oidc/token",
+            ATTIO_OAUTH_ORIGINS,
+            "token endpoint"
+        )
+        .is_err());
+        assert!(parse_trusted_oauth_url(
+            "https://evil.example/oidc/token",
+            ATTIO_OAUTH_ORIGINS,
+            "token endpoint"
+        )
+        .is_err());
+    }
 }

--- a/web/src/app/api/connections/native/[provider]/authorize/route.ts
+++ b/web/src/app/api/connections/native/[provider]/authorize/route.ts
@@ -5,10 +5,14 @@ import { authorizeWorkspace } from "@/lib/auth-server";
 import { getPublicOrigin } from "@/lib/config";
 import {
   getMcpProvider,
-  protectedResourceUrl,
   redirectUriFor,
   type McpProviderSlug,
 } from "@/lib/mcp-providers";
+import {
+  noRedirectFetchInit,
+  trustedOAuthUrl,
+  trustedProviderMcpOrigin,
+} from "@/lib/native-oauth-security";
 import { signNativeMcpState } from "@/lib/oauth-state";
 
 // Native-MCP OAuth authorize handler. URL shape:
@@ -108,10 +112,23 @@ export async function GET(
   const { workspace, userId } = auth;
 
   // ── Step 1: protected-resource discovery ────────────────────────
-  const prMetaUrl = protectedResourceUrl(provider.mcpServerUrl);
+  let mcpOrigin: string;
+  try {
+    mcpOrigin = await trustedProviderMcpOrigin(provider);
+  } catch (e) {
+    return back(
+      workspace.slug,
+      provider.slug,
+      `Provider MCP URL is not trusted: ${(e as Error).message}`,
+    );
+  }
+  const prMetaUrl = `${mcpOrigin}/.well-known/oauth-protected-resource`;
   let prMeta: ProtectedResourceMetadata;
   try {
-    const res = await fetch(prMetaUrl, { headers: { Accept: "application/json" } });
+    const res = await fetch(
+      prMetaUrl,
+      noRedirectFetchInit({ headers: { Accept: "application/json" } }),
+    );
     if (!res.ok) {
       return back(
         workspace.slug,
@@ -127,21 +144,41 @@ export async function GET(
       `Discovery fetch failed: ${(e as Error).message}`,
     );
   }
-  const authServerUrl = prMeta.authorization_servers?.[0];
-  if (!authServerUrl) {
+  const authServerUrlRaw = prMeta.authorization_servers?.[0];
+  if (!authServerUrlRaw) {
     return back(
       workspace.slug,
       provider.slug,
       `${provider.displayName} MCP didn't advertise an authorization server.`,
     );
   }
+  let authServerUrl: URL;
+  try {
+    authServerUrl = await trustedOAuthUrl(
+      authServerUrlRaw,
+      provider,
+      "Authorization server URL",
+    );
+  } catch (e) {
+    return back(
+      workspace.slug,
+      provider.slug,
+      `Authorization server URL is not trusted: ${(e as Error).message}`,
+    );
+  }
   const scopes = prMeta.scopes_supported ?? [];
 
   // ── Step 2: authorization-server discovery ──────────────────────
-  const asMetaUrl = `${authServerUrl.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`;
+  const asMetaUrl = new URL(
+    "/.well-known/oauth-authorization-server",
+    authServerUrl,
+  );
   let asMeta: AuthServerMetadata;
   try {
-    const res = await fetch(asMetaUrl, { headers: { Accept: "application/json" } });
+    const res = await fetch(
+      asMetaUrl,
+      noRedirectFetchInit({ headers: { Accept: "application/json" } }),
+    );
     if (!res.ok) {
       return back(
         workspace.slug,
@@ -168,6 +205,32 @@ export async function GET(
       `${provider.displayName} authorization server is missing required endpoints.`,
     );
   }
+  let authorizationEndpoint: URL;
+  let tokenEndpoint: URL;
+  let registrationEndpoint: URL;
+  try {
+    authorizationEndpoint = await trustedOAuthUrl(
+      asMeta.authorization_endpoint,
+      provider,
+      "Authorization endpoint",
+    );
+    tokenEndpoint = await trustedOAuthUrl(
+      asMeta.token_endpoint,
+      provider,
+      "Token endpoint",
+    );
+    registrationEndpoint = await trustedOAuthUrl(
+      asMeta.registration_endpoint,
+      provider,
+      "Registration endpoint",
+    );
+  } catch (e) {
+    return back(
+      workspace.slug,
+      provider.slug,
+      `Authorization server endpoint is not trusted: ${(e as Error).message}`,
+    );
+  }
   if (
     !(asMeta.code_challenge_methods_supported ?? []).some((m) => m === "S256")
   ) {
@@ -192,7 +255,7 @@ export async function GET(
   const redirectUri = redirectUriFor(provider.slug as McpProviderSlug);
   let clientId: string;
   try {
-    const dcrRes = await fetch(asMeta.registration_endpoint, {
+    const dcrRes = await fetch(registrationEndpoint, noRedirectFetchInit({
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -205,7 +268,7 @@ export async function GET(
         grant_types: ["authorization_code", "refresh_token"],
         response_types: ["code"],
       }),
-    });
+    }));
     if (!dcrRes.ok) {
       const body = await dcrRes.text().catch(() => "");
       return back(
@@ -247,10 +310,10 @@ export async function GET(
     connectionName,
     pkceVerifier,
     clientId,
-    tokenEndpoint: asMeta.token_endpoint,
+    tokenEndpoint: tokenEndpoint.toString(),
   });
 
-  const authorizeUrl = new URL(asMeta.authorization_endpoint);
+  const authorizeUrl = new URL(authorizationEndpoint);
   authorizeUrl.searchParams.set("client_id", clientId);
   authorizeUrl.searchParams.set("redirect_uri", redirectUri);
   authorizeUrl.searchParams.set("response_type", "code");

--- a/web/src/app/api/connections/native/[provider]/callback/route.ts
+++ b/web/src/app/api/connections/native/[provider]/callback/route.ts
@@ -8,6 +8,10 @@ import {
   redirectUriFor,
   type McpProviderSlug,
 } from "@/lib/mcp-providers";
+import {
+  noRedirectFetchInit,
+  trustedOAuthUrl,
+} from "@/lib/native-oauth-security";
 import { fetchNativeMcpTools } from "@/lib/native-mcp-tools";
 import { replaceToolsForConnection } from "@/lib/mcp-tools";
 import { verifyNativeMcpState } from "@/lib/oauth-state";
@@ -114,8 +118,23 @@ export async function GET(
     scope?: string;
     token_type?: string;
   };
+  let tokenEndpoint: URL;
   try {
-    const tokenRes = await fetch(state.tokenEndpoint, {
+    tokenEndpoint = await trustedOAuthUrl(
+      state.tokenEndpoint,
+      provider,
+      "Token endpoint",
+    );
+  } catch (e) {
+    return back(
+      state.workspaceSlug,
+      provider.slug,
+      "error",
+      `Token endpoint is not trusted: ${(e as Error).message}`,
+    );
+  }
+  try {
+    const tokenRes = await fetch(tokenEndpoint, noRedirectFetchInit({
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -128,7 +147,7 @@ export async function GET(
         client_id: state.clientId,
         code_verifier: state.pkceVerifier,
       }).toString(),
-    });
+    }));
     if (!tokenRes.ok) {
       const body = await tokenRes.text().catch(() => "");
       return back(

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -25,6 +25,9 @@ export type McpProvider = {
    *  bearer token at run time. The /.well-known endpoints are
    *  derived from this URL's origin. */
   mcpServerUrl: string;
+  /** Exact OAuth authorization-server origins this provider is allowed
+   *  to advertise through protected-resource discovery. */
+  oauthAuthorizationServerOrigins: string[];
 };
 
 export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
@@ -32,6 +35,7 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
     slug: "attio",
     displayName: "Attio",
     mcpServerUrl: "https://mcp.attio.com/mcp",
+    oauthAuthorizationServerOrigins: ["https://app.attio.com"],
   },
 };
 

--- a/web/src/lib/native-oauth-security.test.ts
+++ b/web/src/lib/native-oauth-security.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { isPublicIpAddress, trustedOAuthUrl } from "./native-oauth-security";
+import type { McpProvider } from "./mcp-providers";
+
+const provider: McpProvider = {
+  slug: "attio",
+  displayName: "Attio",
+  mcpServerUrl: "https://mcp.attio.com/mcp",
+  oauthAuthorizationServerOrigins: ["https://app.attio.com"],
+};
+
+describe("native OAuth URL trust checks", () => {
+  it("rejects non-public IP literals", () => {
+    expect(isPublicIpAddress("127.0.0.1")).toBe(false);
+    expect(isPublicIpAddress("169.254.169.254")).toBe(false);
+    expect(isPublicIpAddress("10.1.2.3")).toBe(false);
+    expect(isPublicIpAddress("::1")).toBe(false);
+    expect(isPublicIpAddress("fc00::1")).toBe(false);
+    expect(isPublicIpAddress("::ffff:a9fe:a9fe")).toBe(false);
+  });
+
+  it("allows known public IP literals", () => {
+    expect(isPublicIpAddress("8.8.8.8")).toBe(true);
+    expect(isPublicIpAddress("2606:4700:4700::1111")).toBe(true);
+  });
+
+  it("requires discovered OAuth endpoints to stay on the provider allowlist", async () => {
+    await expect(
+      trustedOAuthUrl("https://app.attio.com/oidc/token", provider, "Token"),
+    ).resolves.toMatchObject({ origin: "https://app.attio.com" });
+
+    await expect(
+      trustedOAuthUrl("https://evil.example/oidc/token", provider, "Token"),
+    ).rejects.toThrow(/allowed provider origin/);
+  });
+
+  it("rejects http and private-address endpoints before fetch", async () => {
+    await expect(
+      trustedOAuthUrl("http://app.attio.com/oidc/token", provider, "Token"),
+    ).rejects.toThrow(/https/);
+
+    await expect(
+      trustedOAuthUrl("https://169.254.169.254/token", {
+        ...provider,
+        oauthAuthorizationServerOrigins: ["https://169.254.169.254"],
+      }, "Token"),
+    ).rejects.toThrow(/non-public IP/);
+
+    await expect(
+      trustedOAuthUrl("https://[::1]/token", {
+        ...provider,
+        oauthAuthorizationServerOrigins: ["https://[::1]"],
+      }, "Token"),
+    ).rejects.toThrow(/non-public IP/);
+  });
+});

--- a/web/src/lib/native-oauth-security.ts
+++ b/web/src/lib/native-oauth-security.ts
@@ -1,0 +1,148 @@
+import "server-only";
+
+import { lookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
+
+import type { McpProvider } from "@/lib/mcp-providers";
+
+const privateIpBlocks = new BlockList();
+
+privateIpBlocks.addSubnet("0.0.0.0", 8, "ipv4");
+privateIpBlocks.addSubnet("10.0.0.0", 8, "ipv4");
+privateIpBlocks.addSubnet("100.64.0.0", 10, "ipv4");
+privateIpBlocks.addSubnet("127.0.0.0", 8, "ipv4");
+privateIpBlocks.addSubnet("169.254.0.0", 16, "ipv4");
+privateIpBlocks.addSubnet("172.16.0.0", 12, "ipv4");
+privateIpBlocks.addSubnet("192.0.0.0", 24, "ipv4");
+privateIpBlocks.addSubnet("192.0.2.0", 24, "ipv4");
+privateIpBlocks.addSubnet("192.168.0.0", 16, "ipv4");
+privateIpBlocks.addSubnet("198.18.0.0", 15, "ipv4");
+privateIpBlocks.addSubnet("198.51.100.0", 24, "ipv4");
+privateIpBlocks.addSubnet("203.0.113.0", 24, "ipv4");
+privateIpBlocks.addSubnet("224.0.0.0", 4, "ipv4");
+privateIpBlocks.addSubnet("240.0.0.0", 4, "ipv4");
+privateIpBlocks.addAddress("255.255.255.255", "ipv4");
+
+privateIpBlocks.addAddress("::", "ipv6");
+privateIpBlocks.addAddress("::1", "ipv6");
+privateIpBlocks.addSubnet("64:ff9b:1::", 48, "ipv6");
+privateIpBlocks.addSubnet("100::", 64, "ipv6");
+privateIpBlocks.addSubnet("2001::", 23, "ipv6");
+privateIpBlocks.addSubnet("2001:2::", 48, "ipv6");
+privateIpBlocks.addSubnet("2001:db8::", 32, "ipv6");
+privateIpBlocks.addSubnet("fc00::", 7, "ipv6");
+privateIpBlocks.addSubnet("fe80::", 10, "ipv6");
+privateIpBlocks.addSubnet("ff00::", 8, "ipv6");
+
+function ipv4FromMappedIpv6(address: string): string | null {
+  const lower = address.toLowerCase();
+  const prefix = lower.startsWith("::ffff:")
+    ? "::ffff:"
+    : lower.startsWith("0:0:0:0:0:ffff:")
+      ? "0:0:0:0:0:ffff:"
+      : null;
+  if (!prefix) return null;
+
+  const pieces = lower.slice(prefix.length).split(":");
+  if (pieces.length !== 2) return null;
+  const high = Number.parseInt(pieces[0], 16);
+  const low = Number.parseInt(pieces[1], 16);
+  if (
+    !Number.isInteger(high) ||
+    !Number.isInteger(low) ||
+    high < 0 ||
+    high > 0xffff ||
+    low < 0 ||
+    low > 0xffff
+  ) {
+    return null;
+  }
+  return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+
+export function isPublicIpAddress(address: string): boolean {
+  const version = isIP(address);
+  if (version === 4) {
+    return !privateIpBlocks.check(address, "ipv4");
+  }
+  if (version === 6) {
+    const mappedIpv4 = ipv4FromMappedIpv6(address);
+    if (mappedIpv4) return isPublicIpAddress(mappedIpv4);
+    return !privateIpBlocks.check(address, "ipv6");
+  }
+  return false;
+}
+
+function endpointHostname(url: URL): string {
+  return url.hostname.startsWith("[") && url.hostname.endsWith("]")
+    ? url.hostname.slice(1, -1)
+    : url.hostname;
+}
+
+function parseHttpsUrl(rawUrl: string, label: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`${label} is not a valid URL.`);
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`${label} must use https.`);
+  }
+  if (url.username || url.password) {
+    throw new Error(`${label} must not include credentials.`);
+  }
+  if (!url.hostname) {
+    throw new Error(`${label} must include a host.`);
+  }
+  const hostname = endpointHostname(url);
+  const literalIp = isIP(hostname);
+  if (literalIp !== 0 && !isPublicIpAddress(hostname)) {
+    throw new Error(`${label} resolves to a non-public IP address.`);
+  }
+  return url;
+}
+
+async function assertPublicDns(url: URL, label: string): Promise<void> {
+  const hostname = endpointHostname(url);
+  if (isIP(hostname) !== 0) return;
+
+  const records = await lookup(hostname, { all: true, verbatim: true });
+  if (records.length === 0) {
+    throw new Error(`${label} did not resolve to any IP addresses.`);
+  }
+  const blocked = records.find((record) => !isPublicIpAddress(record.address));
+  if (blocked) {
+    throw new Error(
+      `${label} resolves to a non-public IP address (${blocked.address}).`,
+    );
+  }
+}
+
+export async function trustedProviderMcpOrigin(
+  provider: McpProvider,
+): Promise<string> {
+  const url = parseHttpsUrl(provider.mcpServerUrl, "MCP server URL");
+  await assertPublicDns(url, "MCP server URL");
+  return url.origin;
+}
+
+export async function trustedOAuthUrl(
+  rawUrl: string,
+  provider: McpProvider,
+  label: string,
+): Promise<URL> {
+  const url = parseHttpsUrl(rawUrl, label);
+  if (!provider.oauthAuthorizationServerOrigins.includes(url.origin)) {
+    throw new Error(`${label} is not on an allowed provider origin.`);
+  }
+  await assertPublicDns(url, label);
+  return url;
+}
+
+export function noRedirectFetchInit(init?: RequestInit): RequestInit {
+  return {
+    ...init,
+    redirect: "manual",
+  };
+}


### PR DESCRIPTION
## Summary
Enforce HTTPS, validate origins, and block private IPs in native-MCP OAuth discovery to prevent SSRF and refresh token exfiltration.

- Added URL validation for HTTPS scheme and allowed origins.
- DNS resolution checks to block private IP addresses.
- Disabled automatic redirects in HTTP clients.
- Updated native OAuth discovery flow to use trusted URLs only.
- Added tests for IP and URL validation.
- Refactored web OAuth authorize and callback routes to validate endpoints before fetch.
- Extended MCP provider config with allowed OAuth origins.

This mitigates SSRF and token exfiltration risks by ensuring only trusted, public endpoints are used in OAuth flows. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/1f08f0ca-f12b-4262-af70-69a35511ef39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> 