### PR TITLE
Add Tembo as a self-key native-MCP connection

### DIFF
--- a/web/src/app/[workspace]/connections/native-mcp-actions.ts
+++ b/web/src/app/[workspace]/connections/native-mcp-actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
 
+import { deleteApiKey } from "@/lib/api-keys-db";
 import { writeAuditEvent } from "@/lib/audit-db";
 import { authorizeWorkspace, DENIED_MESSAGE } from "@/lib/auth-server";
 import {
@@ -61,6 +62,13 @@ export async function disconnectNativeMcpConnectionAction(
 
   const ok = await deleteNativeConnection(workspace.id, connectionId);
   if (!ok) return { error: "Connection no longer exists." };
+
+  // Self-key (Tembo) rows own a minted tas_ API key — revoke it so the
+  // credential can't outlive the connection. Other providers' tokens live
+  // only inside the now-deleted row, so there's nothing extra to revoke.
+  if (row.type === "tembo" && typeof row.metadata.api_key_id === "string") {
+    await deleteApiKey(workspace.id, row.metadata.api_key_id);
+  }
 
   // Drop the cached tool catalog for this slot too. A future
   // re-connect under the same name shouldn't inherit a stale list

--- a/web/src/app/[workspace]/connections/native-mcp-connections-section.tsx
+++ b/web/src/app/[workspace]/connections/native-mcp-connections-section.tsx
@@ -150,6 +150,7 @@ function ProviderRow({
   viewingOther?: boolean;
 }) {
   const isManual = provider.authMode === "manual";
+  const isSelfKey = provider.authMode === "self-key";
 
   if (!connection) {
     // Placeholder "Connect" rows are DCR-only (manual providers connect via the
@@ -170,7 +171,9 @@ function ProviderRow({
             </Badge>
           </div>
           <p className="text-foreground-weak text-sm">
-            Click Connect to log in with your {provider.displayName} account.
+            {isSelfKey
+              ? "Connect to let your agents manage agents, runs, and automations on your behalf — they act with your workspace role."
+              : `Click Connect to log in with your ${provider.displayName} account.`}
           </p>
         </div>
         <Button asChild variant="primary" size="small">
@@ -271,8 +274,10 @@ function ProviderRow({
           </Link>
         )}
         {/* DCR slots are free-named; a manual slot IS its OAuth-app instance,
-            so renaming would desync it from the app — not offered. */}
-        {!isManual && (
+            so renaming would desync it from the app — not offered. Self-key
+            (Tembo) is a single fixed "default" slot agent specs reference by
+            provider, so renaming it would silently break them — not offered. */}
+        {!isManual && !isSelfKey && (
           <RenameNativeMcpConnectionForm
             workspaceSlug={workspaceSlug}
             connectionId={connection.id}

--- a/web/src/app/[workspace]/connections/native-mcp/page.tsx
+++ b/web/src/app/[workspace]/connections/native-mcp/page.tsx
@@ -129,9 +129,12 @@ export default async function NativeMcpConnectionsPage({
     }
   }
 
-  // Visible DCR providers feed the "Add another" named-slot picker.
+  // Visible DCR providers feed the "Add another" named-slot picker. Self-key
+  // (Tembo) is excluded — it's a single per-user "default" slot, not a
+  // multi-account provider, and agent specs reference it as `{type: tembo}`.
   const addableProviders = nativeCatalog.filter(
-    (p) => p.authMode !== "manual" && isVisible(p),
+    (p) =>
+      p.authMode !== "manual" && p.authMode !== "self-key" && isVisible(p),
   );
   // Visible manual providers + their connectable instances.
   const manualConnect: ManualConnectTarget[] = nativeCatalog

--- a/web/src/app/api/connections/native/[provider]/authorize/route.ts
+++ b/web/src/app/api/connections/native/[provider]/authorize/route.ts
@@ -1,13 +1,23 @@
 import { createHash, randomBytes } from "node:crypto";
 import { NextResponse, type NextRequest } from "next/server";
 
+import { writeAuditEvent } from "@/lib/audit-db";
 import { authorizeWorkspace } from "@/lib/auth-server";
 import { getPublicOrigin } from "@/lib/config";
+import { createApiKey, deleteApiKey } from "@/lib/api-keys-db";
+import {
+  getNativeConnection,
+  saveNativeConnection,
+} from "@/lib/connections";
 import {
   getMcpProvider,
   redirectUriFor,
+  tasMcpServerUrl,
+  type McpProvider,
   type McpProviderSlug,
 } from "@/lib/mcp-providers";
+import { fetchNativeMcpTools } from "@/lib/native-mcp-tools";
+import { replaceToolsForConnection } from "@/lib/mcp-tools";
 import {
   noRedirectFetchInit,
   trustedOAuthUrl,
@@ -50,6 +60,102 @@ function back(slug: string, provider: string, detail: string): NextResponse {
   target.searchParams.set("native_mcp", provider);
   target.searchParams.set("result", "error");
   target.searchParams.set("detail", detail.slice(0, 200));
+  return NextResponse.redirect(target, 302);
+}
+
+/**
+ * Self-key connect (Tembo connecting to its own /mcp). No OAuth: mint a
+ * per-user `tas_` API key, store it as the connection's bearer, and point the
+ * row at TAS's own MCP server. Because the key is owned by the connecting user,
+ * /mcp resolves *their* live workspace role at run time — so an agent that uses
+ * this connection acts with the role of whoever the run runs as. Reconnecting
+ * the same slot revokes the previously minted key so we never orphan a live
+ * credential.
+ */
+async function connectSelfKey(
+  provider: McpProvider,
+  workspace: { id: string; slug: string },
+  userId: string,
+  connectionName: string,
+): Promise<NextResponse> {
+  // Capture any key minted by a prior connect on this slot — revoked after the
+  // new one is stored (the saveNativeConnection upsert overwrites credentials).
+  const prior = await getNativeConnection(
+    workspace.id,
+    userId,
+    provider.slug,
+    connectionName,
+  );
+  const priorKeyId =
+    typeof prior?.metadata.api_key_id === "string"
+      ? prior.metadata.api_key_id
+      : null;
+
+  const mcpUrl = tasMcpServerUrl();
+  const { key, token } = await createApiKey({
+    workspaceId: workspace.id,
+    userId,
+    name: "Tembo (native MCP)",
+    createdBy: userId,
+  });
+
+  const saved = await saveNativeConnection({
+    workspaceId: workspace.id,
+    userId,
+    type: provider.slug,
+    name: connectionName,
+    mcpServerUrl: mcpUrl,
+    // "pat", with no token_expires_at, so the OAuth refresh sweep skips it —
+    // the tas_ key doesn't expire.
+    authType: "pat",
+    credentials: { access_token: token },
+    metadata: { api_key_id: key.id },
+  });
+
+  if (priorKeyId && priorKeyId !== key.id) {
+    await deleteApiKey(workspace.id, priorKeyId);
+  }
+
+  await writeAuditEvent({
+    workspaceId: workspace.id,
+    actorUserId: userId,
+    source: "human_action",
+    kind: "connection.authorized",
+    targetType: "connection",
+    targetId: saved.id,
+    agentName: null,
+    payload: { provider: provider.slug, name: connectionName, source: "native-mcp" },
+  });
+
+  // Best-effort: prime the tool-list cache so the Connections page shows the
+  // TAS tool catalog immediately. Don't block the redirect on failure.
+  try {
+    const tools = await fetchNativeMcpTools(mcpUrl, token);
+    await replaceToolsForConnection({
+      workspaceId: workspace.id,
+      userId,
+      source: "native-mcp",
+      provider: provider.slug,
+      connectionName,
+      tools: tools.map((t) => ({
+        slug: t.slug,
+        displayName: t.name,
+        description: t.description,
+      })),
+    });
+  } catch (e) {
+    console.error(
+      `[native-mcp/${provider.slug}] tool-cache prime failed:`,
+      (e as Error).message,
+    );
+  }
+
+  const target = new URL(
+    `/${workspace.slug}/connections/native-mcp`,
+    getPublicOrigin(),
+  );
+  target.searchParams.set("native_mcp", provider.slug);
+  target.searchParams.set("result", "ok");
   return NextResponse.redirect(target, 302);
 }
 
@@ -126,6 +232,12 @@ export async function GET(
     );
   }
   const { workspace, userId } = auth;
+
+  // Self-key providers (Tembo → its own /mcp) skip the entire OAuth dance:
+  // mint a per-user tas_ key and store it as the connection bearer.
+  if (provider.authMode === "self-key") {
+    return connectSelfKey(provider, workspace, userId, connectionName);
+  }
 
   // ── Step 1: protected-resource discovery ────────────────────────
   let mcpOrigin: string;

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -16,14 +16,21 @@
 
 import { getPublicOrigin } from "@/lib/config";
 
-export type McpProviderSlug = "attio" | "pylon" | "hubspot" | "fathom";
+export type McpProviderSlug =
+  | "attio"
+  | "pylon"
+  | "hubspot"
+  | "fathom"
+  | "tembo";
 
 export type McpProvider = {
   slug: McpProviderSlug;
   displayName: string;
   /** The MCP server URL pydantic-ai connects to with the user's
    *  bearer token at run time. The /.well-known endpoints are
-   *  derived from this URL's origin. */
+   *  derived from this URL's origin. Empty for "self-key" providers
+   *  (TAS itself) — resolved at connect time via tasMcpServerUrl(),
+   *  since the origin is env-derived rather than a constant. */
   mcpServerUrl: string;
   /** Exact OAuth authorization-server origins this provider is allowed
    *  to advertise through protected-resource discovery. */
@@ -37,8 +44,12 @@ export type McpProvider = {
    *    provider and stores its client_id/secret in TAS
    *    (workspace_native_oauth_client); the flow uses that confidential
    *    client. HubSpot is the first of these.
+   *  - "self-key": no upstream OAuth at all — the "provider" is TAS's
+   *    own /mcp server. Connect mints a per-user `tas_` API key and
+   *    stores it as the connection's bearer; the key's owner (and their
+   *    live workspace role) is what /mcp enforces. Tembo is the first.
    */
-  authMode?: "dcr" | "manual";
+  authMode?: "dcr" | "manual" | "self-key";
 };
 
 export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
@@ -86,10 +97,31 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
       "https://fathom.video",
     ],
   },
+  tembo: {
+    slug: "tembo",
+    displayName: "Tembo",
+    // Self-key: no upstream OAuth. The connect flow branches before any
+    // discovery, mints a per-user tas_ key, and stores the row pointing at
+    // TAS's own /mcp (resolved via tasMcpServerUrl() at connect time). These
+    // two fields are intentionally empty — the OAuth helpers never run for it.
+    mcpServerUrl: "",
+    oauthAuthorizationServerOrigins: [],
+    authMode: "self-key",
+  },
 };
 
 export function getMcpProvider(slug: string): McpProvider | null {
   return MCP_PROVIDERS[slug as McpProviderSlug] ?? null;
+}
+
+/**
+ * The MCP server URL for the "self-key" Tembo provider — TAS's own /mcp
+ * endpoint. Computed from the request/env-derived public origin rather than
+ * baked into the catalog, then stored per-row in workspace_connection so it
+ * can be tuned (e.g. to an internal URL) without code changes.
+ */
+export function tasMcpServerUrl(): string {
+  return `${getPublicOrigin()}/mcp`;
 }
 
 export function listMcpProviders(): McpProvider[] {


### PR DESCRIPTION
## Why

You want an agent (e.g. a Slack "personal assistant" `@pa`) to be able to create/edit TAS agents, trigger runs, and schedule automations by calling TAS's own MCP server. Today an agent only reaches tools it declares in `connections:` (Composio / Native-MCP / Secrets), and the new `/mcp` server authenticates with `tas_` API keys — which didn't fit the OAuth-based Native-MCP catalog.

This makes **Tembo itself a connection**, so it's per-agent opt-in (only agents that declare it get it, narrowable via `tools:`) and its tools show up in the tool list.

## How

New **`self-key`** auth mode in the native-MCP catalog — no upstream OAuth:

- **Connect** mints a per-user `tas_` API key and stores it as the connection's bearer, pointing the row at TAS's own `/mcp` (`tasMcpServerUrl()` → `${publicOrigin}/mcp`).
- Because the key is owned by the connecting user, `/mcp` resolves **their live workspace role** per request — so an agent acts with the role of whoever the run runs as. Through Slack, `resolveActingUser` maps the sender's email → workspace member (falling back to the app's default owner).
- Stored as `auth_type='pat'` with no expiry, so the OAuth refresh sweep skips it.

The native-MCP runtime is provider-agnostic (`runner.rs` → `build_native_mcp_toolsets`), so **no Rust/Python/migration changes** — the row just needs `mcp_server_url` + `access_token`.

### Files
- `web/src/lib/mcp-providers.ts` — `tembo` entry + `self-key` mode + `tasMcpServerUrl()`
- `.../native/[provider]/authorize/route.ts` — self-key branch: mint key, store row, revoke prior key on reconnect, prime tool cache, audit
- `.../connections/native-mcp-actions.ts` — disconnect revokes the minted key via `metadata.api_key_id`
- `.../connections/native-mcp/page.tsx` + `native-mcp-connections-section.tsx` — single `default` slot, self-key copy, no rename

## Using it (`@pa`)
After a user connects Tembo:
```yaml
connections:
  - type: tembo
    source: native-mcp
    tools: [create_agent, request_agent_change, list_agents]  # narrow; omit trigger_run to avoid self-fan-out
```

## Verification
- `tsc --noEmit`, `eslint` (touched files), `next build`: clean
- Unit tests (`api-keys-db`, `mcp/server`, `native-oauth-security`): 25 passed
- **Not yet run live** (needs a running stack): connect → run-agent → role-enforcement → disconnect (key revoked / 401).

## Risks to be deliberate about
- **Slack email-fallback:** an unmapped Slack sender runs as the app's `defaultOwnerUserId` → uses the *owner's* key/role. Consider failing closed for PAs exposed to arbitrary Slack users.
- **Self-call networking:** the runner opens HTTP to `publicOrigin/mcp` (TAS calls itself) — verify the runtime container can reach the public origin on Railway. The per-row `mcp_server_url` is the tuning knob.
- **Recursion/fan-out:** a tembo agent with `trigger_run`/`create_agent` can spawn runs — default `@pa` to a narrowed `tools:` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)