### PR TITLE
Fix broken auto-merge in mcp-providers.ts (unblocks deploy)

### DIFF
--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -21,7 +21,7 @@ export type McpProviderSlug =
   | "pylon"
   | "hubspot"
   | "fathom"
-  | "dialed";
+  | "dialed"
   | "tembo";
 
 export type McpProvider = {
@@ -110,6 +110,7 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
     // use the apex.)
     mcpServerUrl: "https://dialed.day/mcp",
     oauthAuthorizationServerOrigins: ["https://dialed.day"],
+  },
   tembo: {
     slug: "tembo",
     displayName: "Tembo",


### PR DESCRIPTION
## Problem

`main` doesn't compile — `Typecheck (blocking)` fails and the deploy is blocked:

```
src/lib/mcp-providers.ts(25,3): error TS1109: Expression expected.
src/lib/mcp-providers.ts(124,2): error TS1005: ',' expected.
...
```

## Cause

PR #115 (Tembo self-key) and PR #116 (Dialed) both:
- reshaped the `McpProviderSlug` union, and
- appended a new provider entry immediately after `fathom`

They merged back-to-back, and the second auto-merge stitched the two hunks into **invalid TypeScript**:
- a stray `;` mid-union — `| "dialed";` followed by `| "tembo";`
- the `dialed` object missing its closing `},` — `tembo: {` ran straight onto it

Both providers were intended; the merge just mangled the punctuation between them.

## Fix

Drop the stray semicolon and restore the missing `},`. The catalog now has **both** `dialed` and `tembo`, correctly closed.

## Verification
- `cd web && npx tsc --noEmit` → exit 0 (whole project)
- `eslint src/lib/mcp-providers.ts` → clean
- Brace count balanced; both `dialed:` and `tembo:` entries present

🤖 Generated with [Claude Code](https://claude.com/claude-code)