### PR TITLE
/for-agents: header auth + connection context for agent-change requests

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/chat/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/chat/actions.ts
@@ -17,6 +17,7 @@ import {
   setImprovementCommitted,
   setImprovementTask,
 } from "@/lib/improvements-api";
+import { buildPromptConnectionContext } from "@/lib/prompt-connections";
 import {
   findMissingConnections,
   missingConnectionsMessage,
@@ -103,6 +104,11 @@ export async function chatSubmitAction(args: {
     improvementMarker: improvementMarker(row.id),
     commitMode: workspace.commitMode,
     defaultBranch: repo.defaultBranch,
+    ...(await buildPromptConnectionContext(
+      workspace.id,
+      userId,
+      Math.floor(Date.now() / 1000),
+    )),
   });
 
   const res = await createTemboTask({

--- a/web/src/app/[workspace]/agents/new/actions.ts
+++ b/web/src/app/[workspace]/agents/new/actions.ts
@@ -12,13 +12,9 @@ import {
 import {
   buildCreateAgentPrompt,
   createTemboTask,
-  type AvailableConnectionSlots,
   type CapError,
 } from "@/lib/cap-api";
-import { listConnectionsForUser } from "@/lib/composio-connections";
-import { getPublicOrigin } from "@/lib/config";
-import { signForAgentsToken } from "@/lib/for-agents-token";
-import { buildNativeSlots } from "@/lib/native-slots";
+import { buildPromptConnectionContext } from "@/lib/prompt-connections";
 import {
   createImprovement,
   improvementMarker,
@@ -138,28 +134,10 @@ export async function createFromChatAction(
     userId,
   });
 
-  // Fetch the requesting user's authorized connections so the
-  // prompt can list the actual slot names (not just suggest
-  // `default`). Tembo's coding agent reads the repo, not the TAS
-  // DB, so without this it has no way to know which slot to write
-  // — leading to PRs that say `name: default` when the workspace
-  // already has a `name: tembo` slot authorized.
-  const myConnections = await listConnectionsForUser(workspace.id, userId);
-  const availableSlots: AvailableConnectionSlots = {};
-  for (const c of myConnections) {
-    if (c.status !== "ACTIVE") continue;
-    if (!availableSlots[c.toolkit]) availableSlots[c.toolkit] = [];
-    availableSlots[c.toolkit].push(c.name);
-  }
-  // Native-MCP connections are a separate substrate; CAP looks up their tool
-  // slugs at this instance's /for-agents reference (signed token in the URL).
-  const nativeSlots = await buildNativeSlots(workspace.id, userId);
-  const nativeToolsKey = signForAgentsToken(
-    workspace.id,
-    userId,
-    Math.floor(Date.now() / 1000),
-  );
-
+  // Fetch the requesting user's authorized connections (Composio + native MCP)
+  // so the prompt lists real slot names (not just `default`) and CAP can look
+  // up native tool slugs. Tembo's coding agent reads the repo, not the TAS DB,
+  // so without this it writes `name: default` even when a slot already exists.
   const prompt = buildCreateAgentPrompt({
     framework,
     agentName: agentSlug,
@@ -169,10 +147,11 @@ export async function createFromChatAction(
     improvementMarker: improvementMarker(row.id),
     commitMode: workspace.commitMode,
     defaultBranch: repo.defaultBranch,
-    availableSlots,
-    nativeSlots,
-    nativeToolsBaseUrl: `${getPublicOrigin()}/for-agents`,
-    nativeToolsKey,
+    ...(await buildPromptConnectionContext(
+      workspace.id,
+      userId,
+      Math.floor(Date.now() / 1000),
+    )),
   });
 
   const res = await createTemboTask({

--- a/web/src/app/for-agents/[provider]/route.ts
+++ b/web/src/app/for-agents/[provider]/route.ts
@@ -1,6 +1,9 @@
 import { type NextRequest } from "next/server";
 
-import { verifyForAgentsToken } from "@/lib/for-agents-token";
+import {
+  bearerFromHeader,
+  verifyForAgentsToken,
+} from "@/lib/for-agents-token";
 import {
   renderProviderMarkdown,
   type ForAgentsTool,
@@ -32,12 +35,15 @@ export async function GET(
   const { provider: raw } = await params;
   const slug = raw.replace(/\.md$/, "");
 
-  const key = request.nextUrl.searchParams.get("key");
-  const payload = key
-    ? verifyForAgentsToken(key, Math.floor(Date.now() / 1000))
+  const token = bearerFromHeader(request.headers.get("authorization"));
+  const payload = token
+    ? verifyForAgentsToken(token, Math.floor(Date.now() / 1000))
     : null;
   if (!payload) {
-    return text("# Unauthorized\n\nMissing or invalid `?key=` token.", 401);
+    return text(
+      "# Unauthorized\n\nSend `Authorization: Bearer <token>`.",
+      401,
+    );
   }
 
   const provider = getMcpProvider(slug);

--- a/web/src/app/for-agents/route.ts
+++ b/web/src/app/for-agents/route.ts
@@ -2,7 +2,10 @@ import { type NextRequest } from "next/server";
 
 import { getPublicOrigin } from "@/lib/config";
 import { renderIndexMarkdown } from "@/lib/for-agents-markdown";
-import { verifyForAgentsToken } from "@/lib/for-agents-token";
+import {
+  bearerFromHeader,
+  verifyForAgentsToken,
+} from "@/lib/for-agents-token";
 import { listMcpProviders } from "@/lib/mcp-providers";
 import { listToolsForUser } from "@/lib/mcp-tools";
 
@@ -13,12 +16,12 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest): Promise<Response> {
-  const key = request.nextUrl.searchParams.get("key");
-  const payload = key
-    ? verifyForAgentsToken(key, Math.floor(Date.now() / 1000))
+  const token = bearerFromHeader(request.headers.get("authorization"));
+  const payload = token
+    ? verifyForAgentsToken(token, Math.floor(Date.now() / 1000))
     : null;
-  if (!key || !payload) {
-    return new Response("# Unauthorized\n\nMissing or invalid `?key=` token.", {
+  if (!payload) {
+    return new Response("# Unauthorized\n\nSend `Authorization: Bearer <token>`.", {
       status: 401,
       headers: { "content-type": "text/markdown; charset=utf-8" },
     });
@@ -30,7 +33,6 @@ export async function GET(request: NextRequest): Promise<Response> {
   );
   const md = renderIndexMarkdown(
     `${getPublicOrigin()}/for-agents`,
-    key,
     listMcpProviders(),
     connected,
   );

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -20,12 +20,8 @@ import {
   buildChatEditPrompt,
   buildCreateAgentPrompt,
   createTemboTask,
-  type AvailableConnectionSlots,
 } from "@/lib/cap-api";
-import { listConnectionsForUser } from "@/lib/composio-connections";
-import { getPublicOrigin } from "@/lib/config";
-import { signForAgentsToken } from "@/lib/for-agents-token";
-import { buildNativeSlots } from "@/lib/native-slots";
+import { buildPromptConnectionContext } from "@/lib/prompt-connections";
 import {
   findMissingConnections,
   missingConnectionsMessage,
@@ -279,6 +275,11 @@ export async function requestAgentChange(
       improvementMarker: improvementMarker(row.id),
       commitMode: ctx.workspace.commitMode,
       defaultBranch: repo.defaultBranch,
+      ...(await buildPromptConnectionContext(
+        ctx.workspace.id,
+        ctx.userId,
+        Math.floor(Date.now() / 1000),
+      )),
     });
     return finishTask({ ctx, apiKey, repositoryUrl, repo, rowId: row.id, prompt, kind, agentPath });
   }
@@ -317,23 +318,9 @@ export async function requestAgentChange(
     userId: ctx.userId,
   });
 
-  // Surface the user's authorized connection slots so the coding agent writes
-  // real slot names instead of `default` (it reads the repo, not the TAS DB).
-  const myConnections = await listConnectionsForUser(ctx.workspace.id, ctx.userId);
-  const availableSlots: AvailableConnectionSlots = {};
-  for (const c of myConnections) {
-    if (c.status !== "ACTIVE") continue;
-    (availableSlots[c.toolkit] ??= []).push(c.name);
-  }
-  // Native-MCP connections are a separate substrate; CAP looks up their tool
-  // slugs at this instance's /for-agents reference (signed token in the URL).
-  const nativeSlots = await buildNativeSlots(ctx.workspace.id, ctx.userId);
-  const nativeToolsKey = signForAgentsToken(
-    ctx.workspace.id,
-    ctx.userId,
-    Math.floor(Date.now() / 1000),
-  );
-
+  // Surface the user's authorized connection slots (Composio + native MCP) so
+  // CAP writes real slot names instead of `default` (it reads the repo, not the
+  // TAS DB) and can look up native tool slugs at this instance's /for-agents.
   prompt = buildCreateAgentPrompt({
     framework,
     agentName: agentSlug,
@@ -343,10 +330,11 @@ export async function requestAgentChange(
     improvementMarker: improvementMarker(row.id),
     commitMode: ctx.workspace.commitMode,
     defaultBranch: repo.defaultBranch,
-    availableSlots,
-    nativeSlots,
-    nativeToolsBaseUrl: `${getPublicOrigin()}/for-agents`,
-    nativeToolsKey,
+    ...(await buildPromptConnectionContext(
+      ctx.workspace.id,
+      ctx.userId,
+      Math.floor(Date.now() / 1000),
+    )),
   });
   return finishTask({ ctx, apiKey, repositoryUrl, repo, rowId: row.id, prompt, kind, agentPath });
 }

--- a/web/src/lib/cap-api.ts
+++ b/web/src/lib/cap-api.ts
@@ -350,18 +350,18 @@ function renderAvailableSlots(
 // Native-MCP slots block. Native connections must be declared with
 // `source: native-mcp`; their tool slugs aren't inlined (the catalogs are
 // large and provider-specific) — instead CAP fetches a per-provider reference
-// served by this TAS instance, authorized by a signed `?key=` token. Empty
-// slots, or a missing base/key, returns [].
+// served by this TAS instance, authorized by a signed bearer token sent in the
+// `Authorization` header. Empty slots, or a missing base/token, returns [].
 function renderNativeSlots(
   slots: AvailableConnectionSlots | undefined,
   baseUrl: string | undefined,
-  key: string | undefined,
+  token: string | undefined,
 ): string[] {
-  if (!slots || !baseUrl || !key) return [];
+  if (!slots || !baseUrl || !token) return [];
   const entries = Object.entries(slots).filter(([, names]) => names.length > 0);
   if (entries.length === 0) return [];
   entries.sort(([a], [b]) => a.localeCompare(b));
-  const q = `?key=${encodeURIComponent(key)}`;
+  const [firstProvider, firstNames] = entries[0];
   const lines: string[] = [
     "**Native MCP connection slots already authorized in this workspace:**",
     "",
@@ -369,7 +369,6 @@ function renderNativeSlots(
   for (const [provider, names] of entries) {
     lines.push(`- \`${provider}\`: ${names.map((n) => `\`${n}\``).join(", ")}`);
   }
-  const [firstProvider, firstNames] = entries[0];
   lines.push("");
   lines.push(
     "These talk to the provider's official MCP server. Declare them with",
@@ -378,13 +377,23 @@ function renderNativeSlots(
     "`source: native-mcp` and the existing slot name above. Before writing the",
   );
   lines.push(
-    "`tools:` list, fetch the provider's tool reference (lists the exact slugs)",
+    "`tools:` list, fetch the provider's tool reference (it lists the exact tool",
   );
-  lines.push("and narrow to what you need — one page per provider:");
+  lines.push(
+    "slugs) and narrow to what you need. Each page requires this HTTP header:",
+  );
+  lines.push("");
+  lines.push(`    Authorization: Bearer ${token}`);
+  lines.push("");
+  lines.push("Reference pages (one per provider):");
   lines.push("");
   for (const [provider] of entries) {
-    lines.push(`- \`${provider}\` → ${baseUrl}/${provider}.md${q}`);
+    lines.push(`- \`${provider}\` → ${baseUrl}/${provider}.md`);
   }
+  lines.push("");
+  lines.push(
+    `e.g. \`curl -H "Authorization: Bearer ${token}" ${baseUrl}/${firstProvider}.md\``,
+  );
   lines.push("");
   lines.push("Example:");
   lines.push("");
@@ -409,6 +418,15 @@ export function buildChatEditPrompt(args: {
   improvementMarker: string;
   commitMode: CommitMode;
   defaultBranch: string;
+  /** Composio toolkit → authorized slot names. Lets CAP add/reference real
+   *  slots when the edit touches `connections:`. */
+  availableSlots?: AvailableConnectionSlots;
+  /** Native-MCP provider slug → authorized slot names. */
+  nativeSlots?: AvailableConnectionSlots;
+  /** Origin + path of this instance's /for-agents reference. */
+  nativeToolsBaseUrl?: string;
+  /** Signed token CAP sends as `Authorization: Bearer` to the reference. */
+  nativeToolsKey?: string;
 }): string {
   const framework = frameworkFromAgentPath(args.agentPath);
   return [
@@ -424,6 +442,14 @@ export function buildChatEditPrompt(args: {
       args.improvementMarker,
     ),
     "",
+    // If the edit adds/changes a `connections:` entry, these tell CAP the real
+    // authorized slot names + where to look up native-MCP tool slugs.
+    ...renderAvailableSlots(args.availableSlots),
+    ...renderNativeSlots(
+      args.nativeSlots,
+      args.nativeToolsBaseUrl,
+      args.nativeToolsKey,
+    ),
     "## Requested change",
     args.improvement.trim(),
   ].join("\n");

--- a/web/src/lib/for-agents-markdown.ts
+++ b/web/src/lib/for-agents-markdown.ts
@@ -59,27 +59,28 @@ export function renderProviderMarkdown(
   return lines.join("\n");
 }
 
-/** The /for-agents index: links to each provider's page (carrying the key).
- *  `connected` is the set of provider slugs that have cached tools. */
+/** The /for-agents index: links to each provider's page. Every page (and this
+ *  index) requires an `Authorization: Bearer <token>` header. `connected` is
+ *  the set of provider slugs that have cached tools. */
 export function renderIndexMarkdown(
   baseUrl: string,
-  key: string,
   providers: McpProvider[],
   connected: Set<string>,
 ): string {
-  const q = `?key=${encodeURIComponent(key)}`;
   const lines = [
     "# Native MCP tool reference (for agents)",
     "",
     "One page per provider, listing the exact tool slugs to put in an agent's",
-    "`tools:` list when it declares a `source: native-mcp` connection.",
+    "`tools:` list when it declares a `source: native-mcp` connection. Each page",
+    "requires the same `Authorization: Bearer <token>` header used to fetch this",
+    "index.",
     "",
   ];
   for (const p of [...providers].sort((a, b) =>
     a.displayName.localeCompare(b.displayName),
   )) {
     const note = connected.has(p.slug) ? "" : " — _not connected here yet_";
-    lines.push(`- [${p.displayName}](${baseUrl}/${p.slug}.md${q}) — \`${p.slug}\`${note}`);
+    lines.push(`- [${p.displayName}](${baseUrl}/${p.slug}.md) — \`${p.slug}\`${note}`);
   }
   lines.push("");
   return lines.join("\n");

--- a/web/src/lib/for-agents-token.ts
+++ b/web/src/lib/for-agents-token.ts
@@ -4,10 +4,10 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 
 // Signed, expiring token for the agent-facing /for-agents tool reference.
 //
-// The create-agent prompt sent to the Tembo Coding Agent (CAP) links to
-// `${origin}/for-agents/<provider>.md?key=<token>`. CAP fetches that URL to
-// learn a native MCP's exact tool slugs (it can't introspect the provider's
-// server and there's no central catalog). This token authorizes that read,
+// The create-agent prompt sent to the Tembo Coding Agent (CAP) tells it to
+// fetch `${origin}/for-agents/<provider>.md` with an `Authorization: Bearer
+// <token>` header to learn a native MCP's exact tool slugs (it can't introspect
+// the provider's server and there's no central catalog). This token authorizes that read,
 // scoped to one (workspace, user) and short-lived — it grants nothing but the
 // cached tool catalog (tool names + descriptions), so it's deliberately
 // low-privilege. Signed with BETTER_AUTH_SECRET (same key the OAuth state
@@ -85,4 +85,12 @@ export function verifyForAgentsToken(
   }
   if (payload.exp < nowSeconds) return null;
   return payload;
+}
+
+/** Pull the token out of an `Authorization: Bearer <token>` header value
+ *  (case-insensitive scheme). Returns null when absent or malformed. */
+export function bearerFromHeader(header: string | null): string | null {
+  if (!header) return null;
+  const m = /^Bearer[ ]+(.+)$/i.exec(header.trim());
+  return m ? m[1].trim() : null;
 }

--- a/web/src/lib/prompt-connections.ts
+++ b/web/src/lib/prompt-connections.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import type { AvailableConnectionSlots } from "@/lib/cap-api";
+import { listConnectionsForUser } from "@/lib/composio-connections";
+import { getPublicOrigin } from "@/lib/config";
+import { signForAgentsToken } from "@/lib/for-agents-token";
+import { buildNativeSlots } from "@/lib/native-slots";
+
+// The connection context the create/edit prompts hand to the Tembo Coding
+// Agent (CAP): the user's authorized Composio + native-MCP slot names, plus the
+// base URL and signed bearer token for this instance's /for-agents native-MCP
+// tool reference. CAP reads the repo (not the TAS DB), so without this it would
+// write `default` slot names and have no way to discover native tool slugs.
+export type PromptConnectionContext = {
+  availableSlots: AvailableConnectionSlots;
+  nativeSlots: AvailableConnectionSlots;
+  nativeToolsBaseUrl: string;
+  nativeToolsKey: string;
+};
+
+export async function buildPromptConnectionContext(
+  workspaceId: string,
+  userId: string,
+  nowSeconds: number,
+): Promise<PromptConnectionContext> {
+  const availableSlots: AvailableConnectionSlots = {};
+  for (const c of await listConnectionsForUser(workspaceId, userId)) {
+    if (c.status !== "ACTIVE") continue;
+    (availableSlots[c.toolkit] ??= []).push(c.name);
+  }
+  return {
+    availableSlots,
+    nativeSlots: await buildNativeSlots(workspaceId, userId),
+    nativeToolsBaseUrl: `${getPublicOrigin()}/for-agents`,
+    nativeToolsKey: signForAgentsToken(workspaceId, userId, nowSeconds),
+  };
+}


### PR DESCRIPTION
Follow-up to #120 (native-MCP tool reference for CAP), two related changes:

## 1. Auth via header, not URL
The `/for-agents` pages now read the signed token from `Authorization: Bearer <token>` instead of `?key=`. The create/edit prompt tells CAP to send the header and includes a `curl -H …` example. Keeps the token out of URLs/logs. (TAS already expects this header style for `/mcp`.)

## 2. Agent-change requests get the connection context too
You asked whether **agent-change** requests include the MCP catalog or only new-agent creation — the answer was **only create**. `buildChatEditPrompt` listed *no* connection slots at all, so an edit like "add Slack to this agent" gave CAP no slot names and no native-MCP tool reference.

Now both edit entry points include the same Composio + native-MCP block as create:
- `request_agent_change` (REST/MCP) edit path
- in-app chat-to-edit

The shared context — Composio slots, native slots, `/for-agents` base URL, signed token — is factored into `buildPromptConnectionContext()` and used by all three call sites (create, API edit, chat edit), replacing the duplicated inline logic.

## Verification
- `tsc --noEmit`, eslint, `next build` clean; `/for-agents` routes register.
- `bearerFromHeader` parses case-insensitive `Bearer`, rejects malformed/missing.
- Prompt renders the `Authorization: Bearer …` header + curl example, no `?key=`.
- `mcp/server` tests pass (13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
