### PR TITLE
Filter cached tools to active connections (drop orphans)

### DIFF
--- a/web/src/lib/mcp-tools.ts
+++ b/web/src/lib/mcp-tools.ts
@@ -70,6 +70,12 @@ const COLUMNS = `id, workspace_id, user_id, source, provider,
  * Powers the workspace Tools tab. Sort key chosen so the page
  * groups naturally: source first (composio above native), then
  * provider alphabetical, then connection name, then tool slug.
+ *
+ * Only tools backed by a still-active connection are returned. The cache is
+ * keyed by (source, provider, connection_name), so a connection that was
+ * disconnected, renamed, or whose provider slug changed (e.g. the
+ * `tembo` → `tembo-agent-studio` rename) leaves orphaned rows behind; the
+ * EXISTS guards filter those out instead of showing duplicate/stale tools.
  */
 export async function listToolsForUser(
   workspaceId: string,
@@ -77,9 +83,22 @@ export async function listToolsForUser(
 ): Promise<McpTool[]> {
   const { rows } = await db.query<Row>(
     `SELECT ${COLUMNS}
-       FROM workspace_mcp_tool
-      WHERE workspace_id = $1 AND user_id = $2
-      ORDER BY source ASC, provider ASC, connection_name ASC, slug ASC`,
+       FROM workspace_mcp_tool t
+      WHERE t.workspace_id = $1 AND t.user_id = $2
+        AND (
+          (t.source = 'native-mcp' AND EXISTS (
+            SELECT 1 FROM workspace_connection c
+             WHERE c.workspace_id = t.workspace_id AND c.user_id = t.user_id
+               AND c.type = t.provider AND c.name = t.connection_name
+               AND c.status = 'active'))
+          OR
+          (t.source = 'composio' AND EXISTS (
+            SELECT 1 FROM workspace_composio_connection cc
+             WHERE cc.workspace_id = t.workspace_id AND cc.user_id = t.user_id
+               AND cc.toolkit_slug = t.provider AND cc.name = t.connection_name
+               AND cc.status = 'ACTIVE'))
+        )
+      ORDER BY t.source ASC, t.provider ASC, t.connection_name ASC, t.slug ASC`,
     [workspaceId, userId],
   );
   return rows.map(rowToTool);


### PR DESCRIPTION
## Problem

On the dogfood instance, **Tembo Agent Studio tools appear twice** — under both `tembo-agent-studio` and the old `tembo` provider — even though `tembo` is gone. The `tembo` → `tembo-agent-studio` slug rename (#119) was a code change, so the old `workspace_mcp_tool` rows (keyed by provider slug) were never cleaned up and still show.

## Fix

`listToolsForUser` now returns a cached tool only when its connection is **still active**, via `EXISTS` guards:
- native-mcp → `workspace_connection` with `type = provider`, `name = connection_name`, `status = 'active'`
- composio → `workspace_composio_connection` with `toolkit_slug = provider`, `name = connection_name`, `status = 'ACTIVE'`

This drops orphans from slug renames, disconnects, and name renames everywhere the function feeds: the **Tools tab**, both **Connections pages**, **`/api/v1/tools`**, the MCP **`list_tools`** tool, and the **`/for-agents`** reference.

(The `listToolSlugProviderMap` used for run tool-icon resolution is intentionally left workspace-wide/unfiltered — old runs may reference tools from since-removed connections.)

## Verification
- Against real Postgres: a live native tool + live composio tool are kept; an old-slug (`tembo`) tool, a disconnected composio tool, and a `stale` native tool are all dropped.
- `tsc`, eslint, `next build` clean; 81 lib tests pass.

Note: this filters the orphan rows out of every view; it doesn't delete them. They're harmless now and rare (only a provider-slug rename creates them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)