### PR TITLE
Connections detail: match /agents button padding

### DIFF
--- a/web/src/app/[workspace]/connections/[id]/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/page.tsx
@@ -128,7 +128,7 @@ export default async function ConnectionDetailPage({
     );
     if (!view.viewingOther) {
       actions.push(
-        <Button key="reconnect" asChild variant="secondary" size="small">
+        <Button key="reconnect" asChild variant="secondary">
           <a href={reconnect}>Reconnect</a>
         </Button>,
         <DisconnectNativeMcpConnectionForm key="disconnect" workspaceSlug={workspace.slug} connectionId={c.id} />,
@@ -171,7 +171,7 @@ export default async function ConnectionDetailPage({
     );
     if (!view.viewingOther) {
       actions.push(
-        <Button key="reconnect" asChild variant="secondary" size="small">
+        <Button key="reconnect" asChild variant="secondary">
           <a href={reconnect}>Reconnect</a>
         </Button>,
         <DisconnectComposioConnectionForm key="disconnect" workspaceSlug={workspace.slug} connectionId={c.id} />,
@@ -183,7 +183,7 @@ export default async function ConnectionDetailPage({
   // we're not viewing another member. Placed first so it leads the cluster.
   if (editable && !view.viewingOther) {
     actions.unshift(
-      <Button key="edit" asChild variant="secondary" size="small">
+      <Button key="edit" asChild variant="secondary">
         <Link href={editHref}>Edit</Link>
       </Button>,
     );

--- a/web/src/app/[workspace]/connections/disconnect-native-mcp-connection-form.tsx
+++ b/web/src/app/[workspace]/connections/disconnect-native-mcp-connection-form.tsx
@@ -31,7 +31,7 @@ export function DisconnectNativeMcpConnectionForm({
     <form action={formAction}>
       <input type="hidden" name="workspace" value={workspaceSlug} />
       <input type="hidden" name="connectionId" value={connectionId} />
-      <Button type="submit" variant="destructive" size="small" disabled={pending}>
+      <Button type="submit" variant="destructive" disabled={pending}>
         {pending ? "Disconnecting…" : "Disconnect"}
       </Button>
     </form>

--- a/web/src/app/[workspace]/connections/refresh-native-mcp-tools-form.tsx
+++ b/web/src/app/[workspace]/connections/refresh-native-mcp-tools-form.tsx
@@ -33,7 +33,7 @@ export function RefreshNativeMcpToolsForm({
     <form action={formAction}>
       <input type="hidden" name="workspace" value={workspaceSlug} />
       <input type="hidden" name="connectionId" value={connectionId} />
-      <Button type="submit" variant="secondary" size="small" disabled={pending}>
+      <Button type="submit" variant="secondary" disabled={pending}>
         {pending ? "Refreshing…" : (label ?? "Refresh tools")}
       </Button>
     </form>

--- a/web/src/app/[workspace]/settings/disconnect-composio-connection-form.tsx
+++ b/web/src/app/[workspace]/settings/disconnect-composio-connection-form.tsx
@@ -32,7 +32,7 @@ export function DisconnectComposioConnectionForm({
     <form action={formAction}>
       <input type="hidden" name="workspace" value={workspaceSlug} />
       <input type="hidden" name="connectionId" value={connectionId} />
-      <Button type="submit" variant="destructive" size="small" disabled={pending}>
+      <Button type="submit" variant="destructive" disabled={pending}>
         {pending ? "Disconnecting…" : "Disconnect"}
       </Button>
     </form>

--- a/web/src/app/[workspace]/settings/refresh-composio-tools-form.tsx
+++ b/web/src/app/[workspace]/settings/refresh-composio-tools-form.tsx
@@ -32,7 +32,7 @@ export function RefreshComposioToolsForm({
     <form action={formAction}>
       <input type="hidden" name="workspace" value={workspaceSlug} />
       <input type="hidden" name="connectionId" value={connectionId} />
-      <Button type="submit" variant="secondary" size="small" disabled={pending}>
+      <Button type="submit" variant="secondary" disabled={pending}>
         {pending ? "Refreshing…" : (label ?? "Refresh tools")}
       </Button>
     </form>


### PR DESCRIPTION
The connection detail-view action buttons (Edit / Reconnect / Refresh / Disconnect) used `size="small"`, giving tighter padding than the agent view's header buttons. Dropped the `size` override so they render at the default size, matching `/agents`. Status badges are unchanged.

Follow-up to #162. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)