### PR TITLE
Add a cleanup path for defunct native-MCP connections

### DIFF
--- a/web/src/app/[workspace]/connections/native-mcp-actions.ts
+++ b/web/src/app/[workspace]/connections/native-mcp-actions.ts
@@ -10,6 +10,7 @@ import {
   deleteNativeConnection,
   getNativeConnectionById,
   getNativeConnectionCredentials,
+  listNativeConnectionsForUser,
   renameNativeConnection,
 } from "@/lib/connections";
 import {
@@ -17,6 +18,7 @@ import {
   renameToolsForConnection,
   replaceToolsForConnection,
 } from "@/lib/mcp-tools";
+import { getMcpProvider } from "@/lib/mcp-providers";
 import { fetchNativeMcpTools } from "@/lib/native-mcp-tools";
 
 // Server actions for native-MCP connection rows. Read-paths live on
@@ -64,12 +66,10 @@ export async function disconnectNativeMcpConnectionAction(
   if (!ok) return { error: "Connection no longer exists." };
 
   // Self-key (Tembo) rows own a minted tas_ API key — revoke it so the
-  // credential can't outlive the connection. Other providers' tokens live
-  // only inside the now-deleted row, so there's nothing extra to revoke.
-  if (
-    row.type === "tembo-agent-studio" &&
-    typeof row.metadata.api_key_id === "string"
-  ) {
+  // credential can't outlive the connection. Keyed on `api_key_id` in metadata
+  // (only self-key connections have it) rather than the provider slug, so a
+  // renamed/defunct provider's leftover key still gets revoked.
+  if (typeof row.metadata.api_key_id === "string") {
     await deleteApiKey(workspace.id, row.metadata.api_key_id);
   }
 
@@ -248,4 +248,58 @@ export async function renameNativeMcpConnectionAction(
 
   revalidatePath(`/${slug}/connections`, "layout");
   return { message: "Connection renamed." };
+}
+
+/**
+ * Remove the acting user's "defunct" native-MCP connections — rows whose
+ * provider slug is no longer in the catalog (e.g. the old `tembo` self-key
+ * connection after the rename to `tembo-agent-studio`). Those rows don't render
+ * on the Connections page (no matching catalog provider) so they can't be
+ * disconnected the normal way, yet they still leak into the create-agent prompt
+ * and keep a minted tas_ key alive. This deletes them, revokes any self-key
+ * API key, and drops their cached tools. Operator+ (own connections).
+ */
+export async function removeDefunctNativeConnectionsAction(
+  _prev: SimpleConnectionActionState,
+  formData: FormData,
+): Promise<SimpleConnectionActionState> {
+  const slug = String(formData.get("workspace") ?? "");
+  const auth = await authorizeWorkspace(slug, "operator");
+  if (!auth.ok) {
+    if (auth.reason === "denied") return { error: DENIED_MESSAGE };
+    notFound();
+  }
+  const { workspace, userId } = auth;
+
+  const connections = await listNativeConnectionsForUser(workspace.id, userId);
+  const defunct = connections.filter((c) => !getMcpProvider(c.type));
+  if (defunct.length === 0) return { message: "No defunct connections to remove." };
+
+  for (const row of defunct) {
+    await deleteNativeConnection(workspace.id, row.id);
+    if (typeof row.metadata.api_key_id === "string") {
+      await deleteApiKey(workspace.id, row.metadata.api_key_id);
+    }
+    await deleteToolsForConnection({
+      workspaceId: workspace.id,
+      userId: row.userId,
+      source: "native-mcp",
+      provider: row.type,
+      connectionName: row.name,
+    });
+    await writeAuditEvent({
+      workspaceId: workspace.id,
+      actorUserId: userId,
+      source: "human_action",
+      kind: "connection.disconnected",
+      targetType: "connection",
+      targetId: row.id,
+      agentName: null,
+      payload: { provider: row.type, name: row.name, source: "native-mcp", defunct: true },
+    });
+  }
+
+  revalidatePath(`/${slug}/connections`, "layout");
+  const names = defunct.map((c) => c.type).join(", ");
+  return { message: `Removed ${defunct.length} defunct connection(s): ${names}.` };
 }

--- a/web/src/app/[workspace]/connections/native-mcp/page.tsx
+++ b/web/src/app/[workspace]/connections/native-mcp/page.tsx
@@ -19,6 +19,7 @@ import {
   NativeMcpConnectionsSection,
   type ManualConnectTarget,
 } from "../native-mcp-connections-section";
+import { RemoveDefunctNativeForm } from "../remove-defunct-native-form";
 
 export const dynamic = "force-dynamic";
 
@@ -161,8 +162,29 @@ export default async function NativeMcpConnectionsPage({
         }
       : undefined;
 
+  // Active connections to a provider no longer in the catalog (e.g. the old
+  // `tembo` self-key connection after the rename). They don't render as cards,
+  // so surface a one-click cleanup. Only for your own connections — the action
+  // clears the acting user's rows, not the member you're viewing.
+  const catalogSlugs = new Set(nativeCatalog.map((p) => p.slug));
+  const defunctSlugs = view.viewingOther
+    ? []
+    : [
+        ...new Set(
+          nativeConnections
+            .filter((c) => c.status === "active" && !catalogSlugs.has(c.type))
+            .map((c) => c.type),
+        ),
+      ];
+
   return (
     <>
+      {defunctSlugs.length > 0 && (
+        <RemoveDefunctNativeForm
+          workspaceSlug={workspace.slug}
+          defunctSlugs={defunctSlugs}
+        />
+      )}
       {view.viewingOther && view.viewedMember && (
         <div className="border-border bg-surface-secondary rounded-lg border px-3 py-2 text-sm">
           <span className="text-foreground-weak">

--- a/web/src/app/[workspace]/connections/remove-defunct-native-form.tsx
+++ b/web/src/app/[workspace]/connections/remove-defunct-native-form.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useActionState } from "react";
+import { useActionToast } from "@/lib/use-action-toast";
+
+import {
+  removeDefunctNativeConnectionsAction,
+  type SimpleConnectionActionState,
+} from "./native-mcp-actions";
+
+const INITIAL: SimpleConnectionActionState = {};
+
+// Banner shown when the user holds native-MCP connections to a provider that's
+// no longer in the catalog (e.g. the old `tembo` self-key connection after the
+// rename). Those rows don't render as normal connection cards, so this is the
+// only way to clear them — it deletes the rows + revokes any minted tas_ key.
+export function RemoveDefunctNativeForm({
+  workspaceSlug,
+  defunctSlugs,
+}: {
+  workspaceSlug: string;
+  defunctSlugs: string[];
+}) {
+  const [state, formAction, pending] = useActionState(
+    removeDefunctNativeConnectionsAction,
+    INITIAL,
+  );
+  useActionToast(state);
+  return (
+    <div className="border-sentiment-negative bg-[var(--color-input-error)] flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm">
+      <span className="text-foreground">
+        You have {defunctSlugs.length} connection
+        {defunctSlugs.length === 1 ? "" : "s"} to a removed provider (
+        <code>{defunctSlugs.join(", ")}</code>) that no longer works. Remove to
+        clear them and revoke any leftover key.
+      </span>
+      <form action={formAction}>
+        <input type="hidden" name="workspace" value={workspaceSlug} />
+        <button
+          type="submit"
+          disabled={pending}
+          className="text-foreground hover:text-sentiment-negative shrink-0 font-medium hover:underline disabled:opacity-60"
+        >
+          {pending ? "Removing…" : "Remove"}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
Follow-up to #126. The orphaned `tembo` self-key connection (left by the `tembo` → `tembo-agent-studio` rename) can't be removed from the UI — it doesn't render as a card (no catalog provider), so it lingers with a still-valid minted `tas_` key.

- **Connections → Native MCP** now shows a "removed provider" banner with a one-click **Remove** when you hold connections to a non-catalog provider. `removeDefunctNativeConnectionsAction` deletes the rows, revokes any self-key `tas_` key, drops their cached tools, and audits each.
- **Generalized the disconnect key-revocation**: it now fires whenever the row has a `metadata.api_key_id` (only self-key connections do) instead of matching `type === "tembo-agent-studio"` — so a renamed provider's leftover key is revoked on disconnect/cleanup too.

Scoped to your own connections (the action clears the acting user's rows, so the banner is hidden when an admin is viewing another member).

`tsc` / eslint / `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)