### PR TITLE
Fix connection detail URLs: use "~" delimiter, not ":"

### DIFF
--- a/web/src/app/[workspace]/connections/connection-ref.ts
+++ b/web/src/app/[workspace]/connections/connection-ref.ts
@@ -19,19 +19,22 @@ import {
 
 // One Connections list/view/edit surface spans three record types. We address
 // them through a single composite ref encoded into the [id] route segment:
-//   composio:<uuid> | native:<uuid> | secret:<slug>
-// (":" is path-safe; uuids and secret slugs [a-z0-9_-] are too.)
+//   composio~<uuid> | native~<uuid> | secret~<slug>
+// The separator is "~" (RFC 3986 unreserved — never percent-encoded, never
+// special in a path). A ":" reads as a scheme/port to some routers and proxies
+// and broke the [id] route; "~" appears in neither uuids, kinds, nor secret
+// slugs ([a-z0-9_-]), so splitting on the first one is unambiguous.
 
 export type ConnectionKind = "composio" | "native" | "secret";
 
 export type ConnectionRef = { kind: ConnectionKind; key: string };
 
 export function encodeConnectionRef(kind: ConnectionKind, key: string): string {
-  return `${kind}:${key}`;
+  return `${kind}~${key}`;
 }
 
 export function parseConnectionRef(raw: string): ConnectionRef | null {
-  const i = raw.indexOf(":");
+  const i = raw.indexOf("~");
   if (i <= 0) return null;
   const kind = raw.slice(0, i);
   const key = raw.slice(i + 1);

--- a/web/src/app/[workspace]/connections/secrets-actions.ts
+++ b/web/src/app/[workspace]/connections/secrets-actions.ts
@@ -82,7 +82,7 @@ export async function setSecretConnectionAction(
   revalidatePath(`/${slugRaw}/connections`, "layout");
   revalidatePath(`/${slugRaw}`, "layout");
   // Land on the secret's connection view (works for both add and rotate).
-  redirect(`/${slugRaw}/connections/secret:${name}`);
+  redirect(`/${slugRaw}/connections/secret~${name}`);
 }
 
 /** Remove a Secret entirely. */

--- a/web/src/app/api/connections/composio/callback/route.ts
+++ b/web/src/app/api/connections/composio/callback/route.ts
@@ -193,7 +193,7 @@ export async function GET(request: NextRequest) {
 
   // Land on the new connection's detail view.
   const ok = new URL(
-    `/${payload.workspaceSlug}/connections/composio:${saved.id}`,
+    `/${payload.workspaceSlug}/connections/composio~${saved.id}`,
     getPublicOrigin(),
   );
   ok.searchParams.set("result", "ok");

--- a/web/src/app/api/connections/native/[provider]/authorize/route.ts
+++ b/web/src/app/api/connections/native/[provider]/authorize/route.ts
@@ -152,7 +152,7 @@ async function connectSelfKey(
 
   // Land on the new connection's detail view.
   const target = new URL(
-    `/${workspace.slug}/connections/native:${saved.id}`,
+    `/${workspace.slug}/connections/native~${saved.id}`,
     getPublicOrigin(),
   );
   target.searchParams.set("result", "ok");

--- a/web/src/app/api/connections/native/[provider]/callback/route.ts
+++ b/web/src/app/api/connections/native/[provider]/callback/route.ts
@@ -273,7 +273,7 @@ export async function GET(
 
   // Land on the new connection's detail view.
   const ok = new URL(
-    `/${state.workspaceSlug}/connections/native:${saved.id}`,
+    `/${state.workspaceSlug}/connections/native~${saved.id}`,
     getPublicOrigin(),
   );
   ok.searchParams.set("result", "ok");


### PR DESCRIPTION
**Bug (live on the dogfood instance):** clicking a connection row navigated to `/connections/native:<uuid>` and broke. A `:` in a path segment reads as a scheme/port separator to some routers/proxies, so the `[id]` route didn't resolve.

**Fix:** switch the composite-ref delimiter from `:` to `~`. `~` is RFC 3986 *unreserved* (never percent-encoded, never special in a path) and appears in none of the parts (uuids, the kind keywords, or secret slugs `[a-z0-9_-]`), so splitting on the first `~` stays unambiguous. Refs are now `native~<uuid>` / `composio~<uuid>` / `secret~<slug>`.

Touches `connection-ref.ts` (encode/parse) and the four hardcoded redirect targets (native + Composio OAuth callbacks, self-key authorize, secret set/rotate).

`tsc` clean. Follow-up to #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)