### PR TITLE
Skills: clickable detail view with source link + full content

### DIFF
--- a/web/src/app/[workspace]/skills/[name]/page.tsx
+++ b/web/src/app/[workspace]/skills/[name]/page.tsx
@@ -1,0 +1,125 @@
+import { notFound } from "next/navigation";
+
+import { BackLink } from "@/components/back-link";
+import { Markdown } from "@/components/markdown";
+import { getServerSession } from "@/lib/session";
+import {
+  getWorkspaceBySlug,
+  getWorkspaceRole,
+} from "@/lib/workspace";
+import {
+  getSkillInstallSource,
+  readInstalledSkill,
+} from "@/lib/workspace-skills";
+
+import { RemoveSkillForm } from "../skills-forms";
+
+export const dynamic = "force-dynamic";
+
+// Detail view for one installed skill: its source, full SKILL.md content, and a
+// Remove button top-right. Reached by clicking a row on the Skills index.
+export default async function SkillDetailPage({
+  params,
+}: {
+  params: Promise<{ workspace: string; name: string }>;
+}) {
+  const { workspace: slug, name } = await params;
+  const session = await getServerSession();
+  if (!session) notFound();
+  const workspace = await getWorkspaceBySlug(slug);
+  if (!workspace) notFound();
+
+  const [skill, source, role] = await Promise.all([
+    readInstalledSkill(workspace.id, name),
+    getSkillInstallSource(workspace.id, name),
+    getWorkspaceRole(workspace.id, session.user.id),
+  ]);
+  if (!skill) notFound();
+  const isAdmin = role === "workspace_admin";
+  const src = describeSource(source);
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8">
+      <div className="flex flex-col gap-2">
+        <BackLink href={`/${workspace.slug}/skills`} label="Skills" />
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex min-w-0 flex-col gap-1">
+            <h1 className="text-foreground-title text-2xl font-bold tracking-tight">
+              <code>{skill.name}</code>
+            </h1>
+            {skill.description && (
+              <p className="text-foreground-weak text-base">
+                {skill.description}
+              </p>
+            )}
+          </div>
+          {isAdmin && (
+            <RemoveSkillForm workspaceSlug={workspace.slug} name={skill.name} />
+          )}
+        </div>
+      </div>
+
+      <hr className="border-[var(--color-border-weak)]" />
+
+      <dl className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[8rem_1fr]">
+        <dt className="text-foreground-muted">Source</dt>
+        <dd className="text-foreground-weak">
+          {src ? (
+            src.url ? (
+              <a
+                href={src.url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-foreground underline underline-offset-2"
+              >
+                {src.label}
+              </a>
+            ) : (
+              src.label
+            )
+          ) : (
+            "—"
+          )}
+        </dd>
+        <dt className="text-foreground-muted">Path</dt>
+        <dd className="text-foreground-weak">
+          <code>{skill.path}</code>
+        </dd>
+        <dt className="text-foreground-muted">Files</dt>
+        <dd className="text-foreground-weak">{skill.fileCount}</dd>
+      </dl>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-foreground text-sm font-medium">SKILL.md</span>
+        <div className="border-border bg-surface-raised rounded-lg border px-4 py-3">
+          {skill.skillMd ? (
+            <Markdown>{skill.skillMd}</Markdown>
+          ) : (
+            <p className="text-foreground-muted text-sm">
+              Couldn&apos;t read SKILL.md for this skill.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Map the stored install source ("github:owner/repo", "skills.sh:slug",
+// "upload", "claude-api") to a label + optional outbound link.
+function describeSource(
+  source: string | null,
+): { label: string; url?: string } | null {
+  if (!source) return null;
+  if (source.startsWith("github:")) {
+    const repo = source.slice("github:".length);
+    return { label: repo, url: `https://github.com/${repo}` };
+  }
+  if (source.startsWith("skills.sh:")) {
+    const s = source.slice("skills.sh:".length);
+    return { label: `skills.sh/${s}`, url: `https://skills.sh/${s}` };
+  }
+  if (source === "upload") return { label: "Uploaded file" };
+  if (source === "claude-api") return { label: "Claude Skills API" };
+  return { label: source };
+}

--- a/web/src/app/[workspace]/skills/actions.ts
+++ b/web/src/app/[workspace]/skills/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import { exportAnthropicSkill } from "@/lib/anthropic-skills";
 import { writeAuditEvent } from "@/lib/audit-db";
@@ -215,5 +215,6 @@ export async function removeSkillAction(
     payload: { name, deleted: res.deleted },
   });
   revalidatePath(`/${slug}/skills`);
-  return { message: `Removed skill "${name}".` };
+  // Removal is triggered from the skill's detail page, which no longer resolves.
+  redirect(`/${slug}/skills`);
 }

--- a/web/src/app/[workspace]/skills/page.tsx
+++ b/web/src/app/[workspace]/skills/page.tsx
@@ -15,7 +15,6 @@ import { SkillsCatalogBrowser } from "./skills-catalog-browser";
 import {
   AddFromGitHubForm,
   ImportFromClaudeForm,
-  RemoveSkillForm,
   UploadSkillForm,
   type ImportableSkill,
 } from "./skills-forms";
@@ -108,21 +107,25 @@ export default async function SkillsPage({
             ) : (
               <ul className="divide-border-weak flex flex-col divide-y rounded-lg border border-[var(--color-border-weak)] bg-surface-raised">
                 {installed.map((s) => (
-                  <li
-                    key={s.name}
-                    className="flex items-start justify-between gap-3 px-3 py-2.5"
-                  >
-                    <div className="flex min-w-0 flex-col">
-                      <code className="text-foreground text-sm font-medium">
-                        {s.name}
-                      </code>
-                      {s.description && (
-                        <span className="text-foreground-weak line-clamp-2 text-sm">
-                          {s.description}
-                        </span>
-                      )}
-                    </div>
-                    <RemoveSkillForm workspaceSlug={slug} name={s.name} />
+                  <li key={s.name}>
+                    <Link
+                      href={`/${slug}/skills/${encodeURIComponent(s.name)}`}
+                      className="hover:bg-surface group flex items-center justify-between gap-3 px-3 py-2.5"
+                    >
+                      <div className="flex min-w-0 flex-col">
+                        <code className="text-foreground group-hover:underline text-sm font-medium">
+                          {s.name}
+                        </code>
+                        {s.description && (
+                          <span className="text-foreground-weak line-clamp-2 text-sm">
+                            {s.description}
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-foreground-muted shrink-0 text-sm" aria-hidden>
+                        →
+                      </span>
+                    </Link>
                   </li>
                 ))}
               </ul>

--- a/web/src/app/[workspace]/skills/skills-forms.tsx
+++ b/web/src/app/[workspace]/skills/skills-forms.tsx
@@ -168,7 +168,7 @@ export function RemoveSkillForm({
     <form action={action} className="flex items-center gap-2">
       <input type="hidden" name="workspace" value={workspaceSlug} />
       <input type="hidden" name="name" value={name} />
-      <Button type="submit" variant="ghost" size="small" disabled={pending}>
+      <Button type="submit" variant="destructive" size="small" disabled={pending}>
         {pending ? "Removing…" : "Remove"}
       </Button>
       {state.error && (

--- a/web/src/lib/workspace-skills.ts
+++ b/web/src/lib/workspace-skills.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import YAML from "yaml";
 
+import { db } from "@/lib/db";
 import {
   createFile,
   deleteFile,
@@ -102,6 +103,68 @@ export async function listInstalledSkills(
   );
   out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
+}
+
+export type InstalledSkillDetail = {
+  name: string;
+  title: string | null;
+  description: string | null;
+  path: string;
+  /** The full SKILL.md (frontmatter + body) for display. */
+  skillMd: string;
+  /** Total files in the skill folder. */
+  fileCount: number;
+};
+
+/**
+ * One installed skill with its full SKILL.md content, for the detail view.
+ * Returns null when the workspace has no repo or the skill folder is gone.
+ */
+export async function readInstalledSkill(
+  workspaceId: string,
+  name: string,
+): Promise<InstalledSkillDetail | null> {
+  const repo = await getWorkspaceRepo(workspaceId);
+  if (!repo) return null;
+  const token = await getWorkspaceSecretPlaintext(workspaceId, "github_pat");
+  const ref = repoRefFor(repo);
+  const res = await readSkillFolder(token ?? "", ref, name);
+  if (!res.ok) return null;
+  const mdKey = Object.keys(res.files).find((k) =>
+    k.toLowerCase().endsWith("/skill.md"),
+  );
+  const skillMd = mdKey ? res.files[mdKey] : "";
+  const meta = skillMd
+    ? parseSkillFrontmatter(skillMd)
+    : { title: null, description: null };
+  return {
+    name,
+    title: meta.title,
+    description: meta.description,
+    path: `${SKILLS_DIR}/${name}`,
+    skillMd,
+    fileCount: Object.keys(res.files).length,
+  };
+}
+
+/**
+ * The source a skill was installed from, read off its most recent
+ * `skill.installed` audit event (e.g. "github:owner/repo", "skills.sh:slug",
+ * "upload", "claude-api"). Null if no install event is recorded.
+ */
+export async function getSkillInstallSource(
+  workspaceId: string,
+  name: string,
+): Promise<string | null> {
+  const { rows } = await db.query<{ payload: { source?: string } | null }>(
+    `SELECT payload FROM audit_event
+      WHERE workspace_id = $1 AND kind = 'skill.installed' AND target_id = $2
+      ORDER BY at DESC
+      LIMIT 1`,
+    [workspaceId, name],
+  );
+  const source = rows[0]?.payload?.source;
+  return typeof source === "string" ? source : null;
 }
 
 /**


### PR DESCRIPTION
**Ask:** after installing a skill, there's no link to its source or its full content; both should be visible/clickable, and "Remove" should be top-right.

Each installed skill row now links to a **detail view** (`/skills/[name]`) showing:
- **Source**, linked — GitHub repo (`github:owner/repo` → github.com), skills.sh, or "Uploaded file" / "Claude Skills API" — read off the skill's most recent `skill.installed` audit event.
- Repo **path** + **file count**.
- The full **SKILL.md** rendered as markdown (reusing the existing `Markdown` component).
- **Remove** in the header, **top-right**, as a destructive button (admin only); removing redirects back to the list.

Adds `readInstalledSkill()` (reads the folder's SKILL.md) and `getSkillInstallSource()` to `workspace-skills.ts`. The index list rows are now clickable; the inline Remove moved to the detail view.

`tsc` + `eslint` clean, 101 tests pass, full `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)