### PR TITLE
Rename Tembo native-MCP provider to "Tembo Agent Studio"

### DIFF
--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -113,7 +113,7 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
   },
   tembo: {
     slug: "tembo",
-    displayName: "Tembo",
+    displayName: "Tembo Agent Studio",
     // Self-key: no upstream OAuth. The connect flow branches before any
     // discovery, mints a per-user tas_ key, and stores the row pointing at
     // TAS's own /mcp (resolved via tasMcpServerUrl() at connect time). These


### PR DESCRIPTION
Changes the `tembo` self-key native-MCP provider's `displayName` from **Tembo** → **Tembo Agent Studio**. This is the label shown on the Connections → Native MCP page and in agent tool lists. The slug (`tembo`) is unchanged, so existing `connections: [{type: tembo, source: native-mcp}]` specs and any connected rows keep working.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)