### PR TITLE
Tools page: admins see all connections' tools, not just their own

### DIFF
--- a/web/src/app/[workspace]/tools/page.tsx
+++ b/web/src/app/[workspace]/tools/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { listToolsForUser } from "@/lib/mcp-tools";
+import { listToolsForUser, listToolsForWorkspace } from "@/lib/mcp-tools";
 import { getServerSession } from "@/lib/session";
-import { getWorkspaceBySlug } from "@/lib/workspace";
+import { getWorkspaceBySlug, getWorkspaceRole } from "@/lib/workspace";
 
 import { ToolsTable } from "./tools-table";
 
@@ -35,7 +35,13 @@ export default async function ToolsPage({
   const workspace = await getWorkspaceBySlug(slug);
   if (!workspace) notFound();
 
-  const tools = await listToolsForUser(workspace.id, session.user.id);
+  // Admins see the whole workspace's catalog (every member's active
+  // connections); everyone else sees only the tools from their own.
+  const role = await getWorkspaceRole(workspace.id, session.user.id);
+  const isAdmin = role === "workspace_admin";
+  const tools = isAdmin
+    ? await listToolsForWorkspace(workspace.id)
+    : await listToolsForUser(workspace.id, session.user.id);
 
   // URL params seed the table's initial filter state. Connections
   // rows link here with ?source=…&provider=…&connection=… to land
@@ -58,7 +64,13 @@ export default async function ToolsPage({
           Tools
         </h1>
         <p className="text-foreground-weak text-base">
-          Every MCP tool you&apos;ve authorized in{" "}
+          {isAdmin ? (
+            <>
+              Every MCP tool authorized across all members&apos; connections in{" "}
+            </>
+          ) : (
+            <>Every MCP tool you&apos;ve authorized in </>
+          )}
           <span className="text-foreground font-medium">{workspace.name}</span>,
           across Composio and native MCP providers. Tools are cached on
           connect; refresh a connection from{" "}

--- a/web/src/lib/mcp-tools.ts
+++ b/web/src/lib/mcp-tools.ts
@@ -105,6 +105,48 @@ export async function listToolsForUser(
 }
 
 /**
+ * Every tool across the whole workspace — the union of all members' active
+ * connections, not just one user's. Powers the admin view of the Tools tab,
+ * so a workspace admin can see the full catalog agents can reach without
+ * having to connect every provider themselves.
+ *
+ * Same active-connection guard as listToolsForUser (orphans from disconnects/
+ * renames are filtered out), but correlated on the tool row's own owner
+ * (t.user_id) rather than a fixed acting user. Deduped by
+ * (source, provider, connection_name, slug) via DISTINCT ON, so the same tool
+ * reached through two members' identically-named connections shows once;
+ * differently-named connections still show separately. Same leading sort as
+ * listToolsForUser so the Tools table groups identically.
+ */
+export async function listToolsForWorkspace(
+  workspaceId: string,
+): Promise<McpTool[]> {
+  const { rows } = await db.query<Row>(
+    `SELECT DISTINCT ON (t.source, t.provider, t.connection_name, t.slug)
+            ${COLUMNS}
+       FROM workspace_mcp_tool t
+      WHERE t.workspace_id = $1
+        AND (
+          (t.source = 'native-mcp' AND EXISTS (
+            SELECT 1 FROM workspace_connection c
+             WHERE c.workspace_id = t.workspace_id AND c.user_id = t.user_id
+               AND c.type = t.provider AND c.name = t.connection_name
+               AND c.status = 'active'))
+          OR
+          (t.source = 'composio' AND EXISTS (
+            SELECT 1 FROM workspace_composio_connection cc
+             WHERE cc.workspace_id = t.workspace_id AND cc.user_id = t.user_id
+               AND cc.toolkit_slug = t.provider AND cc.name = t.connection_name
+               AND cc.status = 'ACTIVE'))
+        )
+      ORDER BY t.source ASC, t.provider ASC, t.connection_name ASC, t.slug ASC,
+               t.refreshed_at DESC`,
+    [workspaceId],
+  );
+  return rows.map(rowToTool);
+}
+
+/**
  * Distinct tool-slug → (source, provider) across the whole workspace's tool
  * cache, for resolving a run's recorded tool_name to the provider whose logo
  * to show. Workspace-wide (not per-user) because a tool slug maps to the same


### PR DESCRIPTION
## Ask
Workspace admins should see **all** tools from **all** connections in the workspace, not just tools from their own connections.

## Change
- New `listToolsForWorkspace(workspaceId)` in `lib/mcp-tools.ts` — the union of every member's active connections, deduped by `(source, provider, connection_name, slug)` via `DISTINCT ON` (so the same tool reached through two members' identically-named connections shows once; differently-named ones still show separately). Same active-connection `EXISTS` guard as `listToolsForUser` (orphaned rows from disconnects/renames filtered out) and the same leading sort, so the table groups identically.
- The Tools page branches on role: `workspace_admin` → workspace-wide list; everyone else → the existing per-user list. Page copy updated to reflect the scope.

## Deliberately NOT changed (kept per-user)
`/api/v1/tools` (per-API-key user), `/for-agents/*` (per-agent token), the MCP `list_tools` tool, and the Connections pages (per-connection-owner). Only the human-facing Tools page gets admin-sees-all.

## Verification
`tsc` + `eslint` clean. (Visual check against an instance with multiple members' connections is the manual step.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)