### PR TITLE
Roll sub-run cost up into the orchestrator's run page

### DIFF
--- a/api/migrations/0050_run_parent_run_id.sql
+++ b/api/migrations/0050_run_parent_run_id.sql
@@ -1,0 +1,9 @@
+-- Link a run to the run that triggered it. Set when an agent calls the
+-- tembo-agent-studio MCP `trigger_run` tool from inside its own run (an
+-- orchestrator fanning out to sub-agents): the runner stamps the parent run id
+-- onto the MCP request, /mcp records it here. Lets the parent's run page roll
+-- up its sub-runs' tokens + cost. Nullable: most runs have no parent.
+ALTER TABLE run
+    ADD COLUMN IF NOT EXISTS parent_run_id UUID REFERENCES run(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS run_parent_run_id_idx ON run(parent_run_id);

--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -967,10 +967,14 @@ def build_native_mcp_toolsets(
             )
             missing.append(slot_label)
             continue
-        mcp = MCPToolset(
-            entry["mcp_url"],
-            headers={"Authorization": f"Bearer {entry['access_token']}"},
-        )
+        headers = {"Authorization": f"Bearer {entry['access_token']}"}
+        # Tag trigger_run calls to TAS's own MCP with this run's id, so the
+        # runs it spawns are recorded as our children (parent-run cost rollup).
+        # Only for the self provider — never leak the run id to third parties.
+        run_id = os.environ.get("TAS_RUN_ID")
+        if provider == "tembo-agent-studio" and run_id:
+            headers["X-Tas-Parent-Run"] = run_id
+        mcp = MCPToolset(entry["mcp_url"], headers=headers)
         if tools:
             # Capture the allowed set in a default-argument so the
             # closure doesn't late-bind to the loop variable. The

--- a/api/src/runs/handlers.rs
+++ b/api/src/runs/handlers.rs
@@ -73,6 +73,11 @@ pub struct CreateRunRequest {
     /// Human label for the version ("v3" | "draft"), shown in the runs UI.
     #[serde(default)]
     pub agent_version_label: Option<String>,
+    /// The run that triggered this one (an orchestrator's run id), when this
+    /// run was started via the tembo-agent-studio MCP `trigger_run` tool from
+    /// inside another run. Lets the parent's page roll up sub-run costs.
+    #[serde(default)]
+    pub parent_run_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize)]
@@ -103,8 +108,8 @@ pub async fn create_run(
         r#"INSERT INTO run
             (id, workspace_id, agent_name, agent_path, model, status,
              created_by, user_message, trigger, automation_id,
-             agent_version_id, agent_version_label)
-            VALUES ($1, $2, $3, $4, $5, 'queued', $6, $7, $8, $9, $10, $11)"#,
+             agent_version_id, agent_version_label, parent_run_id)
+            VALUES ($1, $2, $3, $4, $5, 'queued', $6, $7, $8, $9, $10, $11, $12)"#,
     )
     .bind(run_id)
     .bind(req.workspace_id)
@@ -117,6 +122,7 @@ pub async fn create_run(
     .bind(req.automation_id)
     .bind(req.agent_version_id)
     .bind(&req.agent_version_label)
+    .bind(req.parent_run_id)
     .execute(&state.db)
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("db insert: {e}")))?;

--- a/api/src/runs/pydantic.rs
+++ b/api/src/runs/pydantic.rs
@@ -262,6 +262,11 @@ async fn spawn_and_wait(args: &PydanticArgs<'_>) -> anyhow::Result<std::process:
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
+    // This run's id. The wrapper forwards it as the X-Tas-Parent-Run header on
+    // the tembo-agent-studio MCP toolset only, so that a trigger_run call made
+    // from inside this run records this run as the new run's parent.
+    cmd.env("TAS_RUN_ID", args.run_id.to_string());
+
     // Provider keys flow in via env so the wrapper script doesn't
     // have to know which provider the agent's model: string points
     // to — pydantic-ai's own dispatch handles that.

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
@@ -11,7 +11,11 @@ import { toolkitLabel } from "@/lib/composio-label";
 import { getMcpProvider } from "@/lib/mcp-providers";
 import { listWorkspaceToolProviders } from "@/lib/mcp-tools";
 import { getRun, type RunRecord } from "@/lib/runs-api";
-import { listStepsForRun, listToolCallsForRun } from "@/lib/runs-db";
+import {
+  listChildRuns,
+  listStepsForRun,
+  listToolCallsForRun,
+} from "@/lib/runs-db";
 import { getServerSession } from "@/lib/session";
 import { getWorkspaceBySlug, isTemboConfigured } from "@/lib/workspace";
 
@@ -52,10 +56,11 @@ export default async function RunDetailPage({
   // Tools the agent called during this run (pydantic only; empty otherwise),
   // plus the per-step token usage so we can attribute tokens to the model step
   // that fired each call.
-  const [toolCalls, steps, toolProviderRows] = await Promise.all([
+  const [toolCalls, steps, toolProviderRows, childRuns] = await Promise.all([
     listToolCallsForRun(workspace.id, run.id),
     listStepsForRun(workspace.id, run.id),
     listWorkspaceToolProviders(workspace.id),
+    listChildRuns(workspace.id, run.id),
   ]);
 
   // tool_name → provider (slug for the logo + label for the tooltip). First
@@ -109,6 +114,11 @@ export default async function RunDetailPage({
     run.tokensInput !== null && run.tokensOutput !== null
       ? estimateRunCost(run.model, run.tokensInput, run.tokensOutput)
       : null;
+  // Sub-runs this run spawned via trigger_run. Roll their cost up so an
+  // orchestrator's page shows its true total, not just its own (small) cost.
+  const subRunsCost = childRuns.reduce((sum, c) => sum + (c.costUsd ?? 0), 0);
+  const grandTotalCost =
+    childRuns.length > 0 ? (estimatedCost ?? 0) + subRunsCost : null;
 
 
   return (
@@ -212,6 +222,21 @@ export default async function RunDetailPage({
               </dd>
             </div>
           )}
+          {grandTotalCost !== null && (
+            <div className="flex gap-3">
+              <dt className="text-foreground-weak w-24 shrink-0 font-medium">
+                Combined
+              </dt>
+              <dd className="text-foreground">
+                ~{formatCurrency(grandTotalCost)}
+                <span className="text-foreground-weak">
+                  {" "}
+                  (this run + {childRuns.length} sub-run
+                  {childRuns.length === 1 ? "" : "s"})
+                </span>
+              </dd>
+            </div>
+          )}
         </dl>
       </div>
 
@@ -234,6 +259,51 @@ export default async function RunDetailPage({
             toolProviders={toolProviders}
             live={isLive}
           />
+        </Section>
+      )}
+
+      {/* Runs this one spawned via trigger_run (an orchestrator fanning work
+          out to per-source agents). Their cost is rolled into "Combined"
+          above; this lists each one with a link to its own run page. */}
+      {childRuns.length > 0 && (
+        <Section title={`Sub-runs (${childRuns.length})`}>
+          <ul className="divide-y divide-[var(--color-border-weak)]">
+            {childRuns.map((child) => {
+              const childTokens =
+                child.tokensInput !== null && child.tokensOutput !== null
+                  ? child.tokensInput + child.tokensOutput
+                  : null;
+              return (
+                <li key={child.id}>
+                  <Link
+                    href={`/${workspace.slug}/agents/${encodeURIComponent(
+                      child.agentName,
+                    )}/runs/${child.id}`}
+                    className="hover:bg-background-weak flex items-center justify-between gap-3 px-1 py-2"
+                  >
+                    <span className="flex items-center gap-2 truncate">
+                      <span className="text-foreground truncate font-medium">
+                        {child.agentName}
+                      </span>
+                      <span
+                        className={`${STATUS_TEXT_TONE[child.status]} text-sm`}
+                      >
+                        {STATUS_LABELS[child.status]}
+                      </span>
+                    </span>
+                    <span className="text-foreground-weak shrink-0 text-sm">
+                      {childTokens !== null && (
+                        <>{formatTokens(childTokens)} tokens</>
+                      )}
+                      {child.costUsd !== null && (
+                        <> (~{formatCurrency(child.costUsd)})</>
+                      )}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
         </Section>
       )}
 

--- a/web/src/app/mcp/route.ts
+++ b/web/src/app/mcp/route.ts
@@ -35,7 +35,10 @@ export async function POST(request: NextRequest): Promise<Response> {
     sessionIdGenerator: undefined,
     enableJsonResponse: true,
   });
-  const server = buildMcpServer(auth);
+  // Set by the runner when an agent calls /mcp from inside its own run, so
+  // trigger_run can record that run as the parent of the run it spawns.
+  const parentRunId = request.headers.get("x-tas-parent-run") ?? undefined;
+  const server = buildMcpServer(auth, { parentRunId });
   await server.connect(transport);
   return transport.handleRequest(request);
 }

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -63,6 +63,9 @@ export type TriggerRunInput = {
   agent: string;
   message?: string;
   preferDraft?: boolean;
+  /** The run that triggered this one (set when called from /mcp inside a run),
+   *  recorded on the new run so the parent can roll up its sub-runs' cost. */
+  parentRunId?: string;
 };
 
 export async function triggerRun(
@@ -106,6 +109,7 @@ export async function triggerRun(
       trigger: "manual",
       agentVersionId: r.versionId,
       agentVersionLabel: r.versionLabel,
+      parentRunId: input.parentRunId,
     });
     return { ok: true, runId: res.runId };
   } catch (err) {

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -57,7 +57,16 @@ function errorResult(message: string) {
 
 const FRAMEWORK_VALUES = FRAMEWORKS as readonly [Framework, ...Framework[]];
 
-export function buildMcpServer(ctx: McpContext): McpServer {
+export type McpServerOptions = {
+  /** The run that's calling /mcp (when an agent calls it mid-run), recorded as
+   *  the parent of any run trigger_run spawns. */
+  parentRunId?: string;
+};
+
+export function buildMcpServer(
+  ctx: McpContext,
+  options: McpServerOptions = {},
+): McpServer {
   const server = new McpServer({
     name: "tembo-agent-studio",
     version: "1.0.0",
@@ -264,7 +273,12 @@ export function buildMcpServer(ctx: McpContext): McpServer {
     },
     async ({ agent, message, preferDraft }) => {
       if (!isOperator) return operatorOnly();
-      const res = await triggerRun(ctx, { agent, message, preferDraft });
+      const res = await triggerRun(ctx, {
+        agent,
+        message,
+        preferDraft,
+        parentRunId: options.parentRunId,
+      });
       if (!res.ok) return errorResult(res.error);
       return json({ runId: res.runId });
     },

--- a/web/src/lib/runs-api.ts
+++ b/web/src/lib/runs-api.ts
@@ -47,6 +47,9 @@ export type CreateRunInput = {
   // versionLabel is the human string ("v3" | "draft") for the UI.
   agentVersionId?: string | null;
   agentVersionLabel?: string | null;
+  // The run that triggered this one (an orchestrator calling trigger_run from
+  // inside its own run). Recorded so the parent's page can roll up sub-runs.
+  parentRunId?: string;
 };
 
 export type CreateRunResponse = { runId: string };
@@ -149,6 +152,7 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunRespons
       trigger: input.trigger,
       agent_version_id: input.agentVersionId,
       agent_version_label: input.agentVersionLabel,
+      parent_run_id: input.parentRunId,
     }),
   });
   if (!res.ok) {

--- a/web/src/lib/runs-db.ts
+++ b/web/src/lib/runs-db.ts
@@ -8,6 +8,50 @@ import { db } from "@/lib/db";
 
 export type RunTrigger = "manual" | "schedule" | "event";
 
+// A run spawned by another run via the tembo-agent-studio MCP `trigger_run`
+// tool. Shown on the parent run's page so an orchestrator's true cost (its own
+// + every sub-run) is visible in one place.
+export type ChildRun = {
+  id: string;
+  agentName: string;
+  status: "queued" | "running" | "succeeded" | "failed";
+  costUsd: number | null;
+  tokensInput: number | null;
+  tokensOutput: number | null;
+  createdAt: Date;
+};
+
+export async function listChildRuns(
+  workspaceId: string,
+  parentRunId: string,
+): Promise<ChildRun[]> {
+  const { rows } = await db.query<{
+    id: string;
+    agent_name: string;
+    status: ChildRun["status"];
+    cost_usd: string | null;
+    tokens_input: number | null;
+    tokens_output: number | null;
+    created_at: Date;
+  }>(
+    `SELECT id, agent_name, status, cost_usd, tokens_input, tokens_output, created_at
+       FROM run
+      WHERE workspace_id = $1 AND parent_run_id = $2
+      ORDER BY created_at ASC`,
+    [workspaceId, parentRunId],
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    agentName: r.agent_name,
+    status: r.status,
+    // cost_usd is NUMERIC — pg returns it as a string.
+    costUsd: r.cost_usd === null ? null : Number(r.cost_usd),
+    tokensInput: r.tokens_input,
+    tokensOutput: r.tokens_output,
+    createdAt: r.created_at,
+  }));
+}
+
 export type RunSummary = {
   id: string;
   agentName: string;


### PR DESCRIPTION
## What

When an agent calls the `tembo-agent-studio` MCP `trigger_run` tool from inside its own run — an orchestrator fanning work out to per-source sub-agents (e.g. `task-roundup` → `linear-tasks`, `attio-tasks`, …) — the spawned run is now **linked to its parent**, and the parent's run page shows each sub-run with its tokens + cost, plus a **Combined** total (this run + its sub-runs).

This makes an orchestrator's true cost visible. Previously its own page showed only its (small) coordination cost; the real spend lived in disconnected child runs.

## How it threads through

```
runner sets TAS_RUN_ID in subprocess env
  → pydantic wrapper attaches X-Tas-Parent-Run header (tembo-agent-studio toolset only)
    → /mcp reads header → buildMcpServer({ parentRunId })
      → trigger_run → triggerRun → createRun
        → Rust /internal/runs handler persists run.parent_run_id
```

- **Migration 0050** adds `run.parent_run_id UUID REFERENCES run(id) ON DELETE SET NULL` (nullable; most runs have no parent) + an index.
- The header is attached **only** to the `tembo-agent-studio` toolset, so we never leak the parent run id to third-party MCP servers.
- The run-detail page queries `listChildRuns(workspace.id, run.id)` and renders a "Sub-runs" section + the "Combined" cost line.

## Verification

- `cargo check` + `cargo fmt --check` (api) ✓
- `python3 -m py_compile api/scripts/run_pydantic.py` ✓
- `tsc --noEmit` + `eslint` + `next build` (web) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)