### PR TITLE
Match top-right action buttons to /agents (default size)

### DIFF
--- a/web/src/app/[workspace]/skills/skills-forms.tsx
+++ b/web/src/app/[workspace]/skills/skills-forms.tsx
@@ -168,7 +168,7 @@ export function RemoveSkillForm({
     <form action={action} className="flex items-center gap-2">
       <input type="hidden" name="workspace" value={workspaceSlug} />
       <input type="hidden" name="name" value={name} />
-      <Button type="submit" variant="destructive" size="small" disabled={pending}>
+      <Button type="submit" variant="destructive" disabled={pending}>
         {pending ? "Removing…" : "Remove"}
       </Button>
       {state.error && (

--- a/web/src/app/[workspace]/slack-apps/[id]/page.tsx
+++ b/web/src/app/[workspace]/slack-apps/[id]/page.tsx
@@ -60,7 +60,7 @@ export default async function SlackAppDetailPage({
               {app.status}
             </Badge>
           </div>
-          <Button asChild variant="secondary" size="small">
+          <Button asChild variant="secondary">
             <Link href={`/${workspace.slug}/slack-apps/${app.id}/edit`}>
               Edit
             </Link>


### PR DESCRIPTION
**Ask:** make all top-right action buttons use the same style as `/agents`.

`/agents` (and its agent detail header) uses **default-size** `<Button>`s. Two top-right buttons were still `size="small"`:
- Slack-app **detail "Edit"** (`slack-apps/[id]/page.tsx`)
- Skill **detail "Remove"** (`skills-forms.tsx`)

Dropped the `size` override on both so they match. (The connection detail was already fixed in #167.)

Audited the rest: all list "+ New X" buttons (agents, connections, slack-apps, automations) already use the same `<Button asChild>` + `IconPlusLarge size={16}` pattern, and no other page/layout header buttons use `size="small"`.

`tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)