### PR TITLE
Fix native-MCP token refresh for Dialed/Fathom + guard the allowlist drift

### DIFF
--- a/api/src/native_oauth.rs
+++ b/api/src/native_oauth.rs
@@ -52,11 +52,20 @@ const PYLON_OAUTH_ORIGINS: &[&str] = &["https://o.auth.usepylon.com"];
 // metadata says auth_mode=manual.
 const HUBSPOT_MCP_ORIGIN: &str = "https://mcp.hubspot.com";
 const HUBSPOT_OAUTH_ORIGINS: &[&str] = &["https://mcp.hubspot.com"];
+// Fathom's auth server is api.fathom.ai but its authorize endpoint lives on
+// fathom.video — both origins are allowed (matches the web catalog).
+const FATHOM_MCP_ORIGIN: &str = "https://api.fathom.ai";
+const FATHOM_OAUTH_ORIGINS: &[&str] = &["https://api.fathom.ai", "https://fathom.video"];
+// Dialed advertises its auth server as the apex (also the MCP origin).
+const DIALED_MCP_ORIGIN: &str = "https://dialed.day";
+const DIALED_OAUTH_ORIGINS: &[&str] = &["https://dialed.day"];
 
 const NATIVE_MCP_OAUTH_ALLOWLIST: &[(&str, &[&str])] = &[
     (ATTIO_MCP_ORIGIN, ATTIO_OAUTH_ORIGINS),
     (PYLON_MCP_ORIGIN, PYLON_OAUTH_ORIGINS),
     (HUBSPOT_MCP_ORIGIN, HUBSPOT_OAUTH_ORIGINS),
+    (FATHOM_MCP_ORIGIN, FATHOM_OAUTH_ORIGINS),
+    (DIALED_MCP_ORIGIN, DIALED_OAUTH_ORIGINS),
 ];
 
 #[derive(Deserialize)]

--- a/web/src/lib/mcp-providers.allowlist-sync.test.ts
+++ b/web/src/lib/mcp-providers.allowlist-sync.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { MCP_PROVIDERS } from "./mcp-providers";
+
+// Drift guard. The Rust token-refresh path keeps its OWN origin allowlist
+// (api/src/native_oauth.rs, NATIVE_MCP_OAUTH_ALLOWLIST) because the api crate
+// can't import this TS catalog. If a new native-MCP provider is added here but
+// not there, refreshes for it abort with "origin is not in the allowlist" and
+// its short-lived tokens 401 mid-run — exactly the Dialed regression. This test
+// fails CI when the two drift, so the Rust side can't be forgotten.
+//
+// CI checks out the whole repo, so api/ is reachable from the web package.
+describe("native-MCP OAuth origin allowlist stays in sync with the Rust refresher", () => {
+  const rs = readFileSync(
+    join(process.cwd(), "..", "api", "src", "native_oauth.rs"),
+    "utf8",
+  );
+
+  for (const provider of Object.values(MCP_PROVIDERS)) {
+    // Only OAuth providers are refreshed (self-key / PAT providers like
+    // tembo-agent-studio have no auth-server origins and aren't in the sweep).
+    if (provider.oauthAuthorizationServerOrigins.length === 0) continue;
+
+    it(`${provider.slug}'s MCP origin is in native_oauth.rs`, () => {
+      const mcpOrigin = new URL(provider.mcpServerUrl).origin;
+      expect(
+        rs.includes(`"${mcpOrigin}"`),
+        `${provider.slug} (${mcpOrigin}) is in the web catalog but missing from ` +
+          `NATIVE_MCP_OAUTH_ALLOWLIST in api/src/native_oauth.rs — add it there or ` +
+          `token refresh for ${provider.slug} will abort and its tokens will 401 mid-run.`,
+      ).toBe(true);
+
+      // And each advertised OAuth authorization-server origin must be allowed too.
+      for (const oauthOrigin of provider.oauthAuthorizationServerOrigins) {
+        expect(
+          rs.includes(`"${oauthOrigin}"`),
+          `${provider.slug}'s OAuth origin ${oauthOrigin} is missing from native_oauth.rs.`,
+        ).toBe(true);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Root cause (from the dogfood api logs)

```
native MCP token refresh failed … e=mcp_server_url origin is not in the native-MCP provider allowlist  provider=dialed
```

The Rust refresher (`native_oauth.rs`) keeps its **own** origin allowlist (`NATIVE_MCP_OAUTH_ALLOWLIST`) because the api crate can't import the web TS catalog. **Dialed** and **Fathom** were added to the web catalog (#116) but never to this list, so every Dialed refresh **aborted at the allowlist gate** — the expired ~3h token was then used, and the run `401`'d at `dialed.day/mcp`. (Pylon refreshes fine because it *is* listed.) The whole `offline_access` thread was a red herring; this gate blocked refresh before it ever ran.

## Fix
- Add **Dialed** + **Fathom** to `NATIVE_MCP_OAUTH_ALLOWLIST` (origins mirror `web/src/lib/mcp-providers.ts`).
- **Drift guard** (`web/src/lib/mcp-providers.allowlist-sync.test.ts`): for every OAuth provider in the catalog, assert its MCP + auth-server origins appear in `api/src/native_oauth.rs`. Fails CI if a future provider is added to the catalog but forgotten in the Rust allowlist — so this regression can't silently recur. (CI checks out the whole repo, so the test reads `../api/...` directly.)

## Verification
- `cargo check` + `cargo fmt` clean.
- The drift test passes (5 OAuth providers: attio/pylon/hubspot/fathom/dialed; self-key tembo-agent-studio skipped).

## After deploy
The refresh will actually run for Dialed. Either it refreshes cleanly (token survives), or — if Dialed never issued a refresh token — you'll get a clean `"no refresh_token stored"` instead of a 401, which would pin it as a Dialed-side limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)