### PR TITLE
Rename Tembo self-key provider slug to tembo-agent-studio

### DIFF
--- a/web/src/app/[workspace]/connections/native-mcp-actions.ts
+++ b/web/src/app/[workspace]/connections/native-mcp-actions.ts
@@ -66,7 +66,10 @@ export async function disconnectNativeMcpConnectionAction(
   // Self-key (Tembo) rows own a minted tas_ API key — revoke it so the
   // credential can't outlive the connection. Other providers' tokens live
   // only inside the now-deleted row, so there's nothing extra to revoke.
-  if (row.type === "tembo" && typeof row.metadata.api_key_id === "string") {
+  if (
+    row.type === "tembo-agent-studio" &&
+    typeof row.metadata.api_key_id === "string"
+  ) {
     await deleteApiKey(workspace.id, row.metadata.api_key_id);
   }
 

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -22,7 +22,7 @@ export type McpProviderSlug =
   | "hubspot"
   | "fathom"
   | "dialed"
-  | "tembo";
+  | "tembo-agent-studio";
 
 export type McpProvider = {
   slug: McpProviderSlug;
@@ -111,8 +111,8 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
     mcpServerUrl: "https://dialed.day/mcp",
     oauthAuthorizationServerOrigins: ["https://dialed.day"],
   },
-  tembo: {
-    slug: "tembo",
+  "tembo-agent-studio": {
+    slug: "tembo-agent-studio",
     displayName: "Tembo Agent Studio",
     // Self-key: no upstream OAuth. The connect flow branches before any
     // discovery, mints a per-user tas_ key, and stores the row pointing at


### PR DESCRIPTION
Changes the self-key native-MCP provider **slug** from `tembo` → `tembo-agent-studio` (the displayName is already "Tembo Agent Studio" from #118).

The slug is the `workspace_connection.type`, the `/api/connections/native/<slug>/…` route param, and the value agent specs reference — so this updates the catalog union/key/`slug` field plus the disconnect key-revocation guard (`row.type === "tembo-agent-studio"`). The route/banner/lookup paths are all slug-generic and accept the hyphenated value.

Agent specs now declare:
```yaml
connections:
  - type: tembo-agent-studio
    source: native-mcp
```

Pre-launch, no connected `tembo` rows exist yet, so no data migration is needed. The unrelated "Tembo Coding Agent" settings tab (`settings-nav.tsx`) keeps its own `tembo` slug.

`tsc --noEmit` clean; eslint clean (2 pre-existing unused-const warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)