### PR TITLE
Surface native-MCP connections to CAP + serve a tool reference from TAS

### DIFF
--- a/web/src/app/[workspace]/agents/new/actions.ts
+++ b/web/src/app/[workspace]/agents/new/actions.ts
@@ -16,6 +16,9 @@ import {
   type CapError,
 } from "@/lib/cap-api";
 import { listConnectionsForUser } from "@/lib/composio-connections";
+import { getPublicOrigin } from "@/lib/config";
+import { signForAgentsToken } from "@/lib/for-agents-token";
+import { buildNativeSlots } from "@/lib/native-slots";
 import {
   createImprovement,
   improvementMarker,
@@ -148,6 +151,14 @@ export async function createFromChatAction(
     if (!availableSlots[c.toolkit]) availableSlots[c.toolkit] = [];
     availableSlots[c.toolkit].push(c.name);
   }
+  // Native-MCP connections are a separate substrate; CAP looks up their tool
+  // slugs at this instance's /for-agents reference (signed token in the URL).
+  const nativeSlots = await buildNativeSlots(workspace.id, userId);
+  const nativeToolsKey = signForAgentsToken(
+    workspace.id,
+    userId,
+    Math.floor(Date.now() / 1000),
+  );
 
   const prompt = buildCreateAgentPrompt({
     framework,
@@ -159,6 +170,9 @@ export async function createFromChatAction(
     commitMode: workspace.commitMode,
     defaultBranch: repo.defaultBranch,
     availableSlots,
+    nativeSlots,
+    nativeToolsBaseUrl: `${getPublicOrigin()}/for-agents`,
+    nativeToolsKey,
   });
 
   const res = await createTemboTask({

--- a/web/src/app/for-agents/[provider]/route.ts
+++ b/web/src/app/for-agents/[provider]/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest } from "next/server";
+
+import { verifyForAgentsToken } from "@/lib/for-agents-token";
+import {
+  renderProviderMarkdown,
+  type ForAgentsTool,
+} from "@/lib/for-agents-markdown";
+import { getMcpProvider } from "@/lib/mcp-providers";
+import { listToolsForUser } from "@/lib/mcp-tools";
+
+// Agent-facing native-MCP tool reference: GET /for-agents/<provider>.md?key=…
+//
+// The create-agent prompt links CAP here so it can read a native MCP's exact
+// tool slugs (it can't introspect the provider's server). Auth is a signed,
+// expiring, workspace+user-scoped token in `?key=` (see lib/for-agents-token);
+// it unlocks only the cached tool catalog, nothing else. Served as text/markdown.
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function text(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/markdown; charset=utf-8" },
+  });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ provider: string }> },
+): Promise<Response> {
+  const { provider: raw } = await params;
+  const slug = raw.replace(/\.md$/, "");
+
+  const key = request.nextUrl.searchParams.get("key");
+  const payload = key
+    ? verifyForAgentsToken(key, Math.floor(Date.now() / 1000))
+    : null;
+  if (!payload) {
+    return text("# Unauthorized\n\nMissing or invalid `?key=` token.", 401);
+  }
+
+  const provider = getMcpProvider(slug);
+  if (!provider) {
+    return text(`# Unknown provider\n\nNo native MCP provider \`${slug}\`.`, 404);
+  }
+
+  const all = await listToolsForUser(payload.w, payload.u);
+  const seen = new Set<string>();
+  const tools: ForAgentsTool[] = [];
+  for (const t of all) {
+    if (t.source !== "native-mcp" || t.provider !== slug) continue;
+    if (seen.has(t.slug)) continue; // same tool can be cached under many slots
+    seen.add(t.slug);
+    tools.push({ slug: t.slug, name: t.displayName, description: t.description });
+  }
+  tools.sort((a, b) => a.slug.localeCompare(b.slug));
+
+  return text(renderProviderMarkdown(provider, tools), 200);
+}

--- a/web/src/app/for-agents/route.ts
+++ b/web/src/app/for-agents/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest } from "next/server";
+
+import { getPublicOrigin } from "@/lib/config";
+import { renderIndexMarkdown } from "@/lib/for-agents-markdown";
+import { verifyForAgentsToken } from "@/lib/for-agents-token";
+import { listMcpProviders } from "@/lib/mcp-providers";
+import { listToolsForUser } from "@/lib/mcp-tools";
+
+// Agent-facing index: GET /for-agents?key=… → a linked list of the per-provider
+// tool-reference pages. Same signed-token auth as the provider pages.
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const key = request.nextUrl.searchParams.get("key");
+  const payload = key
+    ? verifyForAgentsToken(key, Math.floor(Date.now() / 1000))
+    : null;
+  if (!key || !payload) {
+    return new Response("# Unauthorized\n\nMissing or invalid `?key=` token.", {
+      status: 401,
+      headers: { "content-type": "text/markdown; charset=utf-8" },
+    });
+  }
+
+  const all = await listToolsForUser(payload.w, payload.u);
+  const connected = new Set(
+    all.filter((t) => t.source === "native-mcp").map((t) => t.provider),
+  );
+  const md = renderIndexMarkdown(
+    `${getPublicOrigin()}/for-agents`,
+    key,
+    listMcpProviders(),
+    connected,
+  );
+  return new Response(md, {
+    status: 200,
+    headers: { "content-type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -23,6 +23,9 @@ import {
   type AvailableConnectionSlots,
 } from "@/lib/cap-api";
 import { listConnectionsForUser } from "@/lib/composio-connections";
+import { getPublicOrigin } from "@/lib/config";
+import { signForAgentsToken } from "@/lib/for-agents-token";
+import { buildNativeSlots } from "@/lib/native-slots";
 import {
   findMissingConnections,
   missingConnectionsMessage,
@@ -322,6 +325,14 @@ export async function requestAgentChange(
     if (c.status !== "ACTIVE") continue;
     (availableSlots[c.toolkit] ??= []).push(c.name);
   }
+  // Native-MCP connections are a separate substrate; CAP looks up their tool
+  // slugs at this instance's /for-agents reference (signed token in the URL).
+  const nativeSlots = await buildNativeSlots(ctx.workspace.id, ctx.userId);
+  const nativeToolsKey = signForAgentsToken(
+    ctx.workspace.id,
+    ctx.userId,
+    Math.floor(Date.now() / 1000),
+  );
 
   prompt = buildCreateAgentPrompt({
     framework,
@@ -333,6 +344,9 @@ export async function requestAgentChange(
     commitMode: ctx.workspace.commitMode,
     defaultBranch: repo.defaultBranch,
     availableSlots,
+    nativeSlots,
+    nativeToolsBaseUrl: `${getPublicOrigin()}/for-agents`,
+    nativeToolsKey,
   });
   return finishTask({ ctx, apiKey, repositoryUrl, repo, rowId: row.id, prompt, kind, agentPath });
 }

--- a/web/src/lib/cap-api.ts
+++ b/web/src/lib/cap-api.ts
@@ -210,6 +210,19 @@ export function buildCreateAgentPrompt(args: {
    * authorized yet, so the prompt falls back to `default`.
    */
   availableSlots?: AvailableConnectionSlots;
+  /**
+   * Native-MCP provider slug → authorized slot names for the user.
+   * Rendered as a separate block from `availableSlots`: native connections
+   * must be declared with `source: native-mcp`, and CAP looks up their exact
+   * tool slugs at the TAS-served reference (nativeToolsBaseUrl + nativeToolsKey)
+   * rather than inline.
+   */
+  nativeSlots?: AvailableConnectionSlots;
+  /** Origin + path of this instance's /for-agents reference, e.g.
+   *  "https://tas.example.com/for-agents". */
+  nativeToolsBaseUrl?: string;
+  /** Signed token CAP appends as `?key=` when fetching the reference. */
+  nativeToolsKey?: string;
 }): string {
   const frameworkGuide =
     args.framework === "cargo-ai" ? GUIDANCE_CARGO_AI_PATH : GUIDANCE_PYDANTIC_PATH;
@@ -224,6 +237,11 @@ export function buildCreateAgentPrompt(args: {
     `The agent's \`name:\` field must be exactly \`${args.agentName}\` (it matches the filename). Also set a \`title:\` field to the human display name "${args.title}" (free text — this is what the UI shows). Don't put the file anywhere other than \`${args.agentPath}\`.`,
     "",
     ...renderAvailableSlots(args.availableSlots),
+    ...renderNativeSlots(
+      args.nativeSlots,
+      args.nativeToolsBaseUrl,
+      args.nativeToolsKey,
+    ),
     "If the agent needs to call external services (Slack, Gmail, Google",
     "Sheets, Notion, GitHub, Linear, HubSpot, etc.), declare them via the",
     "`connections:` field. The slug is whatever Composio uses (lowercase,",
@@ -325,6 +343,58 @@ function renderAvailableSlots(
     "doesn't have to re-authorize. For a toolkit not listed above, use",
   );
   lines.push("`default` and TAS will surface a Connect button.");
+  lines.push("");
+  return lines;
+}
+
+// Native-MCP slots block. Native connections must be declared with
+// `source: native-mcp`; their tool slugs aren't inlined (the catalogs are
+// large and provider-specific) — instead CAP fetches a per-provider reference
+// served by this TAS instance, authorized by a signed `?key=` token. Empty
+// slots, or a missing base/key, returns [].
+function renderNativeSlots(
+  slots: AvailableConnectionSlots | undefined,
+  baseUrl: string | undefined,
+  key: string | undefined,
+): string[] {
+  if (!slots || !baseUrl || !key) return [];
+  const entries = Object.entries(slots).filter(([, names]) => names.length > 0);
+  if (entries.length === 0) return [];
+  entries.sort(([a], [b]) => a.localeCompare(b));
+  const q = `?key=${encodeURIComponent(key)}`;
+  const lines: string[] = [
+    "**Native MCP connection slots already authorized in this workspace:**",
+    "",
+  ];
+  for (const [provider, names] of entries) {
+    lines.push(`- \`${provider}\`: ${names.map((n) => `\`${n}\``).join(", ")}`);
+  }
+  const [firstProvider, firstNames] = entries[0];
+  lines.push("");
+  lines.push(
+    "These talk to the provider's official MCP server. Declare them with",
+  );
+  lines.push(
+    "`source: native-mcp` and the existing slot name above. Before writing the",
+  );
+  lines.push(
+    "`tools:` list, fetch the provider's tool reference (lists the exact slugs)",
+  );
+  lines.push("and narrow to what you need — one page per provider:");
+  lines.push("");
+  for (const [provider] of entries) {
+    lines.push(`- \`${provider}\` → ${baseUrl}/${provider}.md${q}`);
+  }
+  lines.push("");
+  lines.push("Example:");
+  lines.push("");
+  lines.push("```yaml");
+  lines.push("connections:");
+  lines.push(`  - ${firstProvider}:`);
+  lines.push("      source: native-mcp");
+  lines.push(`      name: ${firstNames[0]}`);
+  lines.push("      tools: [<slug-from-the-reference-page>]");
+  lines.push("```");
   lines.push("");
   return lines;
 }

--- a/web/src/lib/for-agents-markdown.ts
+++ b/web/src/lib/for-agents-markdown.ts
@@ -1,0 +1,86 @@
+import type { McpProvider } from "@/lib/mcp-providers";
+
+// Markdown for the agent-facing native-MCP tool reference (the /for-agents
+// routes). Served as text/markdown so CAP can read it cheaply when authoring a
+// `tools:` list for a `source: native-mcp` connection.
+
+export type ForAgentsTool = {
+  slug: string;
+  name: string | null;
+  description: string | null;
+};
+
+// Escape a cell for a GitHub-flavored markdown table (pipes + newlines).
+function cell(s: string | null): string {
+  return (s ?? "").replace(/\|/g, "\\|").replace(/\r?\n+/g, " ").trim();
+}
+
+/** One provider's tool reference. `tools` is the workspace's cached catalog
+ *  for that provider (deduped by slug); empty when nothing is cached yet. */
+export function renderProviderMarkdown(
+  provider: McpProvider,
+  tools: ForAgentsTool[],
+): string {
+  const server = provider.mcpServerUrl
+    ? `MCP server: \`${provider.mcpServerUrl}\``
+    : "MCP server: this TAS instance's own `/mcp` endpoint.";
+  const lines = [
+    `# ${provider.displayName} — native MCP tools`,
+    "",
+    server,
+    "",
+    "Declare this connection in the agent spec with `source: native-mcp` and",
+    "the authorized slot name, then narrow `tools:` to the slugs you need:",
+    "",
+    "```yaml",
+    "connections:",
+    `  - ${provider.slug}:`,
+    "      source: native-mcp",
+    "      name: <your-authorized-slot-name>",
+    `      tools: [${tools.length ? tools[0].slug : "<a-slug-below>"}]`,
+    "```",
+    "",
+    "## Tools",
+    "",
+  ];
+  if (tools.length === 0) {
+    lines.push(
+      "_No tools cached for this connection yet._ Open Connections → Native",
+      "MCP in TAS and click Refresh, then reload this page.",
+      "",
+    );
+  } else {
+    lines.push("| slug | name | description |", "| --- | --- | --- |");
+    for (const t of tools) {
+      lines.push(`| \`${cell(t.slug)}\` | ${cell(t.name)} | ${cell(t.description)} |`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/** The /for-agents index: links to each provider's page (carrying the key).
+ *  `connected` is the set of provider slugs that have cached tools. */
+export function renderIndexMarkdown(
+  baseUrl: string,
+  key: string,
+  providers: McpProvider[],
+  connected: Set<string>,
+): string {
+  const q = `?key=${encodeURIComponent(key)}`;
+  const lines = [
+    "# Native MCP tool reference (for agents)",
+    "",
+    "One page per provider, listing the exact tool slugs to put in an agent's",
+    "`tools:` list when it declares a `source: native-mcp` connection.",
+    "",
+  ];
+  for (const p of [...providers].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName),
+  )) {
+    const note = connected.has(p.slug) ? "" : " — _not connected here yet_";
+    lines.push(`- [${p.displayName}](${baseUrl}/${p.slug}.md${q}) — \`${p.slug}\`${note}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/web/src/lib/for-agents-token.ts
+++ b/web/src/lib/for-agents-token.ts
@@ -1,0 +1,88 @@
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// Signed, expiring token for the agent-facing /for-agents tool reference.
+//
+// The create-agent prompt sent to the Tembo Coding Agent (CAP) links to
+// `${origin}/for-agents/<provider>.md?key=<token>`. CAP fetches that URL to
+// learn a native MCP's exact tool slugs (it can't introspect the provider's
+// server and there's no central catalog). This token authorizes that read,
+// scoped to one (workspace, user) and short-lived — it grants nothing but the
+// cached tool catalog (tool names + descriptions), so it's deliberately
+// low-privilege. Signed with BETTER_AUTH_SECRET (same key the OAuth state
+// tokens use), stateless so no DB round-trip on each fetch.
+
+const TTL_SECONDS = 14 * 24 * 60 * 60; // 14 days — covers a slow CAP task.
+
+export type ForAgentsTokenPayload = {
+  /** Workspace whose cached tool catalog the token unlocks. */
+  w: string;
+  /** Acting user — whose per-user native connections (and thus cached
+   *  tools) the reference reflects. */
+  u: string;
+  /** Expiry, epoch seconds. */
+  exp: number;
+};
+
+function secret(): Buffer {
+  const raw = process.env.BETTER_AUTH_SECRET;
+  if (!raw) {
+    throw new Error(
+      "BETTER_AUTH_SECRET is required to sign /for-agents tokens.",
+    );
+  }
+  return Buffer.from(raw, "utf8");
+}
+
+function sign(data: string): string {
+  return createHmac("sha256", secret()).update(data).digest("base64url");
+}
+
+/** Mint a token for (workspaceId, userId), valid for TTL_SECONDS. */
+export function signForAgentsToken(
+  workspaceId: string,
+  userId: string,
+  nowSeconds: number,
+): string {
+  const payload: ForAgentsTokenPayload = {
+    w: workspaceId,
+    u: userId,
+    exp: nowSeconds + TTL_SECONDS,
+  };
+  const body = Buffer.from(JSON.stringify(payload), "utf8").toString(
+    "base64url",
+  );
+  return `${body}.${sign(body)}`;
+}
+
+/** Verify a token; returns its payload or null (bad shape / signature /
+ *  expired). `nowSeconds` is passed in so callers stay testable. */
+export function verifyForAgentsToken(
+  token: string,
+  nowSeconds: number,
+): ForAgentsTokenPayload | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+  const body = token.slice(0, dot);
+  const presented = token.slice(dot + 1);
+  const expected = sign(body);
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  let payload: ForAgentsTokenPayload;
+  try {
+    payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload?.w !== "string" ||
+    typeof payload?.u !== "string" ||
+    typeof payload?.exp !== "number"
+  ) {
+    return null;
+  }
+  if (payload.exp < nowSeconds) return null;
+  return payload;
+}

--- a/web/src/lib/native-slots.ts
+++ b/web/src/lib/native-slots.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import type { AvailableConnectionSlots } from "@/lib/cap-api";
+import { listNativeConnectionsForUser } from "@/lib/connections";
+
+// Build the native-MCP slot map (provider slug → authorized slot names) for the
+// create-agent prompt, from the user's active native connections. Native
+// connections live in a separate table from Composio and must be declared with
+// `source: native-mcp`, so the prompt renders them as their own block (and
+// points CAP at the per-provider tool reference for the exact slugs).
+export async function buildNativeSlots(
+  workspaceId: string,
+  userId: string,
+): Promise<AvailableConnectionSlots> {
+  const connections = await listNativeConnectionsForUser(workspaceId, userId);
+  const slots: AvailableConnectionSlots = {};
+  for (const c of connections) {
+    if (c.status !== "active") continue;
+    (slots[c.type] ??= []).push(c.name);
+  }
+  return slots;
+}


### PR DESCRIPTION
## Why

When TAS asks the Tembo Coding Agent (CAP) to author an agent, the prompt listed the workspace's authorized connection slots — but **only Composio**. Agents using a native-MCP connection (Attio, Dialed, **Tembo Agent Studio**) got no slot guidance, and CAP had no way to learn a native MCP's exact **tool slugs**: it reads the repo, holds no TAS credential, and the providers' MCP servers `401` on `tools/list` without auth (verified for all of ours). There's also **no central DB** to read — TAS is single-tenant/self-hosted.

## What

**1. Prompt now includes native slots + a per-provider reference link.** Lists each authorized native slot (`provider: name`), says to declare it with `source: native-mcp`, and points CAP at a tool-reference URL per provider. No tools inlined. Wired into both create paths (`request_agent_change`/MCP and the in-app new-agent form) via a shared `buildNativeSlots()`.

**2. Each TAS instance serves the reference from its own cached catalog.** New routes:
- `GET /for-agents/<provider>.md` → markdown table of that provider's tools, from `workspace_mcp_tool` (the same cache the Connections UI fills on Connect/Refresh).
- `GET /for-agents` → index linking each provider.

**Auth:** a signed, expiring, `(workspace, user)`-scoped token (`lib/for-agents-token`, HMAC over `BETTER_AUTH_SECRET`) that TAS mints **into the prompt URL** as `?key=…`. It unlocks only the tool catalog (names + descriptions) — no session, no DB key, stateless verify. 14-day TTL.

No central DB, no third-party tokens, no GitHub Pages — each instance answers from its own data.

```
- `attio` → https://<instance>/for-agents/attio.md?key=…
- `tembo-agent-studio` → https://<instance>/for-agents/tembo-agent-studio.md?key=…
```

## Reachability note
CAP must reach the instance's public origin to fetch the reference — true for the hosted/dogfood instance; a fully air-gapped self-host would not get the reference (the prompt still lists the slots).

## Verification
- `tsc --noEmit`, eslint, `next build` clean; `/for-agents` + `/for-agents/[provider]` register as dynamic routes.
- Token: valid round-trips; expired / tampered / wrong-secret all reject.
- Prompt renders the slot list + per-provider `?key=` URLs (no inline tools).
- `mcp/server` + `api-keys-db` tests pass (21).
- Markdown renderer escapes table pipes; dedupes a tool cached under multiple slots; stubs when a connection has no cached tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
