### PR TITLE
Add send_slack_message tool/endpoint (real DMs via workspace Slack apps)

### DIFF
--- a/web/src/app/api/v1/slack-messages/route.ts
+++ b/web/src/app/api/v1/slack-messages/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { authorizeApiRequest } from "@/lib/api-auth";
+import { sendSlackMessageFor } from "@/lib/api-v1/actions";
+import { apiError, authErrorResponse } from "@/lib/api-v1/http";
+
+// POST /api/v1/slack-messages — send a Slack message from a workspace Slack app
+// (operator). DM a person by `toEmail` or post to a `channel`. Mirrors the MCP
+// `send_slack_message` tool; both share sendSlackMessageFor.
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await authorizeApiRequest(request, "operator");
+  if (!auth.ok) return authErrorResponse(auth);
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, "request body must be JSON");
+  }
+  if (typeof body.text !== "string") {
+    return apiError(400, "`text` (string) is required");
+  }
+
+  const result = await sendSlackMessageFor(auth, {
+    text: body.text,
+    toEmail: typeof body.toEmail === "string" ? body.toEmail : undefined,
+    channel: typeof body.channel === "string" ? body.channel : undefined,
+    slackApp: typeof body.slackApp === "string" ? body.slackApp : undefined,
+    threadTs: typeof body.threadTs === "string" ? body.threadTs : undefined,
+  });
+  if (!result.ok) return apiError(result.status, result.error);
+
+  return NextResponse.json({ channel: result.channel, ts: result.ts });
+}

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -13,9 +13,12 @@ import {
   createSlackApp,
   deleteSlackApp,
   getSlackApp,
+  getSlackAppSecrets,
+  listSlackApps,
   updateSlackApp,
   type SlackApp,
 } from "@/lib/slack-apps";
+import { lookupUserByEmail, postMessage } from "@/lib/slack-api";
 import {
   buildChatEditPrompt,
   buildCreateAgentPrompt,
@@ -540,4 +543,109 @@ export async function deleteSlackAppFor(
   if (!existing) return { ok: false, status: 404, error: "slack app not found" };
   await deleteSlackApp(ctx.workspace.id, id);
   return { ok: true };
+}
+
+export type SendSlackMessageApiInput = {
+  text: string;
+  /** DM target: a person's email (resolved to a real DM with a notification). */
+  toEmail?: string;
+  /** Or post to a channel/user by Slack id (e.g. "C0123", "U0123"). */
+  channel?: string;
+  /** Which Slack app to send from (by name). Optional when the workspace has
+   *  exactly one installed app. */
+  slackApp?: string;
+  /** Reply in a thread instead of a top-level message. */
+  threadTs?: string;
+};
+
+/**
+ * Send a Slack message from one of the workspace's TAS-managed Slack apps —
+ * the way to actually notify a person. (Composio's Slack "DM" posts to the
+ * bot's own connected account, which the human never sees.) DMs by email or
+ * posts to a channel. Returns the sent message's channel + ts.
+ */
+export async function sendSlackMessageFor(
+  ctx: ApiCtx,
+  input: SendSlackMessageApiInput,
+): Promise<
+  { ok: true; channel: string; ts: string | null } | ActionFailure
+> {
+  const text = input.text?.trim();
+  if (!text) return { ok: false, status: 400, error: "`text` is required" };
+  const hasEmail = !!input.toEmail?.trim();
+  const hasChannel = !!input.channel?.trim();
+  if (hasEmail === hasChannel) {
+    return {
+      ok: false,
+      status: 400,
+      error: "provide exactly one of `toEmail` or `channel`",
+    };
+  }
+
+  // Resolve which Slack app to send from.
+  const installed = (await listSlackApps(ctx.workspace.id)).filter(
+    (a) => a.status === "installed" && a.hasBotToken,
+  );
+  if (installed.length === 0) {
+    return {
+      ok: false,
+      status: 409,
+      error:
+        "no installed Slack app in this workspace — finish the OAuth install under Settings → Slack apps first",
+    };
+  }
+  let app: SlackApp;
+  const wanted = input.slackApp?.trim();
+  if (wanted) {
+    const match = installed.find(
+      (a) => a.name.toLowerCase() === wanted.toLowerCase(),
+    );
+    if (!match) {
+      return { ok: false, status: 404, error: `no installed Slack app named "${wanted}"` };
+    }
+    app = match;
+  } else if (installed.length === 1) {
+    app = installed[0];
+  } else {
+    return {
+      ok: false,
+      status: 400,
+      error: `multiple Slack apps installed — pass \`slackApp\` (one of: ${installed
+        .map((a) => a.name)
+        .join(", ")})`,
+    };
+  }
+
+  const secrets = await getSlackAppSecrets(app.id);
+  if (!secrets?.botToken) {
+    return { ok: false, status: 409, error: `Slack app "${app.name}" has no bot token` };
+  }
+  const token = secrets.botToken;
+
+  // Resolve the destination channel: a channel id as-is, or an email → the
+  // person's Slack user id (chat.postMessage to a user id opens a DM).
+  let channel: string;
+  if (hasChannel) {
+    channel = input.channel!.trim();
+  } else {
+    const userId = await lookupUserByEmail(token, input.toEmail!.trim());
+    if (!userId) {
+      return {
+        ok: false,
+        status: 404,
+        error: `no Slack user found for ${input.toEmail!.trim()} in this workspace`,
+      };
+    }
+    channel = userId;
+  }
+
+  const res = await postMessage(token, {
+    channel,
+    text,
+    ...(input.threadTs ? { thread_ts: input.threadTs } : {}),
+  });
+  if (!res.ok) {
+    return { ok: false, status: 502, error: `Slack rejected the message: ${res.error}` };
+  }
+  return { ok: true, channel, ts: res.ts ?? null };
 }

--- a/web/src/lib/mcp/server.test.ts
+++ b/web/src/lib/mcp/server.test.ts
@@ -22,13 +22,19 @@ vi.mock("@/lib/api-v1/actions", () => ({
   createSlackAppFor: vi.fn(),
   updateSlackAppFor: vi.fn(),
   deleteSlackAppFor: vi.fn(),
+  sendSlackMessageFor: vi.fn(),
 }));
 
 import { buildMcpServer, type McpContext } from "./server";
 import { getAgentByName, listAgents } from "@/lib/workspace-agents";
 import { getRun } from "@/lib/runs-api";
 import { listRunsForWorkspace } from "@/lib/runs-db";
-import { createSlackAppFor, triggerRun, validateSpec } from "@/lib/api-v1/actions";
+import {
+  createSlackAppFor,
+  sendSlackMessageFor,
+  triggerRun,
+  validateSpec,
+} from "@/lib/api-v1/actions";
 import type { WorkspaceRole } from "@/lib/rbac";
 
 const mockListAgents = vi.mocked(listAgents);
@@ -38,6 +44,7 @@ const mockListRuns = vi.mocked(listRunsForWorkspace);
 const mockTriggerRun = vi.mocked(triggerRun);
 const mockValidate = vi.mocked(validateSpec);
 const mockCreateSlackApp = vi.mocked(createSlackAppFor);
+const mockSendSlackMessage = vi.mocked(sendSlackMessageFor);
 
 function makeCtx(role: WorkspaceRole = "operator"): McpContext {
   return {
@@ -100,6 +107,7 @@ describe("buildMcpServer", () => {
       "list_slack_apps",
       "list_tools",
       "request_agent_change",
+      "send_slack_message",
       "trigger_run",
       "update_slack_app",
       "validate_agent_spec",
@@ -277,6 +285,38 @@ describe("buildMcpServer", () => {
     })) as { isError?: boolean; content: { text: string }[] };
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toBe("missing connection");
+  });
+
+  it("send_slack_message is denied for a viewer (operator-only) and never calls the action", async () => {
+    const client = await connectedClientFor(makeCtx("viewer"));
+    const res = (await client.callTool({
+      name: "send_slack_message",
+      arguments: { text: "hi", toEmail: "a@b.com" },
+    })) as { isError?: boolean; content: { text: string }[] };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/operator/i);
+    expect(mockSendSlackMessage).not.toHaveBeenCalled();
+  });
+
+  it("send_slack_message as operator delegates and returns the result", async () => {
+    mockSendSlackMessage.mockResolvedValue({
+      ok: true,
+      channel: "U123",
+      ts: "1700000000.000100",
+    });
+    const client = await connectedClientFor(makeCtx("operator"));
+    const res = (await client.callTool({
+      name: "send_slack_message",
+      arguments: { text: "ping", toEmail: "a@b.com", slackApp: "Helper" },
+    })) as { content: { text: string }[] };
+    expect(mockSendSlackMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "operator" }),
+      expect.objectContaining({ text: "ping", toEmail: "a@b.com", slackApp: "Helper" }),
+    );
+    expect(JSON.parse(res.content[0].text)).toMatchObject({
+      sent: true,
+      channel: "U123",
+    });
   });
 
   it("create_slack_app is denied for an operator (admin-only) and never calls the action", async () => {

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -9,6 +9,7 @@ import {
   createSlackAppFor,
   deleteSlackAppFor,
   requestAgentChange,
+  sendSlackMessageFor,
   triggerRun,
   updateSlackAppFor,
   validateSpec,
@@ -321,6 +322,46 @@ export function buildMcpServer(ctx: McpContext): McpServer {
       const res = await requestAgentChange(ctx, { description, agent, name, framework });
       if (!res.ok) return errorResult(res.error);
       return json(res.result);
+    },
+  );
+
+  server.registerTool(
+    "send_slack_message",
+    {
+      description:
+        "Send a Slack message from one of this workspace's Slack apps — the way " +
+        "to actually notify a person. DM someone by `toEmail` (they get a real " +
+        "DM + notification), or post to a channel by `channel` (Slack id). This " +
+        "is NOT the Composio Slack tool, whose 'DM' posts to the bot's own " +
+        "account where nobody sees it. Provide exactly one of toEmail / channel.",
+      inputSchema: {
+        text: z.string().describe("The message text (Slack mrkdwn)."),
+        toEmail: z
+          .string()
+          .optional()
+          .describe("DM this person by email (resolved to their Slack user)."),
+        channel: z
+          .string()
+          .optional()
+          .describe("Or post to this Slack channel/user id (e.g. C0123, U0123)."),
+        slackApp: z
+          .string()
+          .optional()
+          .describe("Which Slack app to send from (by name); optional if one."),
+        threadTs: z.string().optional().describe("Reply under this thread ts."),
+      },
+    },
+    async ({ text, toEmail, channel, slackApp, threadTs }) => {
+      if (!isOperator) return operatorOnly();
+      const res = await sendSlackMessageFor(ctx, {
+        text,
+        toEmail,
+        channel,
+        slackApp,
+        threadTs,
+      });
+      if (!res.ok) return errorResult(res.error);
+      return json({ sent: true, channel: res.channel, ts: res.ts });
     },
   );
 

--- a/web/src/lib/slack-api.ts
+++ b/web/src/lib/slack-api.ts
@@ -115,3 +115,18 @@ export async function getUserEmail(
   if (!res.ok) return null;
   return res.user?.profile?.email ?? null;
 }
+
+/** Resolve an email to its Slack user id (so we can DM them). Returns null
+ *  when no workspace member has that email. Needs the `users:read.email`
+ *  scope — same one getUserEmail relies on. */
+export async function lookupUserByEmail(
+  token: string,
+  email: string,
+): Promise<string | null> {
+  const res = await call<{ user?: { id?: string } }>(
+    "users.lookupByEmail",
+    token,
+    { email },
+  );
+  return res.ok ? (res.user?.id ?? null) : null;
+}


### PR DESCRIPTION
## Why

Agents could only reach Slack through Composio, whose Slack "DM" posts to the **bot's own connected account** — the human you wanted to notify never sees it, and there's no notification. TAS already runs first-class **Slack apps** with bot tokens that can message real people, so let agents use those.

## What

A `send_slack_message` action exposed on **both** surfaces (sharing one implementation in `api-v1/actions.ts`):
- **MCP tool** `send_slack_message` on the `/mcp` server (the `tembo-agent-studio` provider), **operator**-gated.
- **REST** `POST /api/v1/slack-messages`, operator-gated.

Behavior:
- **DM by `toEmail`** — resolves the email to a Slack user via `users.lookupByEmail`, then `chat.postMessage` to that user (a real DM with a notification). Or **post to a `channel`** by Slack id. Exactly one of the two.
- **Picks the Slack app** by `slackApp` name; if omitted and the workspace has exactly one *installed* app, uses it; if several, asks for the name.
- Optional `threadTs`. Returns the sent `channel` + `ts`.
- Added `lookupUserByEmail()` to the minimal Slack client (uses the same `users:read.email` scope `getUserEmail` already relies on).

So an agent connected to the tembo-agent-studio MCP can actually ping a person — e.g. `send_slack_message(toEmail: "ry@…", text: "3 tasks need triage")`.

## Verification
- `tsc`, eslint, `next build` clean (`/api/v1/slack-messages` registers).
- `mcp/server` tests: **15 pass**, incl. the new tool in the tool-list assertion + viewer-denied / operator-delegates cases.

## Note
Needs at least one **installed** Slack app in the workspace (Settings → Slack apps). Sending uses that app's bot token; nothing per-user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)