### PR TITLE
Enable Anthropic prompt caching + cache-aware cost accounting

### DIFF
--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -425,6 +425,12 @@ def usage_payload(usage_obj) -> dict:
         "response_tokens",
         "total_tokens",
         "requests",
+        # Anthropic prompt-cache counters — uncached input is in input_tokens;
+        # these are the cache write (creation) and read halves, priced
+        # separately (~1.25x / ~0.1x of input). The Rust side uses them for the
+        # run's cost estimate.
+        "cache_read_tokens",
+        "cache_write_tokens",
     ):
         val = getattr(usage_obj, attr, None)
         if val is not None:
@@ -711,6 +717,20 @@ def build_agent(
     model_settings = spec.get("model_settings")
     ms = dict(model_settings) if isinstance(model_settings, dict) else {}
     ms.setdefault("parallel_tool_calls", False)
+    # Anthropic prompt caching. An agentic run re-sends the whole prompt every
+    # step; without caching the big static prefix — system instructions + the
+    # MCP/Composio tool schemas — is re-billed at full input rate on each of the
+    # (often 10+) steps. These breakpoints let Anthropic charge the repeated
+    # prefix at the cache-read rate (~0.1x) after the first step, with a small
+    # one-time write surcharge (~1.25x). `anthropic_cache` adds an auto-rolling
+    # breakpoint that follows the growing conversation; pydantic-ai trims to stay
+    # within Anthropic's 4-slot limit. Default 5m TTL fits a single run's burst.
+    # Anthropic-only settings — applying them to OpenAI models would error, so
+    # gate on the provider prefix. A spec can still override via model_settings.
+    if isinstance(model, str) and model.startswith("anthropic:"):
+        ms.setdefault("anthropic_cache_instructions", True)
+        ms.setdefault("anthropic_cache_tool_definitions", True)
+        ms.setdefault("anthropic_cache", True)
     kwargs["model_settings"] = ms
     retries = spec.get("retries")
     if isinstance(retries, int):

--- a/api/src/pricing.rs
+++ b/api/src/pricing.rs
@@ -82,9 +82,23 @@ pub fn estimate_run_cost(
     cache_write: i32,
 ) -> Option<f64> {
     if let Some(rest) = model.strip_prefix("anthropic:") {
-        cost_in_table(rest, tokens_input, tokens_output, cache_read, cache_write, &ANTHROPIC_RATES)
+        cost_in_table(
+            rest,
+            tokens_input,
+            tokens_output,
+            cache_read,
+            cache_write,
+            &ANTHROPIC_RATES,
+        )
     } else if let Some(rest) = model.strip_prefix("openai:") {
-        cost_in_table(rest, tokens_input, tokens_output, cache_read, cache_write, &OPENAI_RATES)
+        cost_in_table(
+            rest,
+            tokens_input,
+            tokens_output,
+            cache_read,
+            cache_write,
+            &OPENAI_RATES,
+        )
     } else {
         None
     }
@@ -113,31 +127,32 @@ mod tests {
 
     #[test]
     fn anthropic_sonnet() {
-        let c =
-            estimate_run_cost("anthropic:claude-sonnet-4-6", 1_000_000, 1_000_000, 0, 0).expect("priced");
+        let c = estimate_run_cost("anthropic:claude-sonnet-4-6", 1_000_000, 1_000_000, 0, 0)
+            .expect("priced");
         // 3 + 15 = 18 USD for 1M in + 1M out
         assert!((c - 18.0).abs() < 1e-9, "expected ~18.0, got {c}");
     }
 
     #[test]
     fn anthropic_opus() {
-        let c =
-            estimate_run_cost("anthropic:claude-opus-4-8", 1_000_000, 1_000_000, 0, 0).expect("priced");
+        let c = estimate_run_cost("anthropic:claude-opus-4-8", 1_000_000, 1_000_000, 0, 0)
+            .expect("priced");
         // 5 + 25 = 30 USD for 1M in + 1M out
         assert!((c - 30.0).abs() < 1e-9, "expected ~30.0, got {c}");
     }
 
     #[test]
     fn anthropic_fable_5() {
-        let c =
-            estimate_run_cost("anthropic:claude-fable-5", 1_000_000, 1_000_000, 0, 0).expect("priced");
+        let c = estimate_run_cost("anthropic:claude-fable-5", 1_000_000, 1_000_000, 0, 0)
+            .expect("priced");
         // 10 + 50 = 60 USD for 1M in + 1M out
         assert!((c - 60.0).abs() < 1e-9, "expected ~60.0, got {c}");
     }
 
     #[test]
     fn openai_gpt_4o_mini() {
-        let c = estimate_run_cost("openai:gpt-4o-mini", 1_000_000, 1_000_000, 0, 0).expect("priced");
+        let c =
+            estimate_run_cost("openai:gpt-4o-mini", 1_000_000, 1_000_000, 0, 0).expect("priced");
         // 0.15 + 0.6 = 0.75
         assert!((c - 0.75).abs() < 1e-9, "expected ~0.75, got {c}");
     }
@@ -169,7 +184,10 @@ mod tests {
             1_000_000,
         )
         .expect("priced");
-        assert!((c - (5.0 + 0.5 + 6.25)).abs() < 1e-9, "expected ~11.75, got {c}");
+        assert!(
+            (c - (5.0 + 0.5 + 6.25)).abs() < 1e-9,
+            "expected ~11.75, got {c}"
+        );
     }
 
     #[test]

--- a/api/src/pricing.rs
+++ b/api/src/pricing.rs
@@ -60,36 +60,50 @@ fn rate(pattern: &str, input: f64, output: f64) -> ModelRate {
     }
 }
 
+// Prompt-cache multipliers on the base INPUT rate. Anthropic bills cache
+// writes (creation) at 1.25x and cache reads at 0.1x of input. `tokens_input`
+// is the uncached input (full rate); cache halves are counted separately and
+// never overlap it. OpenAI/others that don't report cache tokens pass 0 here,
+// so the multipliers are a no-op for them.
+const CACHE_READ_MULTIPLIER: f64 = 0.1;
+const CACHE_WRITE_MULTIPLIER: f64 = 1.25;
+
 /// Returns USD cost for a run, or None if the model isn't in our
 /// pricing tables (callers persist None which renders as "—" in
 /// the UI). Model strings look like `provider:model-name` —
 /// matching the same shape the TS-side helper consumes.
-pub fn estimate_run_cost(model: &str, tokens_input: i32, tokens_output: i32) -> Option<f64> {
-    let (prefix, rates): (&str, &Lazy<Vec<ModelRate>>) =
-        if let Some(rest) = model.strip_prefix("anthropic:") {
-            return cost_in_table(rest, tokens_input, tokens_output, &ANTHROPIC_RATES);
-        } else if let Some(rest) = model.strip_prefix("openai:") {
-            return cost_in_table(rest, tokens_input, tokens_output, &OPENAI_RATES);
-        } else {
-            ("", &ANTHROPIC_RATES)
-        };
-    // Defensive default in case the early returns above don't catch
-    // — `prefix` left unused signals to the reader the function is
-    // shape-driven, not fall-through.
-    let _ = (prefix, rates);
-    None
+/// `cache_read`/`cache_write` are the Anthropic prompt-cache token counts
+/// (0 when caching is off).
+pub fn estimate_run_cost(
+    model: &str,
+    tokens_input: i32,
+    tokens_output: i32,
+    cache_read: i32,
+    cache_write: i32,
+) -> Option<f64> {
+    if let Some(rest) = model.strip_prefix("anthropic:") {
+        cost_in_table(rest, tokens_input, tokens_output, cache_read, cache_write, &ANTHROPIC_RATES)
+    } else if let Some(rest) = model.strip_prefix("openai:") {
+        cost_in_table(rest, tokens_input, tokens_output, cache_read, cache_write, &OPENAI_RATES)
+    } else {
+        None
+    }
 }
 
 fn cost_in_table(
     model_name: &str,
     tokens_input: i32,
     tokens_output: i32,
+    cache_read: i32,
+    cache_write: i32,
     table: &Lazy<Vec<ModelRate>>,
 ) -> Option<f64> {
     let entry = table.iter().find(|r| r.pattern.is_match(model_name))?;
-    let cost = (tokens_input as f64 * entry.input_per_million
-        + tokens_output as f64 * entry.output_per_million)
-        / 1_000_000.0;
+    let input_cost = (tokens_input as f64
+        + cache_read as f64 * CACHE_READ_MULTIPLIER
+        + cache_write as f64 * CACHE_WRITE_MULTIPLIER)
+        * entry.input_per_million;
+    let cost = (input_cost + tokens_output as f64 * entry.output_per_million) / 1_000_000.0;
     Some(cost)
 }
 
@@ -100,7 +114,7 @@ mod tests {
     #[test]
     fn anthropic_sonnet() {
         let c =
-            estimate_run_cost("anthropic:claude-sonnet-4-6", 1_000_000, 1_000_000).expect("priced");
+            estimate_run_cost("anthropic:claude-sonnet-4-6", 1_000_000, 1_000_000, 0, 0).expect("priced");
         // 3 + 15 = 18 USD for 1M in + 1M out
         assert!((c - 18.0).abs() < 1e-9, "expected ~18.0, got {c}");
     }
@@ -108,7 +122,7 @@ mod tests {
     #[test]
     fn anthropic_opus() {
         let c =
-            estimate_run_cost("anthropic:claude-opus-4-8", 1_000_000, 1_000_000).expect("priced");
+            estimate_run_cost("anthropic:claude-opus-4-8", 1_000_000, 1_000_000, 0, 0).expect("priced");
         // 5 + 25 = 30 USD for 1M in + 1M out
         assert!((c - 30.0).abs() < 1e-9, "expected ~30.0, got {c}");
     }
@@ -116,14 +130,14 @@ mod tests {
     #[test]
     fn anthropic_fable_5() {
         let c =
-            estimate_run_cost("anthropic:claude-fable-5", 1_000_000, 1_000_000).expect("priced");
+            estimate_run_cost("anthropic:claude-fable-5", 1_000_000, 1_000_000, 0, 0).expect("priced");
         // 10 + 50 = 60 USD for 1M in + 1M out
         assert!((c - 60.0).abs() < 1e-9, "expected ~60.0, got {c}");
     }
 
     #[test]
     fn openai_gpt_4o_mini() {
-        let c = estimate_run_cost("openai:gpt-4o-mini", 1_000_000, 1_000_000).expect("priced");
+        let c = estimate_run_cost("openai:gpt-4o-mini", 1_000_000, 1_000_000, 0, 0).expect("priced");
         // 0.15 + 0.6 = 0.75
         assert!((c - 0.75).abs() < 1e-9, "expected ~0.75, got {c}");
     }
@@ -131,25 +145,40 @@ mod tests {
     #[test]
     fn openai_gpt_5_5_not_swallowed_by_catch_all() {
         // gpt-5.5 must hit its own $5/$30 rate, not the bare ^gpt-5 ($1.25/$10).
-        let c = estimate_run_cost("openai:gpt-5.5", 1_000_000, 1_000_000).expect("priced");
+        let c = estimate_run_cost("openai:gpt-5.5", 1_000_000, 1_000_000, 0, 0).expect("priced");
         // 5 + 30 = 35
         assert!((c - 35.0).abs() < 1e-9, "expected ~35.0, got {c}");
     }
 
     #[test]
     fn openai_gpt_5_base() {
-        let c = estimate_run_cost("openai:gpt-5", 1_000_000, 1_000_000).expect("priced");
+        let c = estimate_run_cost("openai:gpt-5", 1_000_000, 1_000_000, 0, 0).expect("priced");
         // 1.25 + 10 = 11.25
         assert!((c - 11.25).abs() < 1e-9, "expected ~11.25, got {c}");
     }
 
     #[test]
+    fn anthropic_cache_tokens_priced_at_read_write_multipliers() {
+        // Opus input $5/MTok. 1M cache_read @ 0.1x = $0.50; 1M cache_write @
+        // 1.25x = $6.25; 1M uncached input @ 1x = $5; no output.
+        let c = estimate_run_cost(
+            "anthropic:claude-opus-4-8",
+            1_000_000,
+            0,
+            1_000_000,
+            1_000_000,
+        )
+        .expect("priced");
+        assert!((c - (5.0 + 0.5 + 6.25)).abs() < 1e-9, "expected ~11.75, got {c}");
+    }
+
+    #[test]
     fn unknown_model_returns_none() {
-        assert!(estimate_run_cost("custom:no-such-model", 100, 100).is_none());
+        assert!(estimate_run_cost("custom:no-such-model", 100, 100, 0, 0).is_none());
     }
 
     #[test]
     fn unknown_provider_returns_none() {
-        assert!(estimate_run_cost("cohere:command", 100, 100).is_none());
+        assert!(estimate_run_cost("cohere:command", 100, 100, 0, 0).is_none());
     }
 }

--- a/api/src/runs/pydantic.rs
+++ b/api/src/runs/pydantic.rs
@@ -224,6 +224,13 @@ pub struct PydanticUsage {
     pub response_tokens: Option<i32>,
     #[serde(default)]
     pub total_tokens: Option<i32>,
+    /// Anthropic prompt-cache counters. `cache_write_tokens` (cache creation)
+    /// and `cache_read_tokens` are separate from `input_tokens` (uncached) and
+    /// priced differently — the cost estimate weights them ~1.25x / ~0.1x.
+    #[serde(default)]
+    pub cache_read_tokens: Option<i32>,
+    #[serde(default)]
+    pub cache_write_tokens: Option<i32>,
 }
 
 impl PydanticUsage {

--- a/api/src/runs/runner.rs
+++ b/api/src/runs/runner.rs
@@ -80,6 +80,10 @@ struct RunOutcome {
 struct Usage {
     input_tokens: i32,
     output_tokens: i32,
+    /// Anthropic prompt-cache halves (0 when caching is off / not Anthropic).
+    /// Priced separately from input_tokens in the cost estimate.
+    cache_read_tokens: i32,
+    cache_write_tokens: i32,
 }
 
 /// Drive a single run from queued through to terminal state. Always
@@ -483,14 +487,14 @@ async fn run_pydantic(
     .await;
 
     let outcome = result.map(|r| {
-        let usage = r
-            .usage
-            .as_ref()
-            .and_then(pydantic::PydanticUsage::input_output)
-            .map(|(input, output)| Usage {
+        let usage = r.usage.as_ref().and_then(|u| {
+            u.input_output().map(|(input, output)| Usage {
                 input_tokens: input,
                 output_tokens: output,
-            });
+                cache_read_tokens: u.cache_read_tokens.unwrap_or(0),
+                cache_write_tokens: u.cache_write_tokens.unwrap_or(0),
+            })
+        });
         RunOutcome {
             output: render_output(&ctx.user_message, &r.output),
             usage,
@@ -575,9 +579,15 @@ async fn mark_succeeded(
     // already in hand, so the runs-list UI doesn't have to map
     // model→rate on every render. None when usage is missing
     // (cargo-ai) or the model isn't in our pricing table.
-    let cost_usd: Option<f64> = match (tokens_in, tokens_out) {
-        (Some(i), Some(o)) => crate::pricing::estimate_run_cost(model, i, o),
-        _ => None,
+    let cost_usd: Option<f64> = match usage {
+        Some(u) => crate::pricing::estimate_run_cost(
+            model,
+            u.input_tokens,
+            u.output_tokens,
+            u.cache_read_tokens,
+            u.cache_write_tokens,
+        ),
+        None => None,
     };
     sqlx::query(
         "UPDATE run SET status = 'succeeded', output = $1, completed_at = $2, \

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-steps.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-steps.tsx
@@ -3,6 +3,7 @@ import { Fragment } from "react";
 import { Badge } from "@/components/ui/badge";
 import {
   abbreviateTokens,
+  estimateInputCost,
   estimateRunCost,
   estimateTokenCost,
   formatPenny,
@@ -44,21 +45,35 @@ export function RunSteps({
     callsByStep.set(c.stepOrdinal, arr);
   }
 
-  // Run totals for the footer.
-  let totalIn = 0;
+  // Run totals for the footer. Track the cache halves separately from uncached
+  // input: the "in" token count shows the full context processed (input + cache
+  // read + write), but the cost weights the cache portions (read 0.1x, write
+  // 1.25x).
+  let totalInUncached = 0;
+  let totalCacheRead = 0;
+  let totalCacheWrite = 0;
   let totalOut = 0;
   let hasTokens = false;
   for (const s of steps) {
     if (s.inputTokens !== null) {
-      totalIn += s.inputTokens;
+      totalInUncached += s.inputTokens;
       hasTokens = true;
     }
+    if (s.cacheReadTokens !== null) totalCacheRead += s.cacheReadTokens;
+    if (s.cacheWriteTokens !== null) totalCacheWrite += s.cacheWriteTokens;
     if (s.outputTokens !== null) {
       totalOut += s.outputTokens;
       hasTokens = true;
     }
   }
-  const combinedCost = estimateRunCost(model, totalIn, totalOut);
+  const totalInTokens = totalInUncached + totalCacheRead + totalCacheWrite;
+  const combinedCost = estimateRunCost(
+    model,
+    totalInUncached,
+    totalOut,
+    totalCacheRead,
+    totalCacheWrite,
+  );
 
   return (
     <div className="bg-surface border-border flex flex-col overflow-hidden rounded-lg border">
@@ -111,7 +126,7 @@ export function RunSteps({
               })}
             </div>
             <span className="text-foreground-muted w-28 shrink-0 whitespace-nowrap text-right text-xs leading-6 tabular-nums">
-              {dirStr(model, s.inputTokens, "input")}{" "}
+              {inStr(model, s.inputTokens, s.cacheReadTokens, s.cacheWriteTokens)}{" "}
               <span className="text-foreground-weak">in</span>
             </span>
             <span className="text-foreground-muted w-28 shrink-0 whitespace-nowrap text-right text-xs leading-6 tabular-nums">
@@ -127,7 +142,7 @@ export function RunSteps({
           {/* Broken-down In/Out totals — small, columns aligned with the rows. */}
           <div className="flex items-baseline gap-x-4">
             <span className="text-foreground-weak w-28 shrink-0 whitespace-nowrap text-right text-xs tabular-nums">
-              {dirStr(model, totalIn, "input")}{" "}
+              {inStr(model, totalInUncached, totalCacheRead, totalCacheWrite)}{" "}
               <span className="text-foreground-muted">in</span>
             </span>
             <span className="text-foreground-weak w-28 shrink-0 whitespace-nowrap text-right text-xs tabular-nums">
@@ -137,7 +152,7 @@ export function RunSteps({
           </div>
           {/* Combined total — the headline number, larger. */}
           <div className="text-foreground whitespace-nowrap text-base font-semibold tabular-nums">
-            {abbreviateTokens(totalIn + totalOut)}
+            {abbreviateTokens(totalInTokens + totalOut)}
             {combinedCost !== null && ` ~${formatPenny(combinedCost)}`} total
           </div>
         </div>
@@ -154,5 +169,22 @@ function dirStr(
 ): string {
   if (tokens === null) return "··";
   const cost = estimateTokenCost(model, tokens, direction);
+  return `${abbreviateTokens(tokens)}${cost !== null ? ` ~${formatPenny(cost)}` : ""}`;
+}
+
+// Cache-aware "in" cell. Tokens shown = the full context processed (uncached
+// input + cache read + write); the cost weights the cache halves (read 0.1x,
+// write 1.25x). "··" until tokens land.
+function inStr(
+  model: string,
+  inputTokens: number | null,
+  cacheReadTokens: number | null,
+  cacheWriteTokens: number | null,
+): string {
+  if (inputTokens === null) return "··";
+  const cacheRead = cacheReadTokens ?? 0;
+  const cacheWrite = cacheWriteTokens ?? 0;
+  const tokens = inputTokens + cacheRead + cacheWrite;
+  const cost = estimateInputCost(model, inputTokens, cacheRead, cacheWrite);
   return `${abbreviateTokens(tokens)}${cost !== null ? ` ~${formatPenny(cost)}` : ""}`;
 }

--- a/web/src/lib/pricing.ts
+++ b/web/src/lib/pricing.ts
@@ -66,14 +66,28 @@ function lookupRate(model: string): Rate | null {
   return null;
 }
 
+// Anthropic prompt-cache multipliers on the base INPUT rate: cache writes
+// (creation) bill at 1.25x, cache reads at 0.1x. `tokensInput` is the uncached
+// input (full rate); the cache halves are separate, non-overlapping counts.
+// Keep in lockstep with api/src/pricing.rs.
+const CACHE_READ_MULTIPLIER = 0.1;
+const CACHE_WRITE_MULTIPLIER = 1.25;
+
 export function estimateRunCost(
   model: string,
   tokensInput: number,
   tokensOutput: number,
+  cacheRead = 0,
+  cacheWrite = 0,
 ): number | null {
   const rate = lookupRate(model);
   if (!rate) return null;
-  return (tokensInput * rate.input + tokensOutput * rate.output) / 1_000_000;
+  const inputCost =
+    (tokensInput +
+      cacheRead * CACHE_READ_MULTIPLIER +
+      cacheWrite * CACHE_WRITE_MULTIPLIER) *
+    rate.input;
+  return (inputCost + tokensOutput * rate.output) / 1_000_000;
 }
 
 /** Cost of just the input or just the output tokens, for per-direction display. */
@@ -85,6 +99,25 @@ export function estimateTokenCost(
   const rate = lookupRate(model);
   if (!rate) return null;
   return (tokens * rate[direction]) / 1_000_000;
+}
+
+/** Cache-aware "input" cost for display: uncached input at full rate plus the
+ *  cache read/write halves at their multipliers. */
+export function estimateInputCost(
+  model: string,
+  uncachedInput: number,
+  cacheRead: number,
+  cacheWrite: number,
+): number | null {
+  const rate = lookupRate(model);
+  if (!rate) return null;
+  return (
+    ((uncachedInput +
+      cacheRead * CACHE_READ_MULTIPLIER +
+      cacheWrite * CACHE_WRITE_MULTIPLIER) *
+      rate.input) /
+    1_000_000
+  );
 }
 
 export function formatTokens(n: number): string {


### PR DESCRIPTION
## Context

You flagged that a run's per-step input kept growing and we "charge ourself for the whole amount each step." The **counting was correct** — in an agentic loop each step is a separate API call that re-sends the full conversation, and Anthropic bills the full input every time (361k total × $5/MTok Opus = $1.81, exactly the sum of the per-step inputs). The real issue: **no prompt caching**, so the big static prefix (system prompt + MCP/Composio tool schemas, ~30k tokens) was re-billed at full rate on all ~11 steps.

## Changes

**1. Enable Anthropic prompt caching** (`run_pydantic.py`). `build_agent` now sets, for `anthropic:` models:
- `anthropic_cache_instructions` — cache the system prompt
- `anthropic_cache_tool_definitions` — cache the tool schemas (the big one)
- `anthropic_cache` — auto-rolling breakpoint that follows the growing history (pydantic-ai trims to Anthropic's 4-slot limit)

Default 5m TTL fits a run's burst of steps. A spec can still override via `model_settings`. After the first step the repeated prefix bills at the **cache-read rate (~0.1×)**, with a one-time **write surcharge (~1.25×)** — roughly a **3–5× cost cut** on tool-heavy runs.

**2. Make cost accounting cache-aware.** The runner already captured per-step `cache_read`/`cache_write` tokens; this threads them through the run-level usage sentinel into `estimate_run_cost` (Rust) and `estimateRunCost` (TS), pricing cache reads at 0.1× and writes at 1.25× of the input rate (kept in lockstep). The run-steps UI's **"in" token count now shows the full context processed** (uncached input + cache read + write) while **"$ in" reflects the cache-weighted cost** — so a cached run shows the same ~35k "in" but a much smaller dollar figure. `runs-list` reads the stored cache-aware `cost_usd`, so no change needed there.

## Verification
- `cargo test pricing::` — 9 pass, incl. a new test asserting cache read/write multipliers.
- `tsc`, eslint, `next build` clean; `python -m py_compile` clean.
- ⚠️ The caching itself needs a **live run** to confirm — run a tool-heavy agent and check that `cache_read` tokens appear and the cost drops vs. before. (Can't exercise the LLM loop locally.)

## Note
This only affects Anthropic models (gated on the `anthropic:` prefix); OpenAI runs pass 0 cache tokens, so pricing is unchanged for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)