### PR TITLE
Show prompt-cache read/write tokens in the run-steps footer

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-steps.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-steps.tsx
@@ -150,6 +150,17 @@ export function RunSteps({
               <span className="text-foreground-muted">out</span>
             </span>
           </div>
+          {/* Prompt-cache breakdown — shows caching is working and by how much.
+              `read` tokens billed at ~0.1x, `write` (one-time) at ~1.25x; the
+              `in` cost above already reflects those rates. */}
+          {(totalCacheRead > 0 || totalCacheWrite > 0) && (
+            <div className="text-foreground-muted whitespace-nowrap text-xs tabular-nums">
+              prompt cache: {abbreviateTokens(totalCacheRead)} read
+              {totalCacheWrite > 0
+                ? ` · ${abbreviateTokens(totalCacheWrite)} write`
+                : ""}
+            </div>
+          )}
           {/* Combined total — the headline number, larger. */}
           <div className="text-foreground whitespace-nowrap text-base font-semibold tabular-nums">
             {abbreviateTokens(totalInTokens + totalOut)}


### PR DESCRIPTION
## Why

You ran a tool-heavy agent and said "I don't see anything about cached tokens." Caching **was** working — the totals showed **600k in for ~$1.86**, where full Opus rate ($5/MTok) on 600k would be **$3.00**, so the cost was already cache-weighted (~38% lower). But the UI never surfaced the cache token counts, so there was no visible signal that caching engaged.

## Change

Adds a faint **`prompt cache: N read · M write`** line to the run-steps footer when a run used the cache. `read` tokens bill at ~0.1× and `write` (one-time) at ~1.25×; the `in` cost shown above already reflects those rates. The line only appears when there are cache tokens (Anthropic runs over the ~1k-token minimum).

`tsc` / eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)