### PR TITLE
New connection: pick an option first, then its form

### DIFF
--- a/web/src/app/[workspace]/connections/new/native-connect-form.tsx
+++ b/web/src/app/[workspace]/connections/new/native-connect-form.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+// Connect a single DCR / self-key native-MCP provider. The provider is fixed
+// (the picker already chose it), so this is just an optional connection-name
+// slot + Connect, which jumps into the OAuth-discovery flow.
+export function NativeConnectForm({
+  workspaceSlug,
+  providerSlug,
+  selfKey = false,
+}: {
+  workspaceSlug: string;
+  providerSlug: string;
+  selfKey?: boolean;
+}) {
+  const [name, setName] = useState("default");
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const params = new URLSearchParams({ workspace: workspaceSlug });
+    const trimmed = name.trim().toLowerCase();
+    if (trimmed && trimmed !== "default") params.set("name", trimmed);
+    window.location.href = `/api/connections/native/${providerSlug}/authorize?${params.toString()}`;
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      {!selfKey && (
+        <div className="grid gap-1.5">
+          <Label htmlFor="native-name" className="text-sm">
+            Connection name
+          </Label>
+          <Input
+            id="native-name"
+            name="name"
+            required
+            pattern="[a-z0-9_-]+"
+            autoComplete="off"
+            spellCheck={false}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="default"
+          />
+          <p className="text-foreground-muted text-sm">
+            Distinguishes multiple accounts for the same provider (e.g.{" "}
+            <code>work</code>, <code>personal</code>).
+          </p>
+        </div>
+      )}
+      <div>
+        <Button type="submit" variant="primary">
+          Connect →
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/app/[workspace]/connections/new/page.tsx
+++ b/web/src/app/[workspace]/connections/new/page.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { IconApiConnection } from "central-icons";
 
 import { BackLink } from "@/components/back-link";
+import { McpProviderLogo } from "@/components/mcp-provider-logo";
 import { Button } from "@/components/ui/button";
-import {
-  listAllToolkits,
-  type CatalogToolkit,
-} from "@/lib/composio";
+import { listAllToolkits, type CatalogToolkit } from "@/lib/composio";
 import { listMcpProviders, type McpProvider } from "@/lib/mcp-providers";
 import {
   getProviderEnableMap,
@@ -21,23 +22,26 @@ import {
   getWorkspaceSecretPreview,
 } from "@/lib/workspace";
 
-import { AddNativeMcpConnectionForm } from "../add-native-mcp-connection-form";
 import { ConnectNativeMcpAppForm } from "../connect-native-mcp-app-form";
 import { ToolkitPicker } from "../toolkit-picker";
+import { NativeConnectForm } from "./native-connect-form";
 import { SecretAddForm } from "./secret-add-form";
 
 export const dynamic = "force-dynamic";
 
-// One screen to add any kind of connection: a native-MCP provider (DCR or a
-// manual BYO-app provider), a Composio toolkit, or a workspace secret. Connects
-// are always for the acting user (the list hides "+ New" when an admin is
-// viewing another member).
+// Add a connection in two steps: pick what to connect (a native-MCP provider,
+// Composio, or a secret), then fill in that option's form. The picker is the
+// default view; ?provider=<slug> or ?type=composio|secret drills into a form.
 export default async function NewConnectionPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ workspace: string }>;
+  searchParams: Promise<{ provider?: string; type?: string }>;
 }) {
   const { workspace: slug } = await params;
+  const { provider: providerParam, type: typeParam } = await searchParams;
+
   const session = await getServerSession();
   if (!session) notFound();
   const workspace = await getWorkspaceBySlug(slug);
@@ -51,7 +55,6 @@ export default async function NewConnectionPage({
     getProviderEnableMap(workspace.id),
     getWorkspaceSecretPreview(workspace.id, "composio_api_key"),
   ]);
-
   const instancesByProvider = new Map<
     string,
     { instance: string; label: string | null }[]
@@ -61,133 +64,98 @@ export default async function NewConnectionPage({
     arr.push({ instance: c.instance, label: c.label });
     instancesByProvider.set(c.provider, arr);
   }
-
   const catalog = listMcpProviders();
-  const isVisible = (p: McpProvider): boolean => {
-    if (!isProviderAdminEnabled(p, enableMap)) return false;
-    if (p.authMode === "manual") {
-      return (instancesByProvider.get(p.slug)?.length ?? 0) > 0;
-    }
-    return true;
-  };
-  // DCR + self-key (named-slot) providers feed the native picker; self-key
-  // (Tembo) is a single "default" slot so it joins the dropdown too.
-  const addableProviders = catalog.filter(
-    (p) => p.authMode !== "manual" && isVisible(p),
-  );
-  // Manual providers: connectable instances, or a "needs setup" note.
-  const manualProviders = catalog.filter((p) => p.authMode === "manual");
 
-  // Composio toolkit catalog only when a key is configured.
-  const toolkitCatalog: CatalogToolkit[] = composioPreview
-    ? await getWorkspaceSecretPlaintext(workspace.id, "composio_api_key")
-        .then((k) => listAllToolkits(k))
-        .catch(() => [])
-    : [];
+  // ── A specific option's form ────────────────────────────────────────
+  if (providerParam || typeParam) {
+    const back = (
+      <BackLink
+        href={`/${workspace.slug}/connections/new`}
+        label="New connection"
+      />
+    );
 
-  return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col gap-8 px-6 py-8">
-      <div className="flex flex-col gap-2">
-        <BackLink href={`/${workspace.slug}/connections`} label="Connections" />
-        <h1 className="text-foreground-title text-2xl font-bold tracking-tight">
-          New connection
-        </h1>
-        <p className="text-foreground-weak text-base">
-          Authorize a provider over OAuth, or store an API-key secret. OAuth
-          connections are yours; secrets are shared across the workspace.
-        </p>
-      </div>
-
-      <hr className="border-[var(--color-border-weak)]" />
-
-      {/* Native MCP — DCR + self-key */}
-      <section className="flex flex-col gap-3">
-        <div className="flex flex-col gap-0.5">
-          <h2 className="text-foreground font-medium">Native MCP</h2>
-          <p className="text-foreground-muted text-sm">
-            Connect directly to a provider&apos;s official MCP server with
-            TAS-managed OAuth.
-          </p>
-        </div>
-        {addableProviders.length > 0 ? (
-          <AddNativeMcpConnectionForm
-            workspaceSlug={workspace.slug}
-            catalog={addableProviders}
-          />
-        ) : (
-          <p className="text-foreground-muted text-sm">
-            No native-MCP providers are enabled.{" "}
-            {isAdmin && (
-              <Link
-                href={`/${workspace.slug}/connections/providers`}
-                className="text-foreground underline underline-offset-2"
-              >
-                Enable some →
-              </Link>
-            )}
-          </p>
-        )}
-        {manualProviders.map((p) => {
-          const instances = instancesByProvider.get(p.slug) ?? [];
-          return (
-            <div
-              key={p.slug}
-              className="border-border bg-surface flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
-            >
-              <span className="text-foreground text-sm font-medium">
-                {p.displayName}
-              </span>
-              {instances.length > 0 ? (
-                <ConnectNativeMcpAppForm
-                  workspaceSlug={workspace.slug}
-                  providerSlug={p.slug}
-                  instances={instances}
-                />
-              ) : isAdmin ? (
+    if (providerParam) {
+      const provider = catalog.find((p) => p.slug === providerParam);
+      if (!provider || !isProviderAdminEnabled(provider, enableMap)) notFound();
+      const instances = instancesByProvider.get(provider.slug) ?? [];
+      return (
+        <FormShell
+          back={back}
+          title={`Connect ${provider.displayName}`}
+          logo={
+            <McpProviderLogo
+              slug={provider.slug}
+              label={provider.displayName}
+              size={24}
+            />
+          }
+        >
+          {provider.authMode === "manual" ? (
+            instances.length > 0 ? (
+              <ConnectNativeMcpAppForm
+                workspaceSlug={workspace.slug}
+                providerSlug={provider.slug}
+                instances={instances}
+              />
+            ) : isAdmin ? (
+              <p className="text-foreground-weak text-sm">
+                {provider.displayName} needs an OAuth app first.{" "}
                 <Link
                   href={`/${workspace.slug}/connections/providers`}
-                  className="text-foreground-weak hover:text-foreground text-sm underline underline-offset-2"
+                  className="text-foreground underline underline-offset-2"
                 >
-                  Configure OAuth app →
+                  Configure it on Manage providers →
                 </Link>
-              ) : (
-                <span className="text-foreground-muted text-sm">
-                  Needs an admin to set up
-                </span>
-              )}
-            </div>
-          );
-        })}
-      </section>
+              </p>
+            ) : (
+              <p className="text-foreground-muted text-sm">
+                {provider.displayName} needs an admin to set up its OAuth app
+                first.
+              </p>
+            )
+          ) : (
+            <NativeConnectForm
+              workspaceSlug={workspace.slug}
+              providerSlug={provider.slug}
+              selfKey={provider.authMode === "self-key"}
+            />
+          )}
+        </FormShell>
+      );
+    }
 
-      {/* Composio */}
-      <section className="flex flex-col gap-3">
-        <div className="flex flex-col gap-0.5">
-          <h2 className="text-foreground font-medium">Composio</h2>
-          <p className="text-foreground-muted text-sm">
-            Authorize a toolkit through Composio&apos;s hosted OAuth.
-          </p>
-        </div>
-        {composioPreview ? (
-          <form
-            method="get"
-            action="/api/connections/composio/authorize"
-            className="bg-surface border-border flex flex-col gap-2 rounded-lg border border-dashed px-3 py-3"
-          >
-            <input type="hidden" name="workspace" value={workspace.slug} />
-            <div className="flex flex-wrap items-end gap-2">
-              <div className="flex min-w-[180px] flex-1 flex-col gap-1">
-                <label className="text-foreground-weak text-sm font-medium uppercase tracking-wide">
+    if (typeParam === "composio") {
+      const toolkitCatalog: CatalogToolkit[] = composioPreview
+        ? await getWorkspaceSecretPlaintext(workspace.id, "composio_api_key")
+            .then((k) => listAllToolkits(k))
+            .catch(() => [])
+        : [];
+      return (
+        <FormShell
+          back={back}
+          title="Connect a Composio toolkit"
+          logo={<IconApiConnection size={24} className="text-foreground-muted" />}
+        >
+          {composioPreview ? (
+            <form
+              method="get"
+              action="/api/connections/composio/authorize"
+              className="flex flex-col gap-4"
+            >
+              <input type="hidden" name="workspace" value={workspace.slug} />
+              <div className="grid gap-1.5">
+                <label className="text-foreground-weak text-sm font-medium">
                   Toolkit
                 </label>
                 <ToolkitPicker fieldName="toolkit" catalog={toolkitCatalog} />
               </div>
-              <div className="flex min-w-[140px] flex-1 flex-col gap-1">
+              <div className="grid gap-1.5">
                 <label
                   htmlFor="composio-name"
-                  className="text-foreground-weak text-sm font-medium uppercase tracking-wide"
+                  className="text-foreground-weak text-sm font-medium"
                 >
-                  Name
+                  Connection name
                 </label>
                 <input
                   id="composio-name"
@@ -200,41 +168,169 @@ export default async function NewConnectionPage({
                   className="bg-input border-border text-foreground rounded-md border px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring-color,#009eff)]"
                 />
               </div>
-              <Button type="submit" variant="primary" size="small">
-                Connect
-              </Button>
-            </div>
-          </form>
-        ) : (
-          <p className="text-foreground-muted text-sm">
-            Composio needs a workspace API key.{" "}
-            <Link
-              href={`/${workspace.slug}/settings/composio`}
-              className="text-foreground underline underline-offset-2"
-            >
-              Set it in Settings →
-            </Link>
-          </p>
-        )}
-      </section>
+              <div>
+                <Button type="submit" variant="primary">
+                  Connect →
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <p className="text-foreground-muted text-sm">
+              Composio needs a workspace API key.{" "}
+              <Link
+                href={`/${workspace.slug}/settings/composio`}
+                className="text-foreground underline underline-offset-2"
+              >
+                Set it in Settings →
+              </Link>
+            </p>
+          )}
+        </FormShell>
+      );
+    }
 
-      {/* Secret */}
-      <section className="flex flex-col gap-3">
-        <div className="flex flex-col gap-0.5">
-          <h2 className="text-foreground font-medium">Secret</h2>
-          <p className="text-foreground-muted text-sm">
-            Store an API key or token for tools that authenticate with a static
-            secret. Shared across the workspace.
-          </p>
-        </div>
-        {isAdmin ? (
-          <SecretAddForm workspaceSlug={workspace.slug} />
-        ) : (
-          <p className="text-foreground-muted text-sm">
-            Only workspace admins can add secrets.
-          </p>
+    if (typeParam === "secret") {
+      return (
+        <FormShell back={back} title="Add a secret" logo={<Glyph />}>
+          {isAdmin ? (
+            <SecretAddForm workspaceSlug={workspace.slug} />
+          ) : (
+            <p className="text-foreground-muted text-sm">
+              Only workspace admins can add secrets.
+            </p>
+          )}
+        </FormShell>
+      );
+    }
+
+    notFound();
+  }
+
+  // ── The picker ──────────────────────────────────────────────────────
+  const providerCards = catalog.filter((p) =>
+    isProviderAdminEnabled(p, enableMap),
+  );
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-6 py-8">
+      <div className="flex flex-col gap-2">
+        <BackLink href={`/${workspace.slug}/connections`} label="Connections" />
+        <h1 className="text-foreground-title text-2xl font-bold tracking-tight">
+          New connection
+        </h1>
+        <p className="text-foreground-weak text-base">
+          Pick what to connect. OAuth connections are yours; secrets are shared
+          across the workspace.
+        </p>
+      </div>
+
+      <hr className="border-[var(--color-border-weak)]" />
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        {providerCards.map((p) => (
+          <OptionCard
+            key={p.slug}
+            href={`/${workspace.slug}/connections/new?provider=${encodeURIComponent(p.slug)}`}
+            logo={
+              <McpProviderLogo slug={p.slug} label={p.displayName} size={24} />
+            }
+            title={p.displayName}
+            sublabel={authModeLabel(p)}
+          />
+        ))}
+        <OptionCard
+          href={`/${workspace.slug}/connections/new?type=composio`}
+          logo={<IconApiConnection size={24} className="text-foreground-muted" />}
+          title="Composio toolkit"
+          sublabel="300+ apps via Composio"
+        />
+        {isAdmin && (
+          <OptionCard
+            href={`/${workspace.slug}/connections/new?type=secret`}
+            logo={<Glyph />}
+            title="Secret / API key"
+            sublabel="Static key for custom tools"
+          />
         )}
-      </section>
+      </div>
     </div>
+  );
+}
+
+function authModeLabel(p: McpProvider): string {
+  if (p.authMode === "manual") return "OAuth · your app";
+  if (p.authMode === "self-key") return "Built-in";
+  return "OAuth";
+}
+
+function OptionCard({
+  href,
+  logo,
+  title,
+  sublabel,
+}: {
+  href: string;
+  logo: ReactNode;
+  title: string;
+  sublabel: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="border-border bg-surface hover:bg-surface-secondary group flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors"
+    >
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center">
+        {logo}
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="text-foreground group-hover:underline font-medium">
+          {title}
+        </span>
+        <span className="text-foreground-muted truncate text-sm">
+          {sublabel}
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+function FormShell({
+  back,
+  title,
+  logo,
+  children,
+}: {
+  back: ReactNode;
+  title: string;
+  logo: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-6 py-8">
+      <div className="flex flex-col gap-2">
+        {back}
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center">
+            {logo}
+          </span>
+          <h1 className="text-foreground-title text-2xl font-bold tracking-tight">
+            {title}
+          </h1>
+        </div>
+      </div>
+      <hr className="border-[var(--color-border-weak)]" />
+      {children}
+    </div>
+  );
+}
+
+function Glyph() {
+  return (
+    <span
+      className="bg-surface-secondary text-foreground-muted inline-flex h-6 w-6 items-center justify-center rounded text-sm"
+      aria-hidden
+    >
+      ⚿
+    </span>
   );
 }


### PR DESCRIPTION
Follow-up to the Connections rework (#159). The New-connection screen stacked every add-form (native MCP, Composio, secret) on one page. Make it a two-step **picker** like a "connect an integration" chooser, per request.

- **`/connections/new`** now lists the options as cards — each enabled native-MCP provider, **Composio toolkit**, and (admin) **Secret / API key** — each showing a logo + auth-kind hint.
- Clicking a card drills into just that option's form via `?provider=<slug>` or `?type=composio|secret`, with a back link to the picker.
- Adds a focused single-provider `NativeConnectForm` (connection-name slot + Connect) so the per-option page doesn't show the provider dropdown. The Composio toolkit catalog is fetched only when its form is opened (not on the picker).

`tsc` + `eslint` clean, 101 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)