### PR TITLE
fix(docs): hide version pill outside settings

### DIFF
--- a/web/src/app/[workspace]/docs/docs-nav.tsx
+++ b/web/src/app/[workspace]/docs/docs-nav.tsx
@@ -18,12 +18,10 @@ export function DocsNav({
   workspaceSlug,
   repoUrl,
   starCount,
-  version,
 }: {
   workspaceSlug: string;
   repoUrl: string;
   starCount: number | null;
-  version: string | null;
 }) {
   const base = `/${workspaceSlug}/docs`;
   return (
@@ -57,11 +55,6 @@ export function DocsNav({
           </span>
         )}
       </a>
-      {version && (
-        <span className="text-foreground-muted px-2 pt-1 text-[11px]">
-          {version}
-        </span>
-      )}
     </nav>
   );
 }

--- a/web/src/app/[workspace]/docs/layout.tsx
+++ b/web/src/app/[workspace]/docs/layout.tsx
@@ -1,7 +1,6 @@
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { getAppVersion } from "@/lib/config";
 import { DOCS } from "@/lib/docs-content";
 import { getRepoStars, REPO_URL } from "@/lib/repo-stars";
 import { getServerSession } from "@/lib/session";
@@ -31,7 +30,6 @@ export default async function DocsLayout({
   if (!workspace) notFound();
   if (!(await userIsMember(workspace.id, session.user.id))) notFound();
 
-  const version = getAppVersion();
   const stars = await getRepoStars();
 
   // Lightweight search index over the bundled docs (title + description + a
@@ -62,7 +60,6 @@ export default async function DocsLayout({
             workspaceSlug={workspace.slug}
             repoUrl={REPO_URL}
             starCount={stars}
-            version={version ? `Version ${version}` : null}
           />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-6">{children}</div>


### PR DESCRIPTION
## summary
- remove the running version pill from the in-app docs navigation
- stop fetching/passing `getAppVersion()` in the docs layout
- keep the dedicated `/settings/version` page as the authenticated version surface

## verification
- `git merge --no-edit origin/main` completed without conflicts
- `git diff --check`
- `pnpm exec eslint 'src/app/[workspace]/docs/layout.tsx' 'src/app/[workspace]/docs/docs-nav.tsx'`
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/7b72fe88-6042-4ecc-ab32-87464bf075ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1781575925639579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>