### PR TITLE
Surface orchestrator cost + sub-agent MCPs (run page + agents list)

### DIFF
--- a/web/src/app/[workspace]/agents-inventory.tsx
+++ b/web/src/app/[workspace]/agents-inventory.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useActionState, useMemo, useState } from "react";
 
-import { IconPlusLarge } from "central-icons";
+import { IconApiConnection, IconPlusLarge } from "central-icons";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,13 @@ import { dismissPendingCreateAction } from "./inventory-actions";
 // Status facet pills + free-text search live above; the table itself
 // renders every agent — live, pending-create, and invalid — as a
 // single row so the user sees the whole picture in one place.
+
+export type McpIcon = {
+  /** Provider slug for the logo (e.g. "attio", "linear"). */
+  slug: string;
+  /** Human label for the tooltip / filter (e.g. "Attio"). */
+  label: string;
+};
 
 export type InventoryAgent =
   | {
@@ -32,6 +39,11 @@ export type InventoryAgent =
       frameworkLabel: string;
       /** Spec labels (for grouping + Slack-app scoping). */
       labels: string[];
+      /** MCP/provider connections declared on this agent's own spec. */
+      mcps: McpIcon[];
+      /** MCPs reached one level down: providers this agent's sub-agents use
+       *  (derived from the parent_run_id graph). Empty for non-orchestrators. */
+      subMcps: McpIcon[];
       model: string | null;
       /** 30-day window. Zero when the agent has never run in that window. */
       runs30d: number;
@@ -101,6 +113,7 @@ export function AgentsInventory({
   const [bucket, setBucket] = useState<StatusBucket | null>(null);
   const [labelFilter, setLabelFilter] = useState("");
   const [modelFilter, setModelFilter] = useState("");
+  const [mcpFilter, setMcpFilter] = useState("");
   // Default sort: alphabetical by name. The user can re-sort by clicking
   // column headers.
   const [sortKey, setSortKey] = useState<SortKey>("name");
@@ -145,6 +158,22 @@ export function AgentsInventory({
       ...[...set].sort().map((m) => ({ value: m, label: shortModel(m) })),
     ];
   }, [enriched]);
+  // Distinct MCPs (top-level + sub-agent) across live agents, slug→label.
+  const mcpOptions = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const { agent } of enriched) {
+      if (agent.kind !== "live") continue;
+      for (const m of [...agent.mcps, ...agent.subMcps]) {
+        if (!labels.has(m.slug)) labels.set(m.slug, m.label);
+      }
+    }
+    return [
+      { value: "", label: "All MCPs" },
+      ...[...labels.entries()]
+        .sort((a, b) => a[1].localeCompare(b[1]))
+        .map(([slug, label]) => ({ value: slug, label })),
+    ];
+  }, [enriched]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -165,10 +194,26 @@ export function AgentsInventory({
         ({ agent }) => agent.kind === "live" && agent.model === modelFilter,
       );
     }
+    if (mcpFilter) {
+      rows = rows.filter(
+        ({ agent }) =>
+          agent.kind === "live" &&
+          [...agent.mcps, ...agent.subMcps].some((m) => m.slug === mcpFilter),
+      );
+    }
     return [...rows].sort((a, b) =>
       compareRows(a.agent, b.agent, a.bucket, b.bucket, sortKey, sortDir),
     );
-  }, [enriched, query, bucket, labelFilter, modelFilter, sortKey, sortDir]);
+  }, [
+    enriched,
+    query,
+    bucket,
+    labelFilter,
+    modelFilter,
+    mcpFilter,
+    sortKey,
+    sortDir,
+  ]);
 
   function onHeaderClick(key: SortKey) {
     if (key === sortKey) {
@@ -231,6 +276,15 @@ export function AgentsInventory({
             className="min-w-[130px]"
           />
         )}
+        {mcpOptions.length > 1 && (
+          <Select
+            value={mcpFilter}
+            onValueChange={setMcpFilter}
+            options={mcpOptions}
+            ariaLabel="Filter by MCP"
+            className="min-w-[130px]"
+          />
+        )}
       </div>
 
       {filtered.length === 0 ? (
@@ -271,6 +325,7 @@ export function AgentsInventory({
                 />
                 <th className="px-3 py-2 text-left font-medium">Labels</th>
                 <th className="px-3 py-2 text-left font-medium">Model</th>
+                <th className="px-3 py-2 text-left font-medium">MCPs</th>
                 <SortableTh
                   label="Runs 30d"
                   active={sortKey === "runs"}
@@ -397,6 +452,60 @@ function SortableTh({
   );
 }
 
+// MCPs column for a live agent: the agent's own connection logos, then —
+// for an orchestrator — a "+" and the (dimmed) logos its sub-agents bring in.
+function McpCell({ mcps, subMcps }: { mcps: McpIcon[]; subMcps: McpIcon[] }) {
+  if (mcps.length === 0 && subMcps.length === 0) {
+    return <span className="text-foreground-muted">—</span>;
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {mcps.map((m) => (
+        <McpLogo key={`top:${m.slug}`} icon={m} />
+      ))}
+      {subMcps.length > 0 && (
+        <>
+          <span
+            className="text-foreground-muted px-0.5 text-xs"
+            title="Used by this agent's sub-agents"
+          >
+            +
+          </span>
+          {subMcps.map((m) => (
+            <McpLogo key={`sub:${m.slug}`} icon={m} dimmed />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function McpLogo({ icon, dimmed = false }: { icon: McpIcon; dimmed?: boolean }) {
+  const [failed, setFailed] = useState(false);
+  const title = dimmed ? `${icon.label} (sub-agent)` : icon.label;
+  return (
+    <span
+      title={title}
+      className={`inline-flex h-4 w-4 shrink-0 items-center justify-center overflow-hidden${
+        dimmed ? " opacity-60" : ""
+      }`}
+    >
+      {failed ? (
+        <IconApiConnection size={12} className="text-foreground-muted" />
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={`https://logos.composio.dev/api/${encodeURIComponent(icon.slug.toLowerCase())}`}
+          alt=""
+          aria-hidden
+          className="h-4 w-4 object-contain"
+          onError={() => setFailed(true)}
+        />
+      )}
+    </span>
+  );
+}
+
 function InventoryRow({
   agent,
   bucket,
@@ -421,7 +530,7 @@ function InventoryRow({
         </td>
         <td
           className="text-sentiment-negative px-3 py-2 align-middle text-sm"
-          colSpan={5}
+          colSpan={6}
         >
           {agent.error}
           {agent.detail ? ` — ${agent.detail}` : ""}
@@ -439,6 +548,9 @@ function InventoryRow({
         </td>
         <td className="px-3 py-2 align-middle">
           <StatusCell bucket="pending" />
+        </td>
+        <td className="text-foreground-muted px-3 py-2 align-middle text-sm">
+          —
         </td>
         <td className="text-foreground-muted px-3 py-2 align-middle text-sm">
           —
@@ -503,6 +615,9 @@ function InventoryRow({
       </td>
       <td className="text-foreground-weak px-3 py-2 align-middle font-mono text-sm">
         {shortModel(agent.model)}
+      </td>
+      <td className="px-3 py-2 align-middle">
+        <McpCell mcps={agent.mcps} subMcps={agent.subMcps} />
       </td>
       <td className="text-foreground px-3 py-2 text-right align-middle font-mono text-sm">
         {agent.runs30d.toLocaleString("en-US")}

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
@@ -13,6 +13,7 @@ import { listWorkspaceToolProviders } from "@/lib/mcp-tools";
 import { getRun, type RunRecord } from "@/lib/runs-api";
 import {
   listChildRuns,
+  listChildRunToolNames,
   listStepsForRun,
   listToolCallsForRun,
 } from "@/lib/runs-db";
@@ -23,6 +24,7 @@ import { CopyOutputButton } from "./copy-output-button";
 import { ImproveForm } from "./improve-form";
 import { RunPoller } from "./run-poller";
 import { RunSteps } from "./run-steps";
+import { ToolProviderLogo } from "./tool-provider-logo";
 
 export const dynamic = "force-dynamic";
 
@@ -56,12 +58,14 @@ export default async function RunDetailPage({
   // Tools the agent called during this run (pydantic only; empty otherwise),
   // plus the per-step token usage so we can attribute tokens to the model step
   // that fired each call.
-  const [toolCalls, steps, toolProviderRows, childRuns] = await Promise.all([
-    listToolCallsForRun(workspace.id, run.id),
-    listStepsForRun(workspace.id, run.id),
-    listWorkspaceToolProviders(workspace.id),
-    listChildRuns(workspace.id, run.id),
-  ]);
+  const [toolCalls, steps, toolProviderRows, childRuns, childToolNames] =
+    await Promise.all([
+      listToolCallsForRun(workspace.id, run.id),
+      listStepsForRun(workspace.id, run.id),
+      listWorkspaceToolProviders(workspace.id),
+      listChildRuns(workspace.id, run.id),
+      listChildRunToolNames(workspace.id, run.id),
+    ]);
 
   // tool_name → provider (slug for the logo + label for the tooltip). First
   // row wins on the rare slug collision across providers.
@@ -73,6 +77,21 @@ export default async function RunDetailPage({
         ? (getMcpProvider(t.provider)?.displayName ?? toolkitLabel(t.provider))
         : toolkitLabel(t.provider);
     toolProviders[t.slug] = { slug: t.provider, label };
+  }
+
+  // Which MCPs the sub-agents used: map each tool name the child runs invoked
+  // to its provider, deduped by provider slug. The orchestrator's own "Uses"
+  // row (in the agent layout) only lists its top-level connections, so this
+  // surfaces the providers reached one level down.
+  const subAgentProviders: { slug: string; label: string }[] = [];
+  {
+    const seen = new Set<string>();
+    for (const name of childToolNames) {
+      const p = toolProviders[name];
+      if (!p || seen.has(p.slug)) continue;
+      seen.add(p.slug);
+      subAgentProviders.push(p);
+    }
   }
 
   // Plain-text transcript for the copy button: each step's narration (and the
@@ -114,11 +133,28 @@ export default async function RunDetailPage({
     run.tokensInput !== null && run.tokensOutput !== null
       ? estimateRunCost(run.model, run.tokensInput, run.tokensOutput)
       : null;
-  // Sub-runs this run spawned via trigger_run. Roll their cost up so an
-  // orchestrator's page shows its true total, not just its own (small) cost.
+  // Prompt-cache breakdown lives per-step; sum it for the run header so the
+  // cache hit (read 0.1x) vs. write (1.25x) is visible without scanning steps.
+  const cacheReadTokens = steps.reduce(
+    (sum, s) => sum + (s.cacheReadTokens ?? 0),
+    0,
+  );
+  const cacheWriteTokens = steps.reduce(
+    (sum, s) => sum + (s.cacheWriteTokens ?? 0),
+    0,
+  );
+  const hasCache = cacheReadTokens > 0 || cacheWriteTokens > 0;
+  // Sub-runs this run spawned via trigger_run. Roll their tokens + cost up so
+  // an orchestrator's page shows its true total, not just its own (small) cost.
   const subRunsCost = childRuns.reduce((sum, c) => sum + (c.costUsd ?? 0), 0);
+  const subRunsTokens = childRuns.reduce(
+    (sum, c) => sum + (c.tokensInput ?? 0) + (c.tokensOutput ?? 0),
+    0,
+  );
   const grandTotalCost =
     childRuns.length > 0 ? (estimatedCost ?? 0) + subRunsCost : null;
+  const grandTotalTokens =
+    childRuns.length > 0 ? (totalTokens ?? 0) + subRunsTokens : null;
 
 
   return (
@@ -222,18 +258,63 @@ export default async function RunDetailPage({
               </dd>
             </div>
           )}
-          {grandTotalCost !== null && (
+          {hasCache && (
+            <div className="flex gap-3">
+              <dt className="text-foreground-weak w-24 shrink-0 font-medium">
+                Prompt cache
+              </dt>
+              <dd className="text-foreground">
+                {formatTokens(cacheReadTokens)} read
+                <span className="text-foreground-weak">
+                  {" "}
+                  (0.1×)
+                </span>{" "}
+                · {formatTokens(cacheWriteTokens)} write
+                <span className="text-foreground-weak">
+                  {" "}
+                  (1.25×)
+                </span>
+              </dd>
+            </div>
+          )}
+          {grandTotalTokens !== null && (
             <div className="flex gap-3">
               <dt className="text-foreground-weak w-24 shrink-0 font-medium">
                 Combined
               </dt>
               <dd className="text-foreground">
-                ~{formatCurrency(grandTotalCost)}
+                {formatTokens(grandTotalTokens)} tokens
+                {grandTotalCost !== null && (
+                  <span className="text-foreground-weak">
+                    {" "}
+                    (~{formatCurrency(grandTotalCost)})
+                  </span>
+                )}
                 <span className="text-foreground-weak">
                   {" "}
-                  (this run + {childRuns.length} sub-run
-                  {childRuns.length === 1 ? "" : "s"})
+                  · this run + {childRuns.length} sub-run
+                  {childRuns.length === 1 ? "" : "s"}
                 </span>
+              </dd>
+            </div>
+          )}
+          {subAgentProviders.length > 0 && (
+            <div className="flex gap-3">
+              <dt className="text-foreground-weak w-24 shrink-0 font-medium">
+                Sub-agents use
+              </dt>
+              <dd className="flex flex-wrap items-center gap-1.5">
+                {subAgentProviders.map((p) => (
+                  <span
+                    key={p.slug}
+                    className="bg-surface-raised border-border inline-flex shrink-0 items-center gap-1.5 rounded-md border py-0.5 pl-1 pr-2"
+                  >
+                    <ToolProviderLogo providerSlug={p.slug} title={p.label} />
+                    <span className="text-foreground-weak text-xs">
+                      {p.label}
+                    </span>
+                  </span>
+                ))}
               </dd>
             </div>
           )}
@@ -263,8 +344,8 @@ export default async function RunDetailPage({
       )}
 
       {/* Runs this one spawned via trigger_run (an orchestrator fanning work
-          out to per-source agents). Their cost is rolled into "Combined"
-          above; this lists each one with a link to its own run page. */}
+          out to per-source agents). Each links to its own run page; the Total
+          footer rolls this run + every sub-run into one tokens + cost figure. */}
       {childRuns.length > 0 && (
         <Section title={`Sub-runs (${childRuns.length})`}>
           <ul className="divide-y divide-[var(--color-border-weak)]">
@@ -303,6 +384,28 @@ export default async function RunDetailPage({
                 </li>
               );
             })}
+            {/* Total = this orchestrating run + every sub-run it spawned. */}
+            <li className="flex items-center justify-between gap-3 border-t-2 border-[var(--color-border)] px-1 py-2">
+              <span className="text-foreground font-medium">
+                Total
+                <span className="text-foreground-weak font-normal">
+                  {" "}
+                  (this run + {childRuns.length} sub-run
+                  {childRuns.length === 1 ? "" : "s"})
+                </span>
+              </span>
+              <span className="text-foreground shrink-0 font-medium">
+                {grandTotalTokens !== null && (
+                  <>{formatTokens(grandTotalTokens)} tokens</>
+                )}
+                {grandTotalCost !== null && (
+                  <span className="text-foreground-weak font-normal">
+                    {" "}
+                    (~{formatCurrency(grandTotalCost)})
+                  </span>
+                )}
+              </span>
+            </li>
           </ul>
         </Section>
       )}

--- a/web/src/app/[workspace]/page.tsx
+++ b/web/src/app/[workspace]/page.tsx
@@ -3,10 +3,12 @@ import { notFound, redirect } from "next/navigation";
 
 import { FRAMEWORK_LABELS } from "@/lib/agent-framework";
 import { agentDisplayName } from "@/lib/agent-format";
+import { toolkitLabel } from "@/lib/composio-label";
 import { scanImprovementsForPRs } from "@/lib/improvement-scan";
 import { listPendingCreatesForWorkspace } from "@/lib/improvements-api";
+import { getMcpProvider } from "@/lib/mcp-providers";
 import { meetsMinRole } from "@/lib/rbac";
-import { listAgentSummaries30d } from "@/lib/runs-db";
+import { listAgentSubAgentEdges, listAgentSummaries30d } from "@/lib/runs-db";
 import { getServerSession } from "@/lib/session";
 import { listAgents } from "@/lib/workspace-agents";
 import {
@@ -16,7 +18,11 @@ import {
   getWorkspaceSecretPreview,
 } from "@/lib/workspace";
 
-import { AgentsInventory, type InventoryAgent } from "./agents-inventory";
+import {
+  AgentsInventory,
+  type InventoryAgent,
+  type McpIcon,
+} from "./agents-inventory";
 
 export const dynamic = "force-dynamic";
 
@@ -55,7 +61,62 @@ export default async function WorkspacePage({
   const validNames = agentsResult.ok
     ? agentsResult.agents.filter((a) => a.ok).map((a) => a.spec.name)
     : [];
-  const summaries = await listAgentSummaries30d(workspace.id, validNames);
+  const [summaries, subAgentEdges] = await Promise.all([
+    listAgentSummaries30d(workspace.id, validNames),
+    listAgentSubAgentEdges(workspace.id),
+  ]);
+
+  // Per-agent top-level MCP icons, from each spec's declared connections
+  // (deduped by provider slug). Also drives the orchestrators' sub-agent
+  // rollup below.
+  const mcpsByAgent = new Map<string, McpIcon[]>();
+  if (agentsResult.ok) {
+    for (const a of agentsResult.agents) {
+      if (!a.ok || a.spec.framework !== "pydantic-agentspec") continue;
+      const seen = new Set<string>();
+      const icons: McpIcon[] = [];
+      for (const c of a.spec.connections) {
+        const slug = c.toolkit.trim().toLowerCase();
+        if (!slug || seen.has(slug)) continue;
+        seen.add(slug);
+        icons.push({
+          slug,
+          label:
+            c.source === "native-mcp"
+              ? (getMcpProvider(slug)?.displayName ?? toolkitLabel(slug))
+              : toolkitLabel(slug),
+        });
+      }
+      mcpsByAgent.set(a.spec.name, icons);
+    }
+  }
+
+  // Which sub-agents each orchestrator spawned (parent_run_id graph) → the
+  // union of those sub-agents' MCPs, minus the ones the orchestrator already
+  // declares itself. Lets the list show "top-level MCPs + sub-agent MCPs".
+  const subAgentNamesByParent = new Map<string, Set<string>>();
+  for (const e of subAgentEdges) {
+    let set = subAgentNamesByParent.get(e.parentAgentName);
+    if (!set) {
+      set = new Set<string>();
+      subAgentNamesByParent.set(e.parentAgentName, set);
+    }
+    set.add(e.childAgentName);
+  }
+  const subMcpsByAgent = new Map<string, McpIcon[]>();
+  for (const [parent, children] of subAgentNamesByParent) {
+    const own = new Set((mcpsByAgent.get(parent) ?? []).map((m) => m.slug));
+    const seen = new Set<string>();
+    const icons: McpIcon[] = [];
+    for (const child of children) {
+      for (const m of mcpsByAgent.get(child) ?? []) {
+        if (own.has(m.slug) || seen.has(m.slug)) continue;
+        seen.add(m.slug);
+        icons.push(m);
+      }
+    }
+    if (icons.length > 0) subMcpsByAgent.set(parent, icons);
+  }
 
   // Refresh pending creates' PR status (submitted → pr_opened → merged)
   // so the inventory reflects reality without a separate poll. The
@@ -112,6 +173,8 @@ export default async function WorkspacePage({
             detailHref: `/${workspace.slug}/agents/${encodeURIComponent(a.spec.name)}`,
             frameworkLabel: FRAMEWORK_LABELS[a.spec.framework],
             labels: a.spec.labels,
+            mcps: mcpsByAgent.get(a.spec.name) ?? [],
+            subMcps: subMcpsByAgent.get(a.spec.name) ?? [],
             model: a.spec.model ?? null,
             runs30d: s?.totalRuns30d ?? 0,
             succeeded30d: s?.succeeded30d ?? 0,

--- a/web/src/lib/runs-db.ts
+++ b/web/src/lib/runs-db.ts
@@ -21,6 +21,24 @@ export type ChildRun = {
   createdAt: Date;
 };
 
+// Distinct tool names invoked across every sub-run a given run spawned via
+// trigger_run. The caller maps these to provider slugs (via the workspace
+// tool→provider table) to show which MCPs the sub-agents actually used —
+// the orchestrator's own connection row only lists its top-level MCPs.
+export async function listChildRunToolNames(
+  workspaceId: string,
+  parentRunId: string,
+): Promise<string[]> {
+  const { rows } = await db.query<{ tool_name: string }>(
+    `SELECT DISTINCT tc.tool_name
+       FROM run_tool_call tc
+       JOIN run r ON r.id = tc.run_id
+      WHERE r.workspace_id = $1 AND r.parent_run_id = $2`,
+    [workspaceId, parentRunId],
+  );
+  return rows.map((r) => r.tool_name);
+}
+
 export async function listChildRuns(
   workspaceId: string,
   parentRunId: string,

--- a/web/src/lib/runs-db.ts
+++ b/web/src/lib/runs-db.ts
@@ -39,6 +39,32 @@ export async function listChildRunToolNames(
   return rows.map((r) => r.tool_name);
 }
 
+// Distinct orchestrator → sub-agent edges across the workspace, derived from
+// the parent_run_id graph: an edge means some run of `parentAgentName` spawned
+// (via trigger_run) a run of `childAgentName`. The agents list uses these to
+// show, per orchestrator, which MCPs its sub-agents bring in. Self-edges
+// (an agent triggering itself) are excluded.
+export async function listAgentSubAgentEdges(
+  workspaceId: string,
+): Promise<{ parentAgentName: string; childAgentName: string }[]> {
+  const { rows } = await db.query<{
+    parent_agent: string;
+    child_agent: string;
+  }>(
+    `SELECT DISTINCT parent.agent_name AS parent_agent,
+            child.agent_name AS child_agent
+       FROM run child
+       JOIN run parent ON parent.id = child.parent_run_id
+      WHERE child.workspace_id = $1
+        AND parent.agent_name <> child.agent_name`,
+    [workspaceId],
+  );
+  return rows.map((r) => ({
+    parentAgentName: r.parent_agent,
+    childAgentName: r.child_agent,
+  }));
+}
+
 export async function listChildRuns(
   workspaceId: string,
   parentRunId: string,


### PR DESCRIPTION
Builds on the `parent_run_id` link from #131 to make orchestrator/sub-agent relationships legible across two surfaces.

## Run-detail page
1. **Combined tokens + cost** — a line in the metadata header *and* a Total footer under Sub-runs, both showing *this run + every sub-run* as one tokens + cost figure.
2. **Prompt cache** — a line breaking out cache-**read** (0.1×) vs cache-**write** (1.25×) tokens, summed across the run's steps (previously only in the step-timeline footer).
3. **Sub-agents' MCPs** — a "Sub-agents use" row of the provider logos the sub-agents actually invoked (distinct providers across child runs' tool calls). The layout's existing "Uses" row only lists the orchestrator's own top-level connections. Backed by a new `listChildRunToolNames()` query.

## Agents list
4. **MCPs column** — each agent's own connection logos; for an orchestrator, a "+" then the (dimmed) logos its sub-agents bring in. Sub-agent MCPs come from the `parent_run_id` graph (`listAgentSubAgentEdges()`): the union of connections of every agent it has spawned via `trigger_run`, minus what it already declares.
5. **Filter by MCP** — a dropdown that matches an agent if the chosen provider is in its own *or* its sub-agents' MCPs.

## Verification
- `tsc --noEmit` + `eslint` + `next build` (web) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)