### PR TITLE
Fix get_run endpoint tenant scoping

### DIFF
--- a/api/src/runs/handlers.rs
+++ b/api/src/runs/handlers.rs
@@ -1,12 +1,12 @@
 //! HTTP surface for the runs subsystem. Two endpoints:
 //!
 //!   POST /internal/runs      — web triggers a run, returns run id
-//!   GET  /internal/runs/:id  — web polls for status + output
+//!   GET  /internal/runs/:id?workspace_id=... — web polls for status + output
 //!
 //! Both gated by the bearer middleware in `crate::auth`.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Json,
 };
@@ -174,18 +174,26 @@ pub struct RunRecord {
     pub automation_id: Option<Uuid>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct GetRunQuery {
+    pub workspace_id: Uuid,
+}
+
 pub async fn get_run(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    Query(query): Query<GetRunQuery>,
 ) -> Result<Json<RunRecord>, StatusCode> {
     let row: Option<RunRecord> = sqlx::query_as(
         r#"SELECT id, workspace_id, agent_name, agent_path, model, status,
                   output, error_message, created_by, created_at,
                   started_at, completed_at, tokens_input, tokens_output,
                   trigger, automation_id
-             FROM run WHERE id = $1"#,
+             FROM run
+             WHERE id = $1 AND workspace_id = $2"#,
     )
     .bind(id)
+    .bind(query.workspace_id)
     .fetch_optional(&state.db)
     .await
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/actions.ts
@@ -49,7 +49,7 @@ export async function improveAgentAction(args: {
   }
   const { workspace, userId } = auth;
 
-  const run = await getRun(args.runId);
+  const run = await getRun(args.runId, workspace.id);
   if (!run || run.workspaceId !== workspace.id) notFound();
 
   const repo = await getWorkspaceRepo(workspace.id);

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
@@ -30,7 +30,7 @@ export default async function RunDetailPage({
   const workspace = await getWorkspaceBySlug(slug);
   if (!workspace) notFound();
 
-  const run = await getRun(runId);
+  const run = await getRun(runId, workspace.id);
   if (!run) notFound();
   // Defense against URL guessing for other workspaces' runs.
   if (run.workspaceId !== workspace.id) notFound();

--- a/web/src/lib/runs-api.ts
+++ b/web/src/lib/runs-api.ts
@@ -124,12 +124,19 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunRespons
   return { runId: body.run_id };
 }
 
-export async function getRun(runId: string): Promise<RunRecord | null> {
-  const res = await fetch(`${API_URL}/internal/runs/${encodeURIComponent(runId)}`, {
-    method: "GET",
-    headers: { ...authHeader() },
-    cache: "no-store",
-  });
+export async function getRun(
+  runId: string,
+  workspaceId: string,
+): Promise<RunRecord | null> {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  const res = await fetch(
+    `${API_URL}/internal/runs/${encodeURIComponent(runId)}?${params}`,
+    {
+      method: "GET",
+      headers: { ...authHeader() },
+      cache: "no-store",
+    },
+  );
   if (res.status === 404) return null;
   if (!res.ok) {
     const text = await res.text().catch(() => "");


### PR DESCRIPTION
## Summary
Enforce tenant scoping on get_run endpoint by requiring workspace_id param and adding it to SQL query filter.

- Updated API handler to accept workspace_id query param
- Modified SQL query to filter by run id and workspace_id
- Updated frontend calls to pass workspace_id when fetching run
- Added GetRunQuery struct for query param deserialization

This prevents cross-tenant run data disclosure by ensuring runs are fetched only within the correct tenant workspace. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/2dde2e75-3d42-451d-b252-006f4d6cf744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> 