### PR TITLE
native-MCP: fall back to the sole connection when the slot name doesn't match

### DIFF
--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -952,7 +952,15 @@ def build_native_mcp_toolsets(
     toolsets: list = []
     missing: list[str] = []
     for provider, name, tools in native:
-        entry = nested.get(provider, {}).get(name)
+        provider_slots = nested.get(provider, {})
+        entry = provider_slots.get(name)
+        # Slot-name fallback: agents pin a connection by slot name, but users
+        # routinely have the provider connected under a different name (e.g.
+        # `tembo` vs `default`). When the named slot is absent but the user has
+        # exactly ONE connection for this provider, use it — so the spec doesn't
+        # have to match the slot name exactly. Ambiguous (2+ slots) still fails.
+        if not entry and len(provider_slots) == 1:
+            entry = next(iter(provider_slots.values()))
         if not entry or not entry.get("mcp_url") or not entry.get("access_token"):
             slot_label = (
                 provider if name == "default" else f"{provider}/{name}"

--- a/web/src/lib/connection-checks.test.ts
+++ b/web/src/lib/connection-checks.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/composio-connections", () => ({
+  listConnectionsForUser: vi.fn(async () => []),
+}));
+vi.mock("@/lib/connections", () => ({
+  listNativeConnectionsForUser: vi.fn(async () => []),
+}));
+vi.mock("@/lib/secret-connections", () => ({
+  listSecretConnections: vi.fn(async () => []),
+}));
+
+import { findMissingConnections } from "./connection-checks";
+import { listNativeConnectionsForUser } from "@/lib/connections";
+
+const mockNative = vi.mocked(listNativeConnectionsForUser);
+
+// Only the fields findMissingConnections reads.
+function nativeRow(type: string, name: string, status = "active") {
+  return { type, name, status } as Awaited<
+    ReturnType<typeof listNativeConnectionsForUser>
+  >[number];
+}
+const declare = (toolkit: string, name: string) => [
+  { toolkit, name, source: "native-mcp" as const },
+];
+
+describe("findMissingConnections — native single-connection slot fallback", () => {
+  beforeEach(() => mockNative.mockReset());
+
+  it("exact slot match is not missing", async () => {
+    mockNative.mockResolvedValue([nativeRow("pylon", "tembo")]);
+    expect(await findMissingConnections("w", "u", declare("pylon", "tembo"))).toEqual([]);
+  });
+
+  it("slot-name mismatch with exactly ONE connection falls back (not missing)", async () => {
+    mockNative.mockResolvedValue([nativeRow("pylon", "tembo")]);
+    // agent pins `default`, user only has `tembo` → use it
+    expect(await findMissingConnections("w", "u", declare("pylon", "default"))).toEqual([]);
+  });
+
+  it("slot-name mismatch with TWO connections is ambiguous (missing)", async () => {
+    mockNative.mockResolvedValue([
+      nativeRow("pylon", "tembo"),
+      nativeRow("pylon", "work"),
+    ]);
+    const missing = await findMissingConnections("w", "u", declare("pylon", "default"));
+    expect(missing.map((m) => m.toolkit)).toEqual(["pylon"]);
+  });
+
+  it("no connection for the provider is missing", async () => {
+    mockNative.mockResolvedValue([]);
+    const missing = await findMissingConnections("w", "u", declare("pylon", "default"));
+    expect(missing.map((m) => m.toolkit)).toEqual(["pylon"]);
+  });
+
+  it("a non-active sole connection does not satisfy the fallback", async () => {
+    mockNative.mockResolvedValue([nativeRow("pylon", "tembo", "stale")]);
+    const missing = await findMissingConnections("w", "u", declare("pylon", "default"));
+    expect(missing.map((m) => m.toolkit)).toEqual(["pylon"]);
+  });
+});

--- a/web/src/lib/connection-checks.ts
+++ b/web/src/lib/connection-checks.ts
@@ -51,9 +51,17 @@ export async function findMissingConnections(
   const composioSlots = new Set(
     composio.filter((c) => c.status === "ACTIVE").map((c) => `${c.toolkit}:${c.name}`),
   );
-  const nativeSlots = new Set(
-    native.filter((c) => c.status === "active").map((c) => `${c.type}:${c.name}`),
-  );
+  const activeNative = native.filter((c) => c.status === "active");
+  const nativeSlots = new Set(activeNative.map((c) => `${c.type}:${c.name}`));
+  // How many active native connections the user has per provider. Used for the
+  // single-connection slot-name fallback (mirrors build_native_mcp_toolsets):
+  // an agent pins a slot by name, but users routinely have the provider under a
+  // different name (e.g. `tembo` vs `default`); when there's exactly one, the
+  // runtime uses it regardless of the declared name, so it isn't "missing".
+  const nativeCountByProvider = new Map<string, number>();
+  for (const c of activeNative) {
+    nativeCountByProvider.set(c.type, (nativeCountByProvider.get(c.type) ?? 0) + 1);
+  }
   const secretSlugs = new Set(secrets.map((s) => s.slug));
 
   const missing: MissingConnection[] = [];
@@ -67,7 +75,9 @@ export async function findMissingConnections(
     if (conn.source === "secret") {
       isMissing = !secretSlugs.has(toolkit);
     } else if (conn.source === "native-mcp") {
-      isMissing = !nativeSlots.has(`${toolkit}:${name}`);
+      isMissing =
+        !nativeSlots.has(`${toolkit}:${name}`) &&
+        nativeCountByProvider.get(toolkit) !== 1;
     } else {
       isMissing = !composioSlots.has(`${toolkit}:${name}`);
     }


### PR DESCRIPTION
## Problem (you flagged this)

> lots of users will have this issue where name of existing connection isn't reused

An agent pins a native-MCP connection by **slot name**. If it doesn't match the user's slot verbatim, the run is rejected as "you haven't connected X" — even though the provider **is** connected, just under a different name (the `task-roundup` sub-agents hit this: spec said `default`, the workspace uses `tembo`).

## Fix

When the declared slot is absent but the user has **exactly one** active connection for that provider, use it — so the slot name doesn't have to match in the common (one-connection) case. Applied in **both** gates so the check and the runtime agree:

- **`build_native_mcp_toolsets`** (Python runtime) — resolve to the sole slot's entry.
- **`findMissingConnections`** (pre-run check / `trigger_run`) — not "missing" when the provider has exactly one active connection.

Ambiguous (2+ slots, none matching) still fails — the user must name one. Non-active sole connections don't count.

Scoped to **native-MCP** (the demonstrated case); Composio has the same coupling and can get the same treatment as a follow-up. (The sidebar's `layout.tsx` nudge duplicates the slot logic and is left as a cosmetic follow-up — it's a prompt, not a run gate.)

## Verification
- `python -m py_compile`, `tsc`, eslint clean.
- New `connection-checks.test.ts` — 5 cases pass: exact match, single-connection fallback, ambiguous→missing, none→missing, stale-sole→missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)