### PR TITLE
Fix sidebar nagging Connect when the single-connection fallback applies

### DIFF
--- a/web/src/app/[workspace]/layout.tsx
+++ b/web/src/app/[workspace]/layout.tsx
@@ -4,6 +4,10 @@ import { notFound, redirect } from "next/navigation";
 
 import { AppShell } from "@/components/app-shell";
 import { Toaster } from "@/components/toaster";
+import {
+  buildConnectionSlotSets,
+  isAgentConnectionMissing,
+} from "@/lib/connection-checks";
 import { listConnectionsForUser } from "@/lib/composio-connections";
 import { listNativeConnectionsForUser } from "@/lib/connections";
 import { listSecretConnections } from "@/lib/secret-connections";
@@ -115,25 +119,18 @@ export default async function WorkspaceLayout({
   // workspace's first job is obvious.
   const hasLlmProvider = anthropicKey !== null || openaiKey !== null;
   const switcherList = workspaces.map((w) => ({ slug: w.slug, name: w.name }));
-  // Two parallel slot sets — one per substrate. An agent's
-  // `connections:` entry dispatches by its `source:` field, so a
-  // native-mcp entry checks myNativeSlots and a composio entry
-  // checks mySlots. Mixing them up was the bug that surfaced "Attio
-  // for pipeline-report Connect" in the sidebar even after the user
-  // had authorized Native MCP Attio.
-  const mySlots = new Set(
-    myConnections
-      .filter((c) => c.status === "ACTIVE")
-      .map((c) => `${c.toolkit}:${c.name}`),
+  // Slot inventory + the missing-slot predicate are shared with the run-blocking
+  // pre-flight (findMissingConnections) so the sidebar and the runtime agree —
+  // crucially including the native single-connection fallback (an agent pins a
+  // slot by name, but a user with exactly one connection for that provider runs
+  // fine regardless of the name, so it isn't "missing"). They drifted before:
+  // the sidebar lacked the fallback and nagged "Attio (tembo) Connect" even
+  // though the agent ran.
+  const slotSets = buildConnectionSlotSets(
+    myConnections,
+    myNativeConnections,
+    workspaceSecrets,
   );
-  const myNativeSlots = new Set(
-    myNativeConnections
-      .filter((c) => c.status === "active")
-      .map((c) => `${c.type}:${c.name}`),
-  );
-  // Secrets are workspace-level (one shared key), not per-user — so the
-  // "missing" check is against the workspace's set, keyed by slug alone.
-  const workspaceSecretSlugs = new Set(workspaceSecrets.map((s) => s.slug));
   const missingConnections: {
     toolkit: string;
     name: string;
@@ -148,27 +145,16 @@ export default async function WorkspaceLayout({
         const toolkit = conn.toolkit.trim().toLowerCase();
         const name = conn.name.trim().toLowerCase() || "default";
         if (!toolkit) continue;
-        if (conn.source === "secret") {
-          // Workspace-level: present if any admin set a secret with this slug.
-          if (!workspaceSecretSlugs.has(toolkit)) {
-            missingConnections.push({
-              toolkit,
-              name: "default",
-              agentName: a.spec.name,
-              source: "secret",
-            });
-          }
+        if (!isAgentConnectionMissing(conn.source, toolkit, name, slotSets)) {
           continue;
         }
-        const slots = conn.source === "native-mcp" ? myNativeSlots : mySlots;
-        if (!slots.has(`${toolkit}:${name}`)) {
-          missingConnections.push({
-            toolkit,
-            name,
-            agentName: a.spec.name,
-            source: conn.source,
-          });
-        }
+        missingConnections.push({
+          toolkit,
+          // Secrets are workspace-level (one shared key); normalize the slot.
+          name: conn.source === "secret" ? "default" : name,
+          agentName: a.spec.name,
+          source: conn.source,
+        });
       }
     }
   }

--- a/web/src/lib/connection-checks.ts
+++ b/web/src/lib/connection-checks.ts
@@ -27,12 +27,78 @@ export type MissingConnection = {
   label: string;
 };
 
-function labelFor(toolkit: string, source: AgentConnectionSource): string {
+export function labelFor(
+  toolkit: string,
+  source: AgentConnectionSource,
+): string {
   if (source === "native-mcp") {
     return getMcpProvider(toolkit)?.displayName ?? toolkitLabel(toolkit);
   }
   if (source === "secret") return toolkit;
   return toolkitLabel(toolkit);
+}
+
+// The per-user / per-workspace connection inventory, pre-bucketed into the
+// lookups the missing-slot predicate needs. Built once per page (the sidebar
+// reuses it across every agent) so we don't refetch per agent.
+export type ConnectionSlotSets = {
+  /** `${toolkit}:${name}` for each ACTIVE Composio connection. */
+  composioSlots: Set<string>;
+  /** `${type}:${name}` for each active Native-MCP connection. */
+  nativeSlots: Set<string>;
+  /** Active Native-MCP connection count per provider (single-slot fallback). */
+  nativeCountByProvider: Map<string, number>;
+  /** Slugs of workspace-level secrets. */
+  secretSlugs: Set<string>;
+};
+
+export function buildConnectionSlotSets(
+  composio: { toolkit: string; name: string; status: string }[],
+  native: { type: string; name: string; status: string }[],
+  secrets: { slug: string }[],
+): ConnectionSlotSets {
+  const composioSlots = new Set(
+    composio
+      .filter((c) => c.status === "ACTIVE")
+      .map((c) => `${c.toolkit}:${c.name}`),
+  );
+  const activeNative = native.filter((c) => c.status === "active");
+  const nativeSlots = new Set(activeNative.map((c) => `${c.type}:${c.name}`));
+  const nativeCountByProvider = new Map<string, number>();
+  for (const c of activeNative) {
+    nativeCountByProvider.set(
+      c.type,
+      (nativeCountByProvider.get(c.type) ?? 0) + 1,
+    );
+  }
+  const secretSlugs = new Set(secrets.map((s) => s.slug));
+  return { composioSlots, nativeSlots, nativeCountByProvider, secretSlugs };
+}
+
+// Single source of truth for "is this agent connection set up for the user?".
+// Both the run-blocking pre-flight (findMissingConnections) and the sidebar's
+// "Action needed" list call this, so they can't drift. `toolkit`/`name` must
+// already be trimmed + lowercased (name defaulted to "default").
+//
+// The native-mcp single-connection fallback (mirrors build_native_mcp_toolsets):
+// an agent pins a slot by name, but users routinely have the provider under a
+// different name (e.g. `tembo` vs `default`); when there's exactly one active
+// connection for the provider, the runtime uses it regardless of the declared
+// name — so it isn't "missing".
+export function isAgentConnectionMissing(
+  source: AgentConnectionSource,
+  toolkit: string,
+  name: string,
+  sets: ConnectionSlotSets,
+): boolean {
+  if (source === "secret") return !sets.secretSlugs.has(toolkit);
+  if (source === "native-mcp") {
+    return (
+      !sets.nativeSlots.has(`${toolkit}:${name}`) &&
+      sets.nativeCountByProvider.get(toolkit) !== 1
+    );
+  }
+  return !sets.composioSlots.has(`${toolkit}:${name}`);
 }
 
 export async function findMissingConnections(
@@ -47,22 +113,7 @@ export async function findMissingConnections(
     listNativeConnectionsForUser(workspaceId, actingUserId).catch(() => []),
     listSecretConnections(workspaceId).catch(() => []),
   ]);
-
-  const composioSlots = new Set(
-    composio.filter((c) => c.status === "ACTIVE").map((c) => `${c.toolkit}:${c.name}`),
-  );
-  const activeNative = native.filter((c) => c.status === "active");
-  const nativeSlots = new Set(activeNative.map((c) => `${c.type}:${c.name}`));
-  // How many active native connections the user has per provider. Used for the
-  // single-connection slot-name fallback (mirrors build_native_mcp_toolsets):
-  // an agent pins a slot by name, but users routinely have the provider under a
-  // different name (e.g. `tembo` vs `default`); when there's exactly one, the
-  // runtime uses it regardless of the declared name, so it isn't "missing".
-  const nativeCountByProvider = new Map<string, number>();
-  for (const c of activeNative) {
-    nativeCountByProvider.set(c.type, (nativeCountByProvider.get(c.type) ?? 0) + 1);
-  }
-  const secretSlugs = new Set(secrets.map((s) => s.slug));
+  const sets = buildConnectionSlotSets(composio, native, secrets);
 
   const missing: MissingConnection[] = [];
   const seen = new Set<string>();
@@ -70,18 +121,7 @@ export async function findMissingConnections(
     const toolkit = conn.toolkit.trim().toLowerCase();
     const name = conn.name.trim().toLowerCase() || "default";
     if (!toolkit) continue;
-
-    let isMissing: boolean;
-    if (conn.source === "secret") {
-      isMissing = !secretSlugs.has(toolkit);
-    } else if (conn.source === "native-mcp") {
-      isMissing =
-        !nativeSlots.has(`${toolkit}:${name}`) &&
-        nativeCountByProvider.get(toolkit) !== 1;
-    } else {
-      isMissing = !composioSlots.has(`${toolkit}:${name}`);
-    }
-    if (!isMissing) continue;
+    if (!isAgentConnectionMissing(conn.source, toolkit, name, sets)) continue;
 
     const key = `${conn.source}:${toolkit}:${name}`;
     if (seen.has(key)) continue;


### PR DESCRIPTION
## Symptom
After removing duplicate connections, the sidebar's **Action needed** cards still showed "Attio (tembo) for 3 agents — Connect" and "Pylon (tembo) for day-planner — Connect", even though those agents run fine.

## Cause
The sidebar (workspace `layout.tsx`) reimplemented the missing-connection check with a **strict slot-name match** and was missing the **native single-connection fallback** that the run-blocking pre-flight (`findMissingConnections`) has. So when an agent pins `attio:tembo` but the user has exactly one Attio connection (named e.g. `default`), the runtime uses it and the agent runs — but the sidebar's strict `attio:tembo` lookup missed and kept nagging. The two had drifted (despite a comment claiming "same slot logic").

## Fix
Extract the slot inventory + the missing-slot predicate into shared helpers in `connection-checks.ts`:
- `buildConnectionSlotSets(composio, native, secrets)` — the bucketed lookups (incl. per-provider active-native counts).
- `isAgentConnectionMissing(source, toolkit, name, sets)` — the single predicate, **including** the single-connection fallback.

Both `findMissingConnections` (run pre-flight) and the sidebar now call these, so they can't drift again. The existing single-connection-fallback tests now cover the sidebar path through the shared predicate.

## Verification
- `vitest` (connection-checks) ✓ · `tsc --noEmit` + `eslint` + `next build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)