### PR TITLE
Connections page: show provider logos on native-MCP cards

### DIFF
--- a/web/src/app/[workspace]/connections/native-mcp-connections-section.tsx
+++ b/web/src/app/[workspace]/connections/native-mcp-connections-section.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { LocalTime } from "@/components/local-time";
+import { McpProviderLogo } from "@/components/mcp-provider-logo";
 import { Section } from "@/components/section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -102,7 +103,12 @@ export function NativeMcpConnectionsSection({
                 className="flex items-baseline justify-between gap-3 px-3 py-3"
               >
                 <div className="flex min-w-0 flex-col gap-1">
-                  <div className="flex items-baseline gap-2">
+                  <div className="flex items-center gap-2">
+                    <McpProviderLogo
+                      slug={provider.slug}
+                      label={provider.displayName}
+                      size={18}
+                    />
                     <span className="text-foreground text-sm font-medium">
                       {provider.displayName}
                     </span>
@@ -162,7 +168,12 @@ function ProviderRow({
     return (
       <li className="flex items-baseline justify-between gap-3 px-3 py-3">
         <div className="flex min-w-0 flex-col gap-1">
-          <div className="flex items-baseline gap-2">
+          <div className="flex items-center gap-2">
+            <McpProviderLogo
+              slug={provider.slug}
+              label={provider.displayName}
+              size={18}
+            />
             <span className="text-foreground text-sm font-medium">
               {provider.displayName}
             </span>
@@ -205,7 +216,12 @@ function ProviderRow({
   return (
     <li className="flex flex-col gap-3 px-3 py-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex min-w-0 flex-col gap-2">
-        <div className="flex flex-wrap items-baseline gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <McpProviderLogo
+            slug={provider.slug}
+            label={provider.displayName}
+            size={18}
+          />
           <span className="text-foreground text-sm font-medium">
             {provider.displayName}
           </span>

--- a/web/src/components/mcp-provider-logo.tsx
+++ b/web/src/components/mcp-provider-logo.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+
+import { IconApiConnection } from "central-icons";
+
+import { mcpLogoUrl } from "@/lib/mcp-logo";
+
+// Provider logo for a native-MCP / Composio provider, resolved via
+// mcpLogoUrl() (Composio CDN, or our local art for the providers Composio
+// doesn't carry). Falls back to a generic connection glyph if the image is
+// missing or blocked. Client component so the onError fallback works.
+export function McpProviderLogo({
+  slug,
+  label,
+  size = 20,
+}: {
+  slug: string;
+  label?: string;
+  size?: number;
+}) {
+  const [failed, setFailed] = useState(false);
+  return (
+    <span
+      title={label}
+      className="inline-flex shrink-0 items-center justify-center overflow-hidden rounded"
+      style={{ width: size, height: size }}
+    >
+      {failed ? (
+        <IconApiConnection
+          size={Math.round(size * 0.7)}
+          className="text-foreground-muted"
+        />
+      ) : (
+        // Plain <img> (not next/image) — small third-party logo; broken/unknown
+        // slugs swap to the fallback glyph.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={mcpLogoUrl(slug)}
+          alt=""
+          aria-hidden
+          className="h-full w-full object-contain"
+          onError={() => setFailed(true)}
+        />
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
Follow-up to #134. The native-MCP cards on the Connections page rendered provider names as plain text with no logo. This adds the provider logo to all three card states — placeholder **Connect** row, manual-app **Connect** row, and the **connected** row.

- New shared `McpProviderLogo` client component (`@/components/mcp-provider-logo`), backed by the same `mcpLogoUrl()` helper (Composio CDN + local art for Pylon/Dialed/Tembo) with the generic-glyph `onError` fallback.
- Card header rows switched from `items-baseline` to `items-center` so the logo aligns with the name + badges.

## Verification
- `tsc --noEmit` + `eslint` + `next build` (web) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)