### PR TITLE
Sidebar: dismiss "Action needed" connection prompts

### DIFF
--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 import { DocsSidebarLink } from "@/components/docs-sidebar-link";
+import { MissingConnectionCards } from "@/components/missing-connection-cards";
 import { SidebarNav } from "@/components/sidebar-nav";
 import { Button } from "@/components/ui/button";
 import { UserMenu } from "@/components/user-menu";
@@ -176,79 +177,51 @@ export async function AppShell({
                   </div>
                 );
               })}
-              {groupedMissing.map(({ rep: m, agentNames }) => {
-                // Authorize endpoint differs per substrate: Composio
-                // is one route per workspace (toolkit in query
-                // string), Native MCP is one route per provider
-                // (provider in path). Sidebar dispatches by source
-                // so the Connect button always lands on the right
-                // OAuth flow.
-                let authorizeHref: string;
-                let providerLabel: string;
-                if (m.source === "secret") {
-                  // Secrets are workspace-level: no per-user authorize
-                  // flow — link straight to the Secrets tab where an
-                  // admin sets the key. Labelled by the secret's name.
-                  authorizeHref = `/${workspace.slug}/connections/secrets`;
-                  providerLabel = m.toolkit;
-                } else if (m.source === "native-mcp") {
-                  const params = new URLSearchParams({
-                    workspace: workspace.slug,
-                  });
-                  if (m.name && m.name !== "default") {
-                    params.set("name", m.name);
+              <MissingConnectionCards
+                items={groupedMissing.map(({ rep: m, agentNames }) => {
+                  // Authorize endpoint differs per substrate: Composio is one
+                  // route per workspace (toolkit in query string), Native MCP
+                  // one route per provider (provider in path), secrets link to
+                  // the Secrets tab. Dispatch by source so Connect lands on the
+                  // right flow.
+                  let href: string;
+                  let providerLabel: string;
+                  if (m.source === "secret") {
+                    href = `/${workspace.slug}/connections/secrets`;
+                    providerLabel = m.toolkit;
+                  } else if (m.source === "native-mcp") {
+                    const params = new URLSearchParams({
+                      workspace: workspace.slug,
+                    });
+                    if (m.name && m.name !== "default") params.set("name", m.name);
+                    href = `/api/connections/native/${m.toolkit}/authorize?${params.toString()}`;
+                    providerLabel =
+                      getMcpProvider(m.toolkit)?.displayName ?? m.toolkit;
+                  } else {
+                    const params = new URLSearchParams({
+                      workspace: workspace.slug,
+                      toolkit: m.toolkit,
+                    });
+                    if (m.name && m.name !== "default") params.set("name", m.name);
+                    href = `/api/connections/composio/authorize?${params.toString()}`;
+                    providerLabel = toolkitLabel(m.toolkit);
                   }
-                  authorizeHref = `/api/connections/native/${m.toolkit}/authorize?${params.toString()}`;
-                  providerLabel =
-                    getMcpProvider(m.toolkit)?.displayName ?? m.toolkit;
-                } else {
-                  const params = new URLSearchParams({
-                    workspace: workspace.slug,
-                    toolkit: m.toolkit,
-                  });
-                  if (m.name && m.name !== "default") {
-                    params.set("name", m.name);
-                  }
-                  authorizeHref = `/api/connections/composio/authorize?${params.toString()}`;
-                  providerLabel = toolkitLabel(m.toolkit);
-                }
-                // Show "Gmail (work)" when the slot has a custom name
-                // so the user can tell which account the agent
-                // wants — otherwise just the provider label.
-                const labelWithSlot =
-                  m.name && m.name !== "default"
-                    ? `${providerLabel} (${m.name})`
-                    : providerLabel;
-                return (
-                  <div
-                    key={`${m.source}:${m.toolkit}:${m.name}`}
-                    className="flex items-start gap-2 rounded-md px-2 py-2 bg-[var(--color-sentiment-caution-subtle)]"
-                  >
-                    <IconExclamationTriangle
-                      size={14}
-                      className="mt-0.5 shrink-0 text-[var(--color-icon-sentiment-caution)]"
-                    />
-                    <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
-                      <span className="text-sm leading-tight text-[var(--color-foreground-sentiment-caution)]">
-                        <span className="font-semibold">{labelWithSlot}</span>{" "}
-                        for{" "}
-                        {agentNames.length === 1 ? (
-                          <span className="font-semibold">{agentNames[0]}</span>
-                        ) : (
-                          <span className="font-semibold">
-                            {agentNames.length} agents
-                          </span>
-                        )}
-                      </span>
-                      <Button asChild variant="orange" size="small">
-                        <Link href={authorizeHref}>
-                          {m.source === "secret" ? "Set" : "Connect"}
-                        </Link>
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
+                  const label =
+                    m.name && m.name !== "default"
+                      ? `${providerLabel} (${m.name})`
+                      : providerLabel;
+                  return {
+                    key: `${m.source}:${m.toolkit}:${m.name}`,
+                    label,
+                    agentLabel:
+                      agentNames.length === 1
+                        ? agentNames[0]
+                        : `${agentNames.length} agents`,
+                    href,
+                    action: m.source === "secret" ? "Set" : "Connect",
+                  };
+                })}
+              />
             </div>
           )}
         </nav>

--- a/web/src/components/missing-connection-cards.tsx
+++ b/web/src/components/missing-connection-cards.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { IconExclamationTriangle } from "central-icons";
+
+import { Button } from "@/components/ui/button";
+
+// One "Action needed" missing-connection card per item, with a per-user
+// dismiss. A user who doesn't intend to wire up a given connection can hide its
+// nag; the choice persists in localStorage (no server round-trip, matches the
+// sidebar-nav / docs-nav persistence pattern). Dismissals are keyed by the
+// connection identity (source:toolkit:name), so a brand-new missing connection
+// still shows.
+
+export type MissingConnectionItem = {
+  /** Stable identity = `${source}:${toolkit}:${name}` — also the dismiss key. */
+  key: string;
+  label: string;
+  agentLabel: string;
+  href: string;
+  action: string;
+};
+
+const STORAGE_KEY = "tas-dismissed-connections";
+
+function loadDismissed(): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+export function MissingConnectionCards({
+  items,
+}: {
+  items: MissingConnectionItem[];
+}) {
+  // Hydrate dismissals after mount (localStorage is client-only; reading it in
+  // the initializer would mismatch SSR). `ready` gates the first paint so we
+  // don't briefly flash a card the user already dismissed.
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    // Hydrate from localStorage after mount (client-only).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setDismissed(loadDismissed());
+    setReady(true);
+  }, []);
+
+  function dismiss(key: string) {
+    setDismissed((prev) => {
+      const next = new Set(prev).add(key);
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
+      } catch {
+        // ignore (private mode / storage disabled)
+      }
+      return next;
+    });
+  }
+
+  if (!ready) return null;
+  const visible = items.filter((it) => !dismissed.has(it.key));
+
+  return (
+    <>
+      {visible.map((it) => (
+        <div
+          key={it.key}
+          className="flex items-start gap-2 rounded-md bg-[var(--color-sentiment-caution-subtle)] px-2 py-2"
+        >
+          <IconExclamationTriangle
+            size={14}
+            className="mt-0.5 shrink-0 text-[var(--color-icon-sentiment-caution)]"
+          />
+          <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
+            <span className="text-sm leading-tight text-[var(--color-foreground-sentiment-caution)]">
+              <span className="font-semibold">{it.label}</span> for{" "}
+              <span className="font-semibold">{it.agentLabel}</span>
+            </span>
+            <div className="flex items-center gap-3">
+              <Button asChild variant="orange" size="small">
+                <Link href={it.href}>{it.action}</Link>
+              </Button>
+              <button
+                type="button"
+                onClick={() => dismiss(it.key)}
+                className="text-foreground-muted hover:text-foreground-weak text-xs underline underline-offset-2"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
**Ask:** let me dismiss an "Action needed" connection prompt in the sidebar if I don't want to do that connection — a smaller text link next to "Connect".

Adds a small **"Dismiss"** text link next to each Connect/Set button in the sidebar's "Action needed" list. Dismissing hides that prompt, persisted **per-user in localStorage** (keyed by the connection's `source:toolkit:name`, matching the existing sidebar-nav / docs-nav persistence). A genuinely new missing connection still surfaces (different key).

Extracts the missing-connection cards from the server-rendered `app-shell` into a small client `MissingConnectionCards` component; the LLM-key and failing-agent alerts are unchanged.

`tsc` + `eslint` clean, 101 tests pass, full `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)