### PR TITLE
Hide defunct/renamed native providers from the create-agent prompt

### DIFF
--- a/web/src/lib/native-slots.ts
+++ b/web/src/lib/native-slots.ts
@@ -2,12 +2,19 @@ import "server-only";
 
 import type { AvailableConnectionSlots } from "@/lib/cap-api";
 import { listNativeConnectionsForUser } from "@/lib/connections";
+import { getMcpProvider } from "@/lib/mcp-providers";
 
 // Build the native-MCP slot map (provider slug → authorized slot names) for the
 // create-agent prompt, from the user's active native connections. Native
 // connections live in a separate table from Composio and must be declared with
 // `source: native-mcp`, so the prompt renders them as their own block (and
 // points CAP at the per-provider tool reference for the exact slugs).
+//
+// Only connections whose provider is still in the catalog are surfaced. A
+// provider slug that was renamed or removed (e.g. the old `tembo` self-key
+// connection, now `tembo-agent-studio`) leaves an orphaned row that the
+// Connections UI no longer renders — without this guard it would still leak
+// into the prompt and point CAP at a defunct /for-agents page.
 export async function buildNativeSlots(
   workspaceId: string,
   userId: string,
@@ -16,6 +23,7 @@ export async function buildNativeSlots(
   const slots: AvailableConnectionSlots = {};
   for (const c of connections) {
     if (c.status !== "active") continue;
+    if (!getMcpProvider(c.type)) continue; // defunct/renamed provider — hide it
     (slots[c.type] ??= []).push(c.name);
   }
   return slots;


### PR DESCRIPTION
## Problem

CAP was being handed a **defunct `tembo` native connection**. The `tembo` → `tembo-agent-studio` slug rename (#119) was code-only, so old `workspace_connection` rows with `type='tembo'` linger. The Connections UI doesn't render them (no matching catalog provider), but `buildNativeSlots` still listed them — so the create/edit prompt told CAP to declare a `tembo` slot and fetch `…/for-agents/tembo.md`, which 404s with "Unknown provider."

## Fix

`buildNativeSlots` now skips any active native connection whose provider slug is no longer in the catalog (`getMcpProvider(c.type) === null`). Renamed/removed providers' orphaned rows stay out of CAP's prompt; the live `tembo-agent-studio` connection is unaffected. General guard, not a one-off for `tembo`.

`tsc` / eslint clean.

## Loose end (separate)
The orphaned `tembo` row still exists in the DB and, since it's a self-key connection, its minted `tas_` key is still valid — and it can't be disconnected from the UI (the page doesn't render non-catalog providers). Worth a one-time cleanup (delete the row + revoke the key), but this PR stops the CAP exposure, which was the ask. Happy to do that cleanup next if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)