### PR TITLE
fix(runner): explicit 300s read timeout on Anthropic streaming client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ api/target/
 *.log
 *.db
 __pycache__/
+
+# JetBrains IDEs
+.idea/

--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -33,9 +33,9 @@ import os
 import sys
 import tempfile
 import traceback
-
 import httpx
 import yaml
+
 from anthropic import AsyncAnthropic
 from pydantic_ai import Agent, capture_run_messages
 from pydantic_ai.models.anthropic import AnthropicModel

--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -740,7 +740,7 @@ def build_agent(
         model = AnthropicModel(
             model.removeprefix("anthropic:"),
             anthropic_client=AsyncAnthropic(
-                timeout=httpx.Timeout(timeout=None, connect=10.0)
+                timeout=httpx.Timeout(timeout=300.0, connect=10.0)
             ),
         )
     kwargs["model_settings"] = ms

--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -739,8 +739,10 @@ def build_agent(
         # turns in multi-step agentic runs and causes ReadTimeout errors mid-run.
         model = AnthropicModel(
             model.removeprefix("anthropic:"),
-            anthropic_client=AsyncAnthropic(
-                timeout=httpx.Timeout(timeout=300.0, connect=10.0)
+            provider=AnthropicProvider(
+                anthropic_client=AsyncAnthropic(
+                    timeout=httpx.Timeout(timeout=300.0, connect=10.0)
+                )
             ),
         )
     kwargs["model_settings"] = ms

--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -34,8 +34,11 @@ import sys
 import tempfile
 import traceback
 
+import httpx
 import yaml
+from anthropic import AsyncAnthropic
 from pydantic_ai import Agent, capture_run_messages
+from pydantic_ai.models.anthropic import AnthropicModel
 
 
 USAGE_SENTINEL = "__TAS_USAGE__:"
@@ -731,6 +734,15 @@ def build_agent(
         ms.setdefault("anthropic_cache_instructions", True)
         ms.setdefault("anthropic_cache_tool_definitions", True)
         ms.setdefault("anthropic_cache", True)
+        # Swap the string for an AnthropicModel backed by a client with no read
+        # timeout. The default httpx read timeout is too short for long streaming
+        # turns in multi-step agentic runs and causes ReadTimeout errors mid-run.
+        model = AnthropicModel(
+            model.removeprefix("anthropic:"),
+            anthropic_client=AsyncAnthropic(
+                timeout=httpx.Timeout(timeout=None, connect=10.0)
+            ),
+        )
     kwargs["model_settings"] = ms
     retries = spec.get("retries")
     if isinstance(retries, int):


### PR DESCRIPTION
## What

Explicitly constructs an `AsyncAnthropic` client with `httpx.Timeout(timeout=300.0, connect=10.0)` and passes it to `AnthropicModel` when resolving Anthropic model strings in the pydantic-ai runner.

## Why

Long-running agentic runs (operators polling multiple subagents) were hitting `httpx.ReadTimeout` mid-stream. The Anthropic SDK defaults to 600s in isolation, but pydantic-ai's internal model resolution from a string (`"anthropic:claude-sonnet-4-6"`) does not guarantee that default survives through the httpcore transport layer — likely a version mismatch between the packages installed in the container.

By constructing the client explicitly, we bypass whatever timeout pydantic-ai was inheriting and guarantee a consistent 300s read timeout regardless of container package versions. 300s is half the Anthropic SDK's own default — more than enough headroom for any single streaming turn while still allowing genuinely hung connections to be detected and cleaned up.

- `connect: 10s` — fail fast on dead hosts
- `read: 300s` — generous ceiling for complex streaming turns; the Anthropic SDK's built-in retry logic (2 retries with backoff) handles transient failures within that window