### PR TITLE
Redirect signed-out deep links to sign-in instead of 404

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -43,15 +43,28 @@ function describeAuthError(raw: string): string {
   return `Sign-in failed (${raw}). If this instance is invite-only, ask an admin to invite your email.`;
 }
 
+// `next` carries the path a signed-out visitor was originally headed to (set
+// by the proxy auth gate). Only accept a same-origin absolute path — reject
+// protocol-relative (`//host`) and backslash tricks so it can't become an
+// open redirect to another site.
+function safeNext(raw?: string | string[]): string | null {
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (!v || !v.startsWith("/") || v.startsWith("//") || v.startsWith("/\\")) {
+    return null;
+  }
+  return v;
+}
+
 export default async function Home({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string | string[] }>;
+  searchParams: Promise<{ error?: string | string[]; next?: string | string[] }>;
 }) {
   const session = await getServerSession();
   const instanceName = await getInstanceName();
-  const { error } = await searchParams;
+  const { error, next } = await searchParams;
   const errorCode = Array.isArray(error) ? error[0] : error;
+  const dest = safeNext(next);
 
   if (session) {
     // Auto-join any pending workspace invites for this account before
@@ -61,6 +74,10 @@ export default async function Home({
       await resolvePendingInvitesForUserId(session.user.id);
     } catch (e) {
       console.error("[invites] resolve on landing failed:", e);
+    }
+    // A returning deep-link visitor lands back where they were headed.
+    if (dest && dest !== "/") {
+      redirect(dest);
     }
     const workspaces = await listWorkspacesForUser(session.user.id);
     if (workspaces.length === 0) {
@@ -82,7 +99,10 @@ export default async function Home({
           </CardTitle>
         </CardHeader>
         <CardContent className="px-1 pb-1">
-          <SignInButtons providers={providers} />
+          <SignInButtons
+            providers={providers}
+            callbackURL={dest ? `/?next=${encodeURIComponent(dest)}` : "/"}
+          />
         </CardContent>
       </Card>
     ) : (

--- a/web/src/components/sign-in-buttons.tsx
+++ b/web/src/components/sign-in-buttons.tsx
@@ -11,7 +11,16 @@ import { Button } from "@/components/ui/button";
 // (Microsoft Entra, OIDC) go through signIn.oauth2.
 type Provider = { id: string; label: string; kind: "social" | "oauth2" };
 
-export function SignInButtons({ providers }: { providers: Provider[] }) {
+export function SignInButtons({
+  providers,
+  // Where better-auth sends the user after a successful OAuth round-trip.
+  // Defaults to the landing page; a deep-link visitor passes the path they
+  // were headed to so they return there after signing in.
+  callbackURL = "/",
+}: {
+  providers: Provider[];
+  callbackURL?: string;
+}) {
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -24,11 +33,11 @@ export function SignInButtons({ providers }: { providers: Provider[] }) {
         p.kind === "social"
           ? await authClient.signIn.social({
               provider: p.id as "google",
-              callbackURL: "/",
+              callbackURL,
             })
           : await authClient.signIn.oauth2({
               providerId: p.id,
-              callbackURL: "/",
+              callbackURL,
             });
       if (result.error) {
         setError(result.error.message ?? "Sign-in failed.");

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,16 +1,49 @@
+import { getSessionCookie } from "better-auth/cookies";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// Surface the request path to server components via an `x-pathname` header.
-// Next doesn't expose the current pathname to a server layout otherwise, and
-// the [workspace] layout needs it to redirect a renamed workspace's old slug
-// to its current one while preserving the rest of the path
-// (e.g. /old/agents/x → /new/agents/x). This is the only job here — no auth,
-// no DB — so it stays cheap on every request. Auth + RBAC continue to live in
-// the layouts and server actions.
+// Routes that don't require a signed-in session:
+//   /            — the sign-in landing
+//   /mcp         — MCP server, authed by `Authorization: Bearer tas_…`
+//   /for-agents  — native-MCP tool reference, authed by a signed bearer token
+// Everything else under the matcher (/<workspace>/…, /onboarding, /settings)
+// is session-gated.
+function isPublicPath(pathname: string): boolean {
+  return (
+    pathname === "/" ||
+    pathname === "/mcp" ||
+    pathname === "/for-agents" ||
+    pathname.startsWith("/for-agents/")
+  );
+}
+
+// Two jobs:
+//
+//  1. Auth gate. Without this, a signed-out visitor following a deep link
+//     (e.g. /acme/audit) reached a layout/page that gates with notFound(),
+//     so they got a 404 — which reads as "broken link", not "please sign in".
+//     We redirect them to the sign-in landing instead, preserving where they
+//     were headed in `?next=` so they return there after signing in. This is
+//     an optimistic check on the session *cookie* (no DB hit, edge-safe); the
+//     layouts/actions still do the authoritative session + RBAC checks.
+//
+//  2. Surface the request path to server components via an `x-pathname`
+//     header — Next doesn't otherwise expose the pathname to a server layout,
+//     and the [workspace] layout needs it to redirect a renamed workspace's
+//     old slug to its current one (e.g. /old/agents/x → /new/agents/x).
 export function proxy(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+
+  if (!isPublicPath(pathname) && !getSessionCookie(request)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
+    url.search = "";
+    url.searchParams.set("next", pathname + search);
+    return NextResponse.redirect(url);
+  }
+
   const headers = new Headers(request.headers);
-  headers.set("x-pathname", request.nextUrl.pathname);
+  headers.set("x-pathname", pathname);
   return NextResponse.next({ request: { headers } });
 }
 


### PR DESCRIPTION
## Bug
A signed-out visitor following a deep link (e.g. `/acme/audit`, `/acme/agents/x/runs/123`) got a **404** instead of the sign-in page. There's no auth middleware — every layout/page gates with `getServerSession()` + `notFound()`, so "not signed in" rendered as "wrong URL".

## Fix
Add an auth gate to `proxy.ts` (this Next version's renamed middleware), which already runs on all app routes:
- Optimistic, **edge-safe session-cookie check** (`getSessionCookie` from `better-auth/cookies` — no DB hit). On a protected route with no session, redirect to `/` with the intended path in `?next=`.
- **Public routes stay open**: `/` (sign-in), `/mcp` and `/for-agents` (both authed by `Authorization: Bearer`, not a session cookie — gating them would break the MCP server and CAP's tool reference).
- Layouts/server actions keep doing the authoritative session + RBAC checks; this is just the front gate.

**Return to the deep link after login:** the landing page honors `?next=` (validated to a same-origin absolute path — rejects `//host` and backslash tricks, so no open redirect) and forwards there once signed in. The OAuth `callbackURL` routes back through `/` so invite-resolution still runs, then forwards to the deep link. `SignInButtons` gained an optional `callbackURL`.

## Flow
`/acme/audit` (signed out) → `302 /?next=%2Facme%2Faudit` → sign in → back to `/acme/audit`.

## Verification
- `tsc` clean, `eslint` 0 errors, 101 tests pass.
- The edge-middleware import (`better-auth/cookies`) is validated by CI's `web` build job. Runtime click-through (signed-out deep link → sign-in → return) is the remaining manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)