### PR TITLE
native-mcp: request offline_access so refresh tokens are issued

### DIFF
--- a/web/src/app/api/connections/native/[provider]/authorize/route.ts
+++ b/web/src/app/api/connections/native/[provider]/authorize/route.ts
@@ -173,6 +173,7 @@ type AuthServerMetadata = {
   registration_endpoint?: string;
   token_endpoint_auth_methods_supported?: string[];
   code_challenge_methods_supported?: string[];
+  grant_types_supported?: string[];
 };
 
 type DcrResponse = {
@@ -335,6 +336,22 @@ export async function GET(
       provider.slug,
       `${provider.displayName} authorization server is missing required endpoints.`,
     );
+  }
+  // Ask for a refresh token when the provider can mint one. A server that
+  // supports the `refresh_token` grant typically only ISSUES a refresh_token
+  // when the client also requests the OIDC `offline_access` scope (the
+  // resource's own scopes_supported rarely lists it). Without it the access
+  // token expires — e.g. Dialed's ~3h — and the refresh-before-use sweep has
+  // nothing to renew, so the next run 401s. Only for DCR (public) providers:
+  // manual (BYO-app) providers like HubSpot use their own scope vocabulary and
+  // already mint refresh tokens, so an unknown `offline_access` could break
+  // their connect. Gate on the advertised grant, and never duplicate it.
+  if (
+    !isManual &&
+    (asMeta.grant_types_supported ?? []).includes("refresh_token") &&
+    !scopes.includes("offline_access")
+  ) {
+    scopes.push("offline_access");
   }
   let authorizationEndpoint: URL;
   let tokenEndpoint: URL;


### PR DESCRIPTION
## Problem

The Dialed native-MCP connection showed **Active** but its token had **expired**, and running an agent against it **401'd**.

Why: native tokens are refreshed before each run (`refresh_expiring_native_connections`), but `refresh_one` needs a stored **`refresh_token`**. Dialed never gave us one, so the refresh errored `"no refresh_token stored"` — which is *swallowed* (best-effort) and makes no HTTP call, so the row stays `active` (only an actively-*rejected* refresh marks it `stale`). The run then used the expired token → **401**.

Dialed's token lives ~3h (connected 10h ago, expired 7h ago). It advertises the `refresh_token` grant but, like many servers, only **issues** a refresh token when the client also requests the OIDC **`offline_access`** scope. TAS requested only the resource's advertised scopes (`tasks admin`), so we never got one.

## Fix

At authorize time, append `offline_access` to the requested scopes **when the auth server's `grant_types_supported` includes `refresh_token`**, gated to **DCR (public) providers** (manual BYO-app providers like HubSpot use their own scope vocabulary and already mint refresh tokens).

Verified against live discovery + authorize probes:

| Provider | grant_types | scopes already have offline_access? | Effect |
|---|---|---|---|
| **Dialed** | incl. refresh_token | no | **adds** it (authorize accepts) ✅ |
| **Pylon** | incl. refresh_token | no (none advertised) | adds it (authorize accepts) ✅ bonus |
| **Attio** | incl. refresh_token | **yes** | dedup guard → unchanged |
| **Fathom** | authorization_code only | — | skipped (no refresh grant) |
| **HubSpot** | manual | — | excluded |

## ⚠️ Reconnect required
This only affects **new** authorizations. The existing Dialed connection still has no refresh token — **reconnect Dialed once** after this deploys to obtain one. Then its token should auto-refresh instead of 401'ing every ~3h.

## Verification
- `tsc`, eslint, `next build` clean.
- Live probes: Dialed + Pylon authorize endpoints return 302→consent (not `invalid_scope`) when `offline_access` is requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)