### PR TITLE
Add Dialed to the native-MCP provider catalog

### DIFF
--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -16,7 +16,12 @@
 
 import { getPublicOrigin } from "@/lib/config";
 
-export type McpProviderSlug = "attio" | "pylon" | "hubspot" | "fathom";
+export type McpProviderSlug =
+  | "attio"
+  | "pylon"
+  | "hubspot"
+  | "fathom"
+  | "dialed";
 
 export type McpProvider = {
   slug: McpProviderSlug;
@@ -85,6 +90,19 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
       "https://api.fathom.ai",
       "https://fathom.video",
     ],
+  },
+  dialed: {
+    slug: "dialed",
+    displayName: "Dialed",
+    // Verified: POST https://dialed.day/mcp → 401 + WWW-Authenticate Bearer
+    // pointing at /.well-known/oauth-protected-resource, which advertises the
+    // auth server as the apex https://dialed.day. Auth-server metadata supports
+    // DCR (registration_endpoint /oauth/register), PKCE S256, and a public
+    // client (auth method "none") — so it's TAS-managed (no per-customer
+    // setup), like Attio. (The www.dialed.day host is a non-OAuth PAT endpoint;
+    // use the apex.)
+    mcpServerUrl: "https://dialed.day/mcp",
+    oauthAuthorizationServerOrigins: ["https://dialed.day"],
   },
 };
 


### PR DESCRIPTION
## What

Adds **Dialed** (`https://dialed.day/mcp`) to the Native MCP provider catalog (`web/src/lib/mcp-providers.ts`). It's a standard DCR provider — one catalog entry, zero per-customer setup. Members will see a **Connect** button under Connections → Native MCP and can declare it in an agent with `connections: [{type: dialed, source: native-mcp}]`.

## Why it's just a catalog entry

Dialed's apex domain is a fully OAuth-enabled MCP server, verified via discovery:

- `POST https://dialed.day/mcp` → `401` + `WWW-Authenticate: Bearer resource_metadata="https://dialed.day/.well-known/oauth-protected-resource"`
- protected-resource metadata advertises `authorization_servers: ["https://dialed.day"]`, scopes `tasks`/`admin`
- auth-server metadata: `registration_endpoint: /oauth/register` (DCR), `code_challenge_methods_supported: ["S256"]`, and `token_endpoint_auth_methods_supported` includes `"none"` → **public client, TAS-managed**, same shape as Attio/Pylon/Fathom.

So no new auth mode, no Rust/Python changes — the existing DCR authorize/callback flow handles it.

> Note: the `www.dialed.day` host is a *different*, non-OAuth endpoint (static `Bearer <key>:<email>` PAT). This entry uses the **apex** `dialed.day`, which is the OAuth one.

## Verification
- `tsc --noEmit`, `eslint`, `next build`: clean
- OAuth discovery endpoints confirmed reachable + DCR/PKCE-capable (see above)
- Live connect (browser OAuth consent on dialed.day) not exercised — needs an interactive Dialed login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)