### PR TITLE
Audit timeline: label + detail for every event kind; record who invited

### DIFF
--- a/web/src/app/[workspace]/audit/audit-timeline.tsx
+++ b/web/src/app/[workspace]/audit/audit-timeline.tsx
@@ -533,11 +533,24 @@ function EventSummary({ entry }: { entry: LoadedAuditEntry }) {
         </span>
       );
     case "member.added": {
+      const role = String(p.role ?? "");
+      // Two flavors: an admin adding an existing user (payload has `email`;
+      // the actor column is the admin), or a user accepting their own invite
+      // (the actor column is that user; `invitedBy` records who invited them).
+      if (p.via === "invite_accepted") {
+        return (
+          <span className="text-foreground-weak text-sm">
+            accepted invite{role ? ` as ${role}` : ""}
+            {p.invitedBy ? ` · invited by ${String(p.invitedBy)}` : ""}
+          </span>
+        );
+      }
       const t = p.target as { name?: string; email?: string } | undefined;
-      const who = t?.name ?? t?.email ?? "";
+      const who = String(p.email ?? t?.name ?? t?.email ?? "");
       return (
         <span className="text-foreground-weak text-sm">
-          {who} as {String(p.role ?? "")}
+          {who}
+          {role ? ` as ${role}` : ""}
         </span>
       );
     }
@@ -672,6 +685,28 @@ function EventSummary({ entry }: { entry: LoadedAuditEntry }) {
       return (
         <span className="text-foreground-weak text-sm">
           agents/AGENTS.md + per-framework guides
+        </span>
+      );
+    case "api_key.created":
+    case "api_key.enabled":
+    case "api_key.disabled":
+    case "api_key.deleted":
+      return (
+        <span className="text-foreground-weak text-sm">
+          {String(p.name ?? "")}
+        </span>
+      );
+    case "slack_app.installed":
+      return (
+        <span className="text-foreground-weak text-sm">
+          {p.teamId ? `Slack team ${String(p.teamId)}` : ""}
+        </span>
+      );
+    case "slack.dispatch":
+      return (
+        <span className="text-foreground-weak text-sm">
+          {String(p.slackAppName ?? "")}
+          {p.channel ? ` · ${String(p.channel)}` : ""}
         </span>
       );
     default:
@@ -840,6 +875,27 @@ function humanKind(kind: string): string {
     "member.removed": "Member removed",
     "auth.login": "Signed in",
     "audit.exported": "Audit exported",
+    "api_key.created": "API key created",
+    "api_key.enabled": "API key enabled",
+    "api_key.disabled": "API key disabled",
+    "api_key.deleted": "API key deleted",
+    "agent.version.promoted": "Agent version promoted",
+    "agent.owner.changed": "Agent owner changed",
+    "webhook.created": "Webhook created",
+    "webhook.rotated": "Webhook secret rotated",
+    "webhook.enabled": "Webhook enabled",
+    "webhook.disabled": "Webhook disabled",
+    "webhook.deleted": "Webhook deleted",
+    "secret_connection.set": "Secret connection saved",
+    "secret_connection.rotated": "Secret connection rotated",
+    "secret_connection.removed": "Secret connection removed",
+    "native_oauth_client.set": "MCP OAuth app saved",
+    "native_oauth_client.removed": "MCP OAuth app removed",
+    "native_mcp_provider.enabled": "MCP provider enabled",
+    "native_mcp_provider.disabled": "MCP provider disabled",
+    "slack_app.installed": "Slack app installed",
+    "slack.dispatch": "Run launched from Slack",
+    "improvement.dismissed": "Pending agent dismissed",
   };
   return map[kind] ?? kind;
 }

--- a/web/src/lib/invitations.ts
+++ b/web/src/lib/invitations.ts
@@ -168,20 +168,33 @@ export async function resolvePendingInvitesForUser(
   const client = await db.connect();
   try {
     await client.query("BEGIN");
+    // Join the inviter (invited_by) so the acceptance audit event can record
+    // *who* invited this user — otherwise that link is lost once the invite
+    // row is marked accepted.
     const { rows } = await client.query<{
       id: string;
       workspace_id: string;
       role: string;
+      invited_by: string | null;
+      invited_by_name: string | null;
+      invited_by_email: string | null;
     }>(
-      `SELECT id, workspace_id, role FROM workspace_invitation
-        WHERE lower(email) = $1 AND accepted_at IS NULL
-        FOR UPDATE`,
+      `SELECT i.id, i.workspace_id, i.role, i.invited_by,
+              u.name AS invited_by_name, u.email AS invited_by_email
+         FROM workspace_invitation i
+         LEFT JOIN "user" u ON u.id = i.invited_by
+        WHERE lower(i.email) = $1 AND i.accepted_at IS NULL
+        FOR UPDATE OF i`,
       [e],
     );
     let joined = 0;
     // Workspaces where a NEW membership row was actually created (ON CONFLICT
     // skips re-runs) — audited after the commit so we don't log on rollback.
-    const added: { workspaceId: string; role: string }[] = [];
+    const added: {
+      workspaceId: string;
+      role: string;
+      invitedBy: string | null;
+    }[] = [];
     for (const inv of rows) {
       const ins = await client.query(
         `INSERT INTO workspace_member (workspace_id, user_id, role)
@@ -196,14 +209,19 @@ export async function resolvePendingInvitesForUser(
         [inv.id, userId],
       );
       if ((ins.rowCount ?? 0) > 0) {
-        added.push({ workspaceId: inv.workspace_id, role: inv.role });
+        added.push({
+          workspaceId: inv.workspace_id,
+          role: inv.role,
+          invitedBy: inv.invited_by_name ?? inv.invited_by_email ?? null,
+        });
       }
       joined += 1;
     }
     await client.query("COMMIT");
 
     // Best-effort audit (post-commit, off the transaction client). The user
-    // accepting their own invite is the actor.
+    // accepting their own invite is the actor; the payload records who invited
+    // them so the chain (invited by X → accepted) is preserved.
     for (const a of added) {
       try {
         await writeAuditEvent({
@@ -214,7 +232,11 @@ export async function resolvePendingInvitesForUser(
           targetType: "member",
           targetId: userId,
           agentName: null,
-          payload: { role: a.role, via: "invite_accepted" },
+          payload: {
+            role: a.role,
+            via: "invite_accepted",
+            ...(a.invitedBy ? { invitedBy: a.invitedBy } : {}),
+          },
         });
       } catch (e) {
         console.error("[audit] member.added write failed:", e);


### PR DESCRIPTION
Follow-up to #154, addressing the reported gap that **"member invited doesn't say who invited"** and a request to audit *all* event kinds for sufficient detail.

I inventoried every `writeAuditEvent` call site (~56 kinds) against the renderer and found two gap classes:

## 1. Missing labels (rendered as raw dotted strings)
~20 kinds had no `humanKind` label, so the event column literally showed `api_key.created`, `webhook.rotated`, `native_mcp_provider.enabled`, `secret_connection.set`, `native_oauth_client.set`, `agent.version.promoted`, `agent.owner.changed`, `slack_app.installed`, `slack.dispatch`, `improvement.dismissed`. Added human labels for all.

## 2. Missing detail
`api_key.*` (carries `name`), `slack_app.installed` (`teamId`), and `slack.dispatch` (`slackAppName`/`channel`) had no `EventSummary` case, so they showed no detail line despite having useful payload. Added cases.

## 3. "Who invited" (the reported issue)
The real gap was `member.added` **on invite-acceptance**: the actor is the *invitee*, and the original inviter was lost (`workspace_invitation.invited_by` was never carried into the event).
- `resolvePendingInvitesForUser` now joins `invited_by → name/email` and records `payload.invitedBy`.
- The `member.added` summary renders **"accepted invite as `<role>` · invited by `<X>`"**.
- Also fixed the `member.added` summary, which read a `target` field that neither writer sets (it showed " as operator" with no name) — it now uses `email` for admin-adds and the accepted-invite shape otherwise.
- `member.invited` already attributes the inviter via the actor column (the inviter *is* the actor).

## Verification
- `tsc --noEmit` clean, `eslint` 0 errors, **101 tests pass**.
- `member.added` payload change is forward-only (new acceptances carry `invitedBy`); existing rows simply omit it and render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)