### PR TITLE
Add Vercel Eve as a third agent framework

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /app
 # installed as a bundled binary one stage up — both frameworks now
 # get their full power instead of a Rust-side hand-rolled subset.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates libssl3 curl \
+        ca-certificates libssl3 curl xz-utils \
         python3 python3-pip python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
@@ -66,9 +66,30 @@ COPY scripts/requirements-tools.txt /opt/requirements-tools.txt
 RUN "${PYDANTIC_AI_VENV}/bin/pip" install --no-cache-dir \
         -r /opt/requirements-tools.txt
 
+# Node.js + pnpm are runtime deps for the Eve agent path: the Eve runner
+# (api/src/runs/eve.rs) shells out to a Node harness (run_eve.mjs) that builds
+# the agent's TypeScript project and runs one turn in-process. Eve requires
+# Node >= 24. Node lands under /usr/local (node -> /usr/local/bin/node, matching
+# EVE_NODE); pnpm is installed globally (not via corepack) so no network
+# resolution happens at run time. Pin both; bump via PR to vet changelogs.
+ENV NODE_VERSION=24.16.0
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) NODE_ARCH=x64 ;; \
+         arm64) NODE_ARCH=arm64 ;; \
+         *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz \
+    && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
+    && rm /tmp/node.tar.xz \
+    && npm install -g pnpm@10.34.3 \
+    && node --version && pnpm --version
+
 COPY --from=builder /app/tas-api /usr/local/bin/tas-api
 COPY --from=builder /opt/cargo-ai/bin/cargo-ai /usr/local/bin/cargo-ai
 COPY scripts/run_pydantic.py /usr/local/bin/run_pydantic.py
+# Eve agent runner harness (Node). See api/src/runs/eve.rs + EVE_SPIKE_NOTES.md.
+COPY scripts/run_eve.mjs /usr/local/bin/run_eve.mjs
 # Sidecar-tools helper importable by tool modules (`import tas_tools`).
 # Lives next to the wrapper; the wrapper adds this dir to sys.path.
 COPY scripts/tas_tools.py /usr/local/bin/tas_tools.py
@@ -83,6 +104,12 @@ COPY scripts/tas_tools.py /usr/local/bin/tas_tools.py
 RUN groupadd --system --gid 1001 tas \
     && useradd --system --uid 1001 --gid tas --create-home --home-dir /home/tas tas
 ENV HOME=/home/tas
+
+# Persistent pnpm store for the Eve runner (EVE_PNPM_STORE in eve.rs), writable
+# by the runtime user so per-run `pnpm install` is mostly hardlinks. Lives in the
+# container fs (warms within a container's lifetime); mount a volume here to
+# persist across restarts.
+RUN mkdir -p /opt/eve-store && chown -R tas:tas /opt/eve-store
 
 # [::] is dual-stack on Linux (serves IPv4 + IPv6), so Compose keeps
 # working and IPv6-only private networks (e.g. Railway) reach the api

--- a/api/scripts/EVE_SPIKE_NOTES.md
+++ b/api/scripts/EVE_SPIKE_NOTES.md
@@ -1,0 +1,54 @@
+# Eve framework integration — spike findings (PROVEN)
+
+Spike goal: run an Eve agent **one-shot, in-process, with no Eve HTTP server**
+(no listening socket), capturing the assistant reply + token usage. **Result: it
+works.** A turn completed in-process and returned `"hello world"` with
+`usage.inputTokens: 5017` and an output-token count, driving the durable workflow
+entirely through an in-process fetch handler.
+
+## Environment facts
+- **Eve requires Node ≥ 24** (CLI refuses on 22). The API image must ship Node 24.
+- Eve is a pnpm project; scaffolded deps use the `link:` protocol, so **npm cannot
+  install into it — use pnpm@10**. (`--ignore-workspace` needed because the
+  scaffolded `pnpm-workspace.yaml` has no `packages:` field.)
+- `eve init <dir>` is non-interactive when stdin is not a TTY — it scaffolds and
+  prints next steps instead of launching the TUI. Good for CAP scaffolding.
+- `eve build` always emits Nitro **`node-server`** preset (ignores `NITRO_PRESET`).
+
+## The recipe (what the production harness must do)
+1. **Materialize** the agent dir (from the `{repoPath: content}` map) into a temp
+   project root.
+2. **Model = direct provider.** Eve's default `model: "anthropic/…"` string routes
+   through Vercel AI Gateway (needs `AI_GATEWAY_API_KEY`/OIDC). Use a direct
+   `LanguageModel` instead: `agent.ts` → `import { anthropic } from "@ai-sdk/anthropic"; model: anthropic("claude-…")`.
+   The direct provider reads `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` from env (which
+   TAS already has). `@ai-sdk/anthropic@4.0.0-beta.67` matches `ai@7.0.0-beta.178`.
+3. **Channel auth = `none()`** (TAS controls the dir; the handler has no network
+   exposure). Write `agent/channels/eve.ts` → `eveChannel({ auth: [none()] })`.
+   Otherwise the session route 401s (`localDev()` is disabled in a prod build).
+4. `pnpm install` (cache by lockfile hash) then `eve build`.
+5. **Patch the build to not listen.** `.output/server/index.mjs` calls
+   `serve({...})` at import (binds a port). Replace `serve({` with
+   `globalThis.__EVE_FETCH__ = nitroApp.fetch; ((_)=>_)({` so importing the file
+   captures the Nitro fetch handler and binds **no socket**.
+6. **Durable workflow runs locally, in-process.** Set
+   `WORKFLOW_LOCAL_BASE_URL=http://eve.local` and `WORKFLOW_LOCAL_DATA_DIR=<tmp>`.
+   Intercept `globalThis.fetch`: any URL containing the sentinel host is served by
+   `globalThis.__EVE_FETCH__(new Request(...))`. This routes both the session POST
+   and the workflow callbacks (`POST /.well-known/workflow/v1/flow`) back through
+   the in-process handler — no socket.
+7. **Drive** with `eve/client`: `new Client({ host: "http://eve.local" })` →
+   `session.send(message)` → `await res.result()` for the aggregated
+   `MessageResult` (assistant text), and iterate the stream for per-step
+   `usage`/tool events → emit `__TAS_USAGE__` / `__TAS_STEPS__`.
+
+## Open items for full integration
+- **Sandbox**: the spike agent had no tools. Tool-using agents need an Eve sandbox
+  (`eve/sandbox/just-bash` runs locally with no Docker; `docker`/`microsandbox`/
+  `vercel` are the others). v1 can scope to `just-bash`.
+- **Dep install cost**: first run per lockfile pays `pnpm install`; cache it.
+- **Pinned versions**: validated on `eve@0.11.4`, Node 24.16, pnpm@10,
+  `@ai-sdk/anthropic@4.0.0-beta.67`. Re-validate on upgrades (internal/build-shape
+  dependence: the `serve(` patch + `WORKFLOW_LOCAL_*` envs).
+
+See `eve-spike-driver.mjs` for the exact working driver used to prove this.

--- a/api/scripts/eve-spike-driver.mjs
+++ b/api/scripts/eve-spike-driver.mjs
@@ -1,0 +1,15 @@
+import { Client } from "eve/client";
+await import("./.output/server/index.mjs");
+const handler = globalThis.__EVE_FETCH__;
+const realFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = async (input, init) => {
+  const url = typeof input === "string" ? input : (input?.url ?? "");
+  if (url.includes("eve.local")) return handler(input instanceof Request ? input : new Request(url, init));
+  return realFetch(input, init);
+};
+const client = new Client({ host: "http://eve.local" });
+const session = client.session();
+console.error("running turn fully in-process (no socket)...");
+const res = await session.send("Reply with exactly: hello world");
+const out = await res.result();
+console.log("MESSAGE_RESULT:", JSON.stringify(out, null, 2).slice(0, 2000));

--- a/api/scripts/run_eve.mjs
+++ b/api/scripts/run_eve.mjs
@@ -1,0 +1,218 @@
+// TAS runner for Eve agents. Mirrors run_pydantic.py's contract: read the
+// agent's files + a user message, run ONE turn, and print the assistant reply
+// plus the `__TAS_USAGE__:` / `__TAS_STEPS__:` sentinels the Rust runner
+// (api/src/runs/eve.rs) parses into the run/run_step rows.
+//
+// The hard part — proven in the spike (see api/scripts/EVE_SPIKE_NOTES.md) —
+// is running an Eve agent ONE-SHOT, fully in-process, with NO listening HTTP
+// server. Eve's turn executes as a Vercel Workflow that drives itself via a
+// queue making HTTP callbacks to the app's own origin. We:
+//   1. `eve build` the materialized project (Nitro `node-server` output),
+//   2. patch out the `serve(...)` call so importing the build exposes the
+//      Nitro fetch handler WITHOUT binding a socket,
+//   3. point the workflow's LOCAL backend at a sentinel host
+//      (WORKFLOW_LOCAL_BASE_URL) and intercept globalThis.fetch so the session
+//      POST and the workflow callbacks loop back through that in-process handler,
+//   4. open the channel auth (none()) since TAS owns the dir and nothing is
+//      network-exposed,
+//   5. drive the turn with eve/client and aggregate the streamed events.
+//
+// Inputs (env, set by eve.rs):
+//   TAS_EVE_FILES   JSON { "<project-relative path>": "<content>" } of the agent dir
+//   TAS_MESSAGE     the user message for this turn (may be empty)
+//   ANTHROPIC_API_KEY / OPENAI_API_KEY   provider keys (direct AI-SDK providers read these)
+//   TAS_EVE_PNPM_STORE  optional persistent pnpm store dir (fast installs)
+//
+// Requires Node >= 24 and pnpm@10 on PATH (provided by api/Dockerfile).
+
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, isAbsolute, normalize } from "node:path";
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const SENTINEL_HOST = "http://eve.local";
+
+function die(msg) {
+  process.stderr.write(`[run_eve] ${msg}\n`);
+  process.exit(1);
+}
+
+function readFilesEnv() {
+  const raw = process.env.TAS_EVE_FILES;
+  if (!raw) die("TAS_EVE_FILES is required");
+  let files;
+  try {
+    files = JSON.parse(raw);
+  } catch (e) {
+    die(`TAS_EVE_FILES is not valid JSON: ${e}`);
+  }
+  if (!files || typeof files !== "object" || Array.isArray(files)) {
+    die("TAS_EVE_FILES must be a JSON object of {path: content}");
+  }
+  return files;
+}
+
+// Materialize the agent project into a fresh temp dir. Paths are project-relative
+// (eve.rs strips the `agents/eve/<name>/` prefix before sending), so a path like
+// `agent/agent.ts` lands at <root>/agent/agent.ts. Reject path traversal.
+function materialize(files) {
+  const root = mkdtempSync(join(tmpdir(), "tas-eve-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const safe = normalize(rel).replace(/^(\.\.(\/|\\|$))+/, "");
+    if (isAbsolute(safe) || safe.startsWith("..")) continue;
+    const dest = join(root, safe);
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, typeof content === "string" ? content : String(content));
+  }
+  return root;
+}
+
+// Force the eve HTTP channel auth open for this trusted, non-network-exposed run.
+// localDev() is disabled in a production `eve build`, so without this the session
+// route 401s. TAS owns the dir, so overriding the eve channel's auth is safe.
+function forcePublicAuth(root) {
+  const dir = join(root, "agent", "channels");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "eve.ts"),
+    'import { eveChannel } from "eve/channels/eve";\n' +
+      'import { none } from "eve/channels/auth";\n' +
+      "export default eveChannel({ auth: [none()] });\n",
+  );
+}
+
+function run(cmd, cmdArgs, opts = {}) {
+  return execFileSync(cmd, cmdArgs, {
+    cwd: opts.cwd,
+    env: opts.env ?? process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+function installDeps(root) {
+  const env = { ...process.env };
+  if (process.env.TAS_EVE_PNPM_STORE) env.PNPM_HOME = process.env.TAS_EVE_PNPM_STORE;
+  const args = ["install", "--ignore-workspace", "--prod=false"];
+  if (process.env.TAS_EVE_PNPM_STORE) {
+    args.push("--store-dir", join(process.env.TAS_EVE_PNPM_STORE, "store"));
+  }
+  try {
+    run("pnpm", args, { cwd: root, env });
+  } catch (e) {
+    die(`pnpm install failed: ${e.stderr || e.message}`);
+  }
+}
+
+function buildProject(root) {
+  const eveBin = join(root, "node_modules", "eve", "bin", "eve.js");
+  if (!existsSync(eveBin)) die("eve is not a dependency of this agent project");
+  try {
+    run(process.execPath, [eveBin, "build"], { cwd: root });
+  } catch (e) {
+    die(`eve build failed: ${(e.stdout || "") + (e.stderr || e.message)}`);
+  }
+}
+
+// Patch the Nitro node-server entry so importing it captures the fetch handler
+// on globalThis.__EVE_FETCH__ instead of calling serve() (which would bind a
+// port). Idempotent.
+function patchNoListen(root) {
+  const entry = join(root, ".output", "server", "index.mjs");
+  if (!existsSync(entry)) die("build did not produce .output/server/index.mjs");
+  let src = readFileSync(entry, "utf8");
+  if (!src.includes("__EVE_FETCH__")) {
+    if (!src.includes("serve({")) die("could not find serve({...}) to patch in build output");
+    src = src.replace("serve({", "globalThis.__EVE_FETCH__ = nitroApp.fetch; ((_)=>_)({");
+    writeFileSync(entry, src);
+  }
+  return entry;
+}
+
+// Aggregate the streamed turn events into final text + per-step usage.
+function aggregate(events) {
+  let text = "";
+  const steps = new Map(); // stepIndex -> {input_tokens, output_tokens, summary}
+  for (const ev of events) {
+    const t = ev?.type;
+    const d = ev?.data ?? {};
+    if (t === "message.completed" && typeof d.message === "string") {
+      text = d.message;
+    } else if (t === "message.appended" && typeof d.messageSoFar === "string" && !text) {
+      // fall-back accumulation if no completed event arrives
+      text = d.messageSoFar;
+    }
+    if (d.usage && (d.usage.inputTokens != null || d.usage.outputTokens != null)) {
+      const idx = Number.isInteger(d.stepIndex) ? d.stepIndex : steps.size;
+      const prev = steps.get(idx) ?? {};
+      steps.set(idx, {
+        input_tokens: d.usage.inputTokens ?? prev.input_tokens ?? 0,
+        output_tokens: d.usage.outputTokens ?? prev.output_tokens ?? 0,
+      });
+    }
+  }
+  const stepArr = [...steps.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([step, u]) => ({ step, input_tokens: u.input_tokens, output_tokens: u.output_tokens }));
+  const total = stepArr.reduce(
+    (acc, s) => ({
+      input_tokens: acc.input_tokens + (s.input_tokens || 0),
+      output_tokens: acc.output_tokens + (s.output_tokens || 0),
+    }),
+    { input_tokens: 0, output_tokens: 0 },
+  );
+  return { text, steps: stepArr, usage: total };
+}
+
+async function main() {
+  const files = readFilesEnv();
+  const message = process.env.TAS_MESSAGE && process.env.TAS_MESSAGE.length ? process.env.TAS_MESSAGE : "Hello.";
+
+  const root = materialize(files);
+  forcePublicAuth(root);
+  installDeps(root);
+  buildProject(root);
+  const entry = patchNoListen(root);
+
+  // Local durable-workflow backend, looped back in-process via the fetch
+  // intercept below. The data dir is per-run (ephemeral).
+  process.env.WORKFLOW_LOCAL_BASE_URL = SENTINEL_HOST;
+  process.env.WORKFLOW_LOCAL_DATA_DIR = mkdtempSync(join(tmpdir(), "tas-eve-wf-"));
+
+  // Importing the patched entry sets globalThis.__EVE_FETCH__ and binds no socket.
+  await import(pathToFileURL(entry).href);
+  const handler = globalThis.__EVE_FETCH__;
+  if (typeof handler !== "function") die("in-process fetch handler not available after build patch");
+
+  const realFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : (input?.url ?? "");
+    if (url.includes("eve.local")) {
+      return handler(input instanceof Request ? input : new Request(url, init));
+    }
+    return realFetch(input, init);
+  };
+
+  // eve/client resolves from the materialized project's node_modules.
+  const { Client } = await import(
+    pathToFileURL(join(root, "node_modules", "eve", "dist", "src", "client", "index.js")).href
+  );
+  const client = new Client({ host: SENTINEL_HOST });
+  const session = client.session();
+
+  const response = await session.send(message);
+  const events = [];
+  for await (const ev of response) events.push(ev);
+  const { text, steps, usage } = aggregate(events);
+
+  // Emit in the exact shape eve.rs (reusing the pydantic sentinel parsers) reads.
+  process.stdout.write(`${text}\n`);
+  process.stdout.write(`__TAS_STEPS__:${JSON.stringify(steps)}\n`);
+  process.stdout.write(
+    `__TAS_USAGE__:${JSON.stringify({ input_tokens: usage.input_tokens, output_tokens: usage.output_tokens })}\n`,
+  );
+}
+
+main().catch((e) => die(e?.stack || String(e)));

--- a/api/src/runs/eve.rs
+++ b/api/src/runs/eve.rs
@@ -1,0 +1,123 @@
+//! Subprocess wrapper that runs an Eve agent (github.com/vercel/eve) via the
+//! bundled Node harness (api/scripts/run_eve.mjs, copied into the runtime image
+//! at /usr/local/bin/run_eve.mjs — see api/Dockerfile).
+//!
+//! Unlike Pydantic/Cargo, an Eve agent is a *directory of TypeScript files*, not
+//! a single spec. We ship that directory as a `{ repoPath: content }` map (the
+//! same shape Pydantic uses for Agent Skills) in `TAS_EVE_FILES`; the harness
+//! materializes it, builds it, and runs ONE turn fully in-process with no
+//! listening HTTP server (see api/scripts/EVE_SPIKE_NOTES.md for how).
+//!
+//! Output protocol is identical to the Pydantic wrapper — the harness emits the
+//! assistant reply plus `__TAS_STEPS__:` / `__TAS_USAGE__:` sentinels — so we
+//! reuse the pydantic sentinel parsers verbatim.
+
+use anyhow::{anyhow, Context};
+use std::collections::HashMap;
+use std::process::Stdio;
+use tokio::process::Command;
+
+use crate::runs::pydantic::{self, PydanticResult, RunStep, ToolCall};
+
+const EVE_NODE: &str = "/usr/local/bin/node";
+const EVE_SCRIPT: &str = "/usr/local/bin/run_eve.mjs";
+/// Persistent pnpm store so per-run `pnpm install` is mostly hardlinks.
+/// Provisioned as a writable dir in api/Dockerfile.
+const EVE_PNPM_STORE: &str = "/opt/eve-store";
+
+pub struct EveArgs<'a> {
+    /// The agent directory as `{ project-relative path: content }` — the web
+    /// layer strips the `agents/eve/<name>/` prefix so paths are project-root
+    /// relative (e.g. `agent/agent.ts`).
+    pub agent_files: &'a HashMap<String, String>,
+    /// Freeform user input. Empty string means "no input"; the harness
+    /// defaults to "Hello." so the turn has a prompt.
+    pub user_message: &'a str,
+    /// Provider keys — the agent's direct `@ai-sdk` provider reads these from
+    /// env. (Eve's default gateway routing needs Vercel creds, so TAS agents
+    /// use a direct provider; see the Eve guide.)
+    pub openai_api_key: Option<&'a str>,
+    pub anthropic_api_key: Option<&'a str>,
+}
+
+/// Run the harness and return the parsed result plus tool calls + steps. Mirrors
+/// `pydantic::invoke`'s contract: tool calls/steps come back on both the success
+/// and failure path so a failed run still records what it did.
+pub async fn invoke(
+    args: EveArgs<'_>,
+) -> (anyhow::Result<PydanticResult>, Vec<ToolCall>, Vec<RunStep>) {
+    let files_json = match serde_json::to_string(args.agent_files) {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                Err(anyhow!("failed to serialize Eve agent files: {e}")),
+                Vec::new(),
+                Vec::new(),
+            )
+        }
+    };
+
+    let output = match spawn_and_wait(&args, &files_json).await {
+        Ok(o) => o,
+        Err(e) => return (Err(e), Vec::new(), Vec::new()),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let steps = pydantic::extract_steps(&stdout);
+    let tool_calls = if steps.is_empty() {
+        pydantic::extract_tool_calls(&stdout)
+    } else {
+        pydantic::flatten_step_tool_calls(&steps)
+    };
+
+    if !output.status.success() {
+        let snippet = if stderr.trim().is_empty() {
+            stdout.clone()
+        } else {
+            stderr.clone()
+        };
+        return (
+            Err(anyhow!(
+                "eve runner exited with status {}: {}",
+                output.status,
+                snippet.trim().chars().take(16_000).collect::<String>()
+            )),
+            tool_calls,
+            steps,
+        );
+    }
+
+    (Ok(pydantic::parse_output(&stdout)), tool_calls, steps)
+}
+
+async fn spawn_and_wait(
+    args: &EveArgs<'_>,
+    files_json: &str,
+) -> anyhow::Result<std::process::Output> {
+    let mut cmd = Command::new(EVE_NODE);
+    cmd.arg(EVE_SCRIPT)
+        .env_clear()
+        // pnpm + node + eve CLI live on PATH; HOME is needed by pnpm.
+        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("HOME", "/tmp")
+        .env("TAS_EVE_FILES", files_json)
+        .env("TAS_MESSAGE", args.user_message)
+        .env("TAS_EVE_PNPM_STORE", EVE_PNPM_STORE)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(k) = args.openai_api_key {
+        cmd.env("OPENAI_API_KEY", k);
+    }
+    if let Some(k) = args.anthropic_api_key {
+        cmd.env("ANTHROPIC_API_KEY", k);
+    }
+
+    let child = cmd.spawn().context("failed to spawn eve runner (node)")?;
+    let output = child
+        .wait_with_output()
+        .await
+        .context("eve runner process failed to complete")?;
+    Ok(output)
+}

--- a/api/src/runs/handlers.rs
+++ b/api/src/runs/handlers.rs
@@ -58,6 +58,11 @@ pub struct CreateRunRequest {
     /// Transient like spec_content (not persisted on the run row).
     #[serde(default)]
     pub skills_content: Option<std::collections::HashMap<String, String>>,
+    /// The whole Eve agent directory as `{ project-relative path: content }`.
+    /// Required for the "eve" framework; the web layer reads the directory at
+    /// dispatch (transient, not persisted on the run row).
+    #[serde(default)]
+    pub agent_files: Option<std::collections::HashMap<String, String>>,
     /// Where the run came from. Defaults to "manual" so existing
     /// callers (Run-now button, chat) don't need to change. The
     /// scheduler passes "schedule" + automation_id when firing on
@@ -138,6 +143,7 @@ pub async fn create_run(
     let spec_content = req.spec_content;
     let tools_module_content = req.tools_module_content;
     let skills_content = req.skills_content;
+    let agent_files = req.agent_files;
     let spec_format = match req.spec_format.as_deref() {
         Some("yaml") => runner::SpecFormat::Yaml,
         // JSON is the default so cargo-ai callers (which never
@@ -165,6 +171,7 @@ pub async fn create_run(
                 spec_format,
                 tools_module_content,
                 skills_content,
+                agent_files,
             },
         )
         .await;
@@ -179,6 +186,7 @@ pub async fn create_run(
 fn parse_framework(s: &str) -> runner::Framework {
     match s {
         "cargo-ai" => runner::Framework::CargoAi,
+        "eve" => runner::Framework::Eve,
         _ => runner::Framework::Pydantic,
     }
 }

--- a/api/src/runs/mod.rs
+++ b/api/src/runs/mod.rs
@@ -1,4 +1,5 @@
 pub mod cargo_ai;
+pub mod eve;
 pub mod handlers;
 pub mod pydantic;
 pub mod runner;

--- a/api/src/runs/pydantic.rs
+++ b/api/src/runs/pydantic.rs
@@ -705,7 +705,7 @@ async fn mark_connection_stale(
 /// and the parsed usage payload. A missing or malformed sentinel
 /// is non-fatal — we just record no usage rather than failing the
 /// run because token counts aren't critical.
-fn parse_output(stdout: &str) -> PydanticResult {
+pub(crate) fn parse_output(stdout: &str) -> PydanticResult {
     let mut output_lines: Vec<&str> = Vec::new();
     let mut usage = None;
     for line in stdout.lines() {
@@ -743,7 +743,7 @@ fn parse_output(stdout: &str) -> PydanticResult {
 /// Pull the `__TAS_TOOLS__:[...]` sentinel (a JSON array of
 /// `{name, ok, error}`) out of the wrapper's stdout. Absent or malformed
 /// is non-fatal — we just record no tool calls.
-fn extract_tool_calls(stdout: &str) -> Vec<ToolCall> {
+pub(crate) fn extract_tool_calls(stdout: &str) -> Vec<ToolCall> {
     for line in stdout.lines() {
         if let Some(json_part) = line.strip_prefix(TOOLS_SENTINEL) {
             if let Ok(parsed) = serde_json::from_str::<Vec<ToolCallJson>>(json_part) {
@@ -765,7 +765,7 @@ fn extract_tool_calls(stdout: &str) -> Vec<ToolCall> {
 /// Pull the `__TAS_STEPS__:[...]` sentinel (a JSON array of per-model-request
 /// usage + the tool calls each request emitted) out of the wrapper's stdout.
 /// Absent or malformed is non-fatal — we just record no steps.
-fn extract_steps(stdout: &str) -> Vec<RunStep> {
+pub(crate) fn extract_steps(stdout: &str) -> Vec<RunStep> {
     for line in stdout.lines() {
         if let Some(json_part) = line.strip_prefix(STEPS_SENTINEL) {
             if let Ok(parsed) = serde_json::from_str::<Vec<StepJson>>(json_part) {
@@ -802,7 +802,7 @@ fn extract_steps(stdout: &str) -> Vec<RunStep> {
 /// Flatten the tool calls across steps into a single call-ordered list,
 /// preserving each call's originating step_ordinal. Steps arrive in request
 /// order and their calls in emission order, so this is the run's call order.
-fn flatten_step_tool_calls(steps: &[RunStep]) -> Vec<ToolCall> {
+pub(crate) fn flatten_step_tool_calls(steps: &[RunStep]) -> Vec<ToolCall> {
     steps.iter().flat_map(|s| s.tool_calls.clone()).collect()
 }
 

--- a/api/src/runs/runner.rs
+++ b/api/src/runs/runner.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Context};
 use chrono::Utc;
 use uuid::Uuid;
 
-use crate::runs::{cargo_ai, pydantic};
+use crate::runs::{cargo_ai, eve, pydantic};
 use crate::workspace::{
     get_workspace_secret_plaintext, list_active_composio_connections,
     list_active_native_connections, list_workspace_secret_connections, SecretKind,
@@ -20,6 +20,7 @@ use crate::AppState;
 pub enum Framework {
     Pydantic,
     CargoAi,
+    Eve,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -65,6 +66,10 @@ pub struct RunContext {
     /// Files of the Agent Skills the agent opts into, as `{ repoPath: content }`,
     /// passed to the wrapper as TAS_SKILLS_CONTENT (JSON). Pydantic-only.
     pub skills_content: Option<std::collections::HashMap<String, String>>,
+    /// The whole Eve agent directory as `{ project-relative path: content }`
+    /// (the web layer strips the `agents/eve/<name>/` prefix). Required for the
+    /// Eve framework; ignored by the others.
+    pub agent_files: Option<std::collections::HashMap<String, String>>,
 }
 
 struct RunOutcome {
@@ -180,8 +185,83 @@ async fn run_inner(
                 Vec::new(),
             )
         }
+        Framework::Eve => run_eve(state, ctx).await,
         Framework::Pydantic => run_pydantic(state, ctx).await,
     }
+}
+
+async fn run_eve(
+    state: &AppState,
+    ctx: &RunContext,
+) -> (
+    anyhow::Result<RunOutcome>,
+    Vec<pydantic::ToolCall>,
+    Vec<pydantic::RunStep>,
+) {
+    let agent_files = match ctx.agent_files.as_ref().filter(|m| !m.is_empty()) {
+        Some(f) => f,
+        None => {
+            return (
+                Err(anyhow!("Eve run is missing the agent's directory files")),
+                Vec::new(),
+                Vec::new(),
+            )
+        }
+    };
+
+    // Eve agents call their model through a direct @ai-sdk provider, which reads
+    // the provider key from env. Load whichever the workspace has set.
+    let openai_key = get_workspace_secret_plaintext(
+        &state.db,
+        &state.encryption_key,
+        ctx.workspace_id,
+        SecretKind::OpenAiApiKey,
+    )
+    .await
+    .ok();
+    let anthropic_key = get_workspace_secret_plaintext(
+        &state.db,
+        &state.encryption_key,
+        ctx.workspace_id,
+        SecretKind::AnthropicApiKey,
+    )
+    .await
+    .ok();
+    if openai_key.is_none() && anthropic_key.is_none() {
+        return (
+            Err(anyhow!(
+                "No provider API keys set for this workspace. \
+                 Add either an OpenAI or Anthropic API key under \
+                 Settings → API keys before running an agent."
+            )),
+            Vec::new(),
+            Vec::new(),
+        );
+    }
+
+    let (result, tool_calls, steps) = eve::invoke(eve::EveArgs {
+        agent_files,
+        user_message: &ctx.user_message,
+        openai_api_key: openai_key.as_deref(),
+        anthropic_api_key: anthropic_key.as_deref(),
+    })
+    .await;
+
+    let outcome = result.map(|r| {
+        let usage = r.usage.as_ref().and_then(|u| {
+            u.input_output().map(|(input, output)| Usage {
+                input_tokens: input,
+                output_tokens: output,
+                cache_read_tokens: u.cache_read_tokens.unwrap_or(0),
+                cache_write_tokens: u.cache_write_tokens.unwrap_or(0),
+            })
+        });
+        RunOutcome {
+            output: render_output(&ctx.user_message, &r.output),
+            usage,
+        }
+    });
+    (outcome, tool_calls, steps)
 }
 
 async fn run_cargo_ai(

--- a/docs/src/content/docs/authoring-agents.md
+++ b/docs/src/content/docs/authoring-agents.md
@@ -82,3 +82,27 @@ Model choice is a cost/reliability tradeoff:
 - **Promote** a draft to a stable version when you're happy with it; automated
   runs serve stable by default. See
   [Agent lifecycle → promoting](/agent-studio/agent-lifecycle/#promoting-to-stable).
+
+## Eve agents (experimental)
+
+Alongside Pydantic AgentSpec and Cargo AI, TAS can run agents built with
+[Vercel Eve](https://github.com/vercel/eve). Unlike the others, an Eve agent is
+a **directory** of TypeScript files under `agents/eve/<name>/` (an `agent/agent.ts`,
+`agent/instructions.md`, a `package.json`, and a committed lockfile) rather than a
+single spec file. TAS runs it one turn at a time, locally and in-process — no
+Vercel deployment required.
+
+One rule matters when authoring for TAS: **configure the model with a direct
+`@ai-sdk` provider, not the AI Gateway string.** TAS runs with your workspace's
+Anthropic/OpenAI key and has no Gateway credentials, so:
+
+```ts
+import { defineAgent } from "eve";
+import { anthropic } from "@ai-sdk/anthropic";
+
+export default defineAgent({ model: anthropic("claude-opus-4-8") });
+```
+
+Add the provider package to the project's dependencies and commit the lockfile.
+Current scope: Eve agents always run their live directory (no versioned promotion
+yet), and chat-run isn't available for them — use **Run** on the agent page.

--- a/web/src/app/[workspace]/agents/[agent]/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/actions.ts
@@ -182,6 +182,7 @@ export async function runNowAction(
       framework: r.framework,
       specContent: r.specContent,
       specFormat: r.specFormat,
+      agentFiles: r.agentFiles,
       toolsModuleContent: r.toolsModuleContent,
       skillsContent: r.skillsContent,
       userMessage,
@@ -247,6 +248,11 @@ export async function promoteAgentAction(
     };
   }
   const spec = found.agent.spec;
+  // Eve agents are directories with no single-file snapshot — versioned
+  // promotion isn't supported in v1; they always run the live directory.
+  if (spec.framework === "eve") {
+    return { error: "Eve agents don't support versioned promotion yet." };
+  }
   const framework: "pydantic-agentspec" | "cargo-ai" =
     spec.framework === "pydantic-agentspec" ? "pydantic-agentspec" : "cargo-ai";
 

--- a/web/src/app/[workspace]/agents/[agent]/chat/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/chat/actions.ts
@@ -185,6 +185,16 @@ export async function sendToAgentAction(args: {
   }
   const spec = agent.spec;
 
+  // Eve agents are directories (no single raw file the chat surface threads
+  // through); run them from the agent page / API instead. v1 scope.
+  if (spec.framework === "eve") {
+    return {
+      ok: false,
+      error:
+        "Chat-run isn't supported for Eve agents yet — use Run on the agent page.",
+    };
+  }
+
   // Same dispatch the Run-now action uses — both frameworks pass
   // the raw file bytes to the api, which hands them to the
   // appropriate subprocess wrapper (cargo-ai CLI or pydantic-ai

--- a/web/src/app/[workspace]/agents/new/actions.ts
+++ b/web/src/app/[workspace]/agents/new/actions.ts
@@ -41,6 +41,9 @@ function parseFrameworkField(raw: unknown): Framework | null {
 const FRAMEWORK_PATH: Record<Framework, { dir: string; ext: "yaml" | "json" }> = {
   "pydantic-agentspec": { dir: "pydantic-agentspec", ext: "yaml" },
   "cargo-ai": { dir: "cargo-ai", ext: "json" },
+  // Eve agents are directories; the entrypoint path is computed specially
+  // below. ext is unused for eve.
+  eve: { dir: "eve", ext: "json" },
 };
 
 export type ChatCreateFormState = {
@@ -116,7 +119,10 @@ export async function createFromChatAction(
   }
 
   const { dir, ext } = FRAMEWORK_PATH[framework];
-  const agentPath = `agents/${dir}/${agentSlug}.${ext}`;
+  const agentPath =
+    framework === "eve"
+      ? `agents/eve/${agentSlug}/agent/agent.ts`
+      : `agents/${dir}/${agentSlug}.${ext}`;
 
   // Persist the request as an improvement row before talking to
   // Tembo so we own the id we embed in the prompt. agent_name +

--- a/web/src/app/api/hooks/composio/[workspace]/route.ts
+++ b/web/src/app/api/hooks/composio/[workspace]/route.ts
@@ -166,6 +166,7 @@ export async function POST(
         framework: r.framework,
         spec_content: r.specContent,
         spec_format: r.specFormat,
+        agent_files: r.agentFiles,
         tools_module_content: r.toolsModuleContent,
         skills_content: r.skillsContent,
         trigger: "event",

--- a/web/src/app/api/hooks/webhook/[webhookId]/route.ts
+++ b/web/src/app/api/hooks/webhook/[webhookId]/route.ts
@@ -112,6 +112,7 @@ export async function POST(
       framework: r.framework,
       specContent: r.specContent,
       specFormat: r.specFormat,
+      agentFiles: r.agentFiles,
       toolsModuleContent: r.toolsModuleContent,
       skillsContent: r.skillsContent,
       trigger: "event",

--- a/web/src/lib/agent-format.ts
+++ b/web/src/lib/agent-format.ts
@@ -123,7 +123,48 @@ export type CargoAiSpec = AgentSpecBase & {
   model: string | null;
 };
 
-export type AgentSpec = PydanticAgentSpec | CargoAiSpec;
+/**
+ * An Eve agent. Unlike the other two frameworks it is a *directory*, not a
+ * single parseable file — so it's never produced by `parseAgentContent`. It's
+ * built from the directory listing by `buildEveSpec`; `model` is a best-effort
+ * read of `agent/agent.ts` (the source of truth at run time is agent.ts itself).
+ */
+export type EveSpec = AgentSpecBase & {
+  framework: "eve";
+  model: string | null;
+};
+
+export type AgentSpec = PydanticAgentSpec | CargoAiSpec | EveSpec;
+
+/**
+ * Best-effort model string from an Eve agent's `agent/agent.ts`. Matches both
+ * the direct-provider form `anthropic("claude-…")` / `openai("…")` and the
+ * gateway string `model: "anthropic/claude-…"`. Returns null when unrecognized
+ * — cost estimation falls back gracefully and the run still uses agent.ts.
+ */
+export function extractEveModel(agentTs: string | undefined): string | null {
+  if (!agentTs) return null;
+  const direct = agentTs.match(
+    /\b(anthropic|openai|google|groq|mistral|xai)\s*\(\s*["'`]([^"'`]+)["'`]/,
+  );
+  if (direct) return `${direct[1]}:${direct[2]}`;
+  const gateway = agentTs.match(/\bmodel\s*:\s*["'`]([^"'`]+)["'`]/);
+  if (gateway) return gateway[1];
+  return null;
+}
+
+/** Build an EveSpec from a directory name + its `agent/agent.ts` content. */
+export function buildEveSpec(name: string, agentTs: string | undefined): EveSpec {
+  return {
+    name,
+    title: undefined,
+    description: undefined,
+    labels: [],
+    raw: {},
+    framework: "eve",
+    model: extractEveModel(agentTs),
+  };
+}
 
 export type AgentFileFormat = "yaml" | "json";
 

--- a/web/src/lib/agent-framework.ts
+++ b/web/src/lib/agent-framework.ts
@@ -16,10 +16,17 @@
 // agent flow) is a *different* concept and is intentionally deferred until
 // raw-coding-agent flows are first-class — likely v0.3+.
 
-export const FRAMEWORKS = ["pydantic-agentspec", "cargo-ai"] as const;
+//   - `eve` — Vercel's Eve framework. Unlike the other two, an Eve agent is a
+//     *directory* of TypeScript files (agent/agent.ts, tools/, …), not a single
+//     spec file. TAS runs it one-shot in-process via the Node harness (see
+//     api/scripts/run_eve.mjs); the model is configured in agent.ts with a
+//     direct @ai-sdk provider.
+
+export const FRAMEWORKS = ["pydantic-agentspec", "cargo-ai", "eve"] as const;
 export type Framework = (typeof FRAMEWORKS)[number];
 
 export const FRAMEWORK_LABELS: Record<Framework, string> = {
   "pydantic-agentspec": "Pydantic",
   "cargo-ai": "Cargo AI",
+  eve: "Eve",
 };

--- a/web/src/lib/agent-guidance.ts
+++ b/web/src/lib/agent-guidance.ts
@@ -964,6 +964,54 @@ export const GUIDANCE_ADDITIONAL_PATH = "ADDITIONAL_AGENT_INSTRUCTIONS.md";
 export const GUIDANCE_INDEX_PATH = "agents/AGENTS.md";
 export const GUIDANCE_PYDANTIC_PATH = "agents/pydantic-agentspec/AGENT_GUIDE.md";
 export const GUIDANCE_CARGO_AI_PATH = "agents/cargo-ai/AGENT_GUIDE.md";
+export const GUIDANCE_EVE_PATH = "agents/eve/AGENT_GUIDE.md";
+
+// Eve agents are directories (not single-file specs). TAS runs them one-shot,
+// in-process, with no Vercel deploy and no AI Gateway — so the single
+// non-negotiable rule is: configure the model with a DIRECT @ai-sdk provider,
+// not the gateway string. Everything else is standard Eve.
+const EVE_GUIDE: string = `# Eve Agent Guide (Tembo Agent Studio)
+
+An Eve agent is a **directory** under \`agents/eve/<name>/\`, scaffolded by the
+Eve CLI. Minimum shape:
+
+\`\`\`
+agents/eve/<name>/
+  agent/agent.ts          # model + config (defineAgent)
+  agent/instructions.md   # system prompt
+  package.json            # deps incl. eve + a direct @ai-sdk provider
+  pnpm-lock.yaml          # commit this — the runner installs from it
+\`\`\`
+
+The directory name, the \`name:\`, and how TAS lists the agent must all match.
+
+## CRITICAL: use a direct provider, not the AI Gateway
+
+TAS runs Eve agents locally with the workspace's \`ANTHROPIC_API_KEY\` /
+\`OPENAI_API_KEY\` — it does **not** have Vercel AI Gateway credentials. The
+default scaffold's gateway model string (\`model: "anthropic/claude-…"\`) will
+fail with "AI Gateway received no credentials". Use a direct \`LanguageModel\`:
+
+\`\`\`ts
+import { defineAgent } from "eve";
+import { anthropic } from "@ai-sdk/anthropic";
+
+export default defineAgent({
+  model: anthropic("claude-opus-4-8"),
+});
+\`\`\`
+
+Add the provider to dependencies (matching your \`ai\` version), e.g.
+\`@ai-sdk/anthropic\` for \`ai@7\` betas, and commit the updated lockfile.
+
+## What TAS uses (and doesn't)
+
+- TAS drives **one turn** per run and captures the reply + token usage.
+- Tools defined under \`agent/tools/\` work; tool execution uses Eve's local
+  sandbox.
+- Channels, schedules, and durable/deploy features are **not** used by a TAS run
+  — TAS is the runner. Keep the agent runnable headless.
+`;
 
 // Customer-managed instructions slot. Created once, never refreshed.
 // No version marker — TAS treats this file as opaque after first
@@ -992,6 +1040,11 @@ export function guidanceFilesFor(framework: Framework): GuidanceFile[] {
       path: GUIDANCE_CARGO_AI_PATH,
       content: withVersionMarker(CARGO_AI_GUIDE),
     });
+  } else if (framework === "eve") {
+    files.push({
+      path: GUIDANCE_EVE_PATH,
+      content: withVersionMarker(EVE_GUIDE),
+    });
   } else {
     files.push({
       path: GUIDANCE_PYDANTIC_PATH,
@@ -1013,6 +1066,10 @@ export function allGuidanceFiles(): GuidanceFile[] {
     {
       path: GUIDANCE_CARGO_AI_PATH,
       content: withVersionMarker(CARGO_AI_GUIDE),
+    },
+    {
+      path: GUIDANCE_EVE_PATH,
+      content: withVersionMarker(EVE_GUIDE),
     },
     {
       path: GUIDANCE_PYDANTIC_PATH,

--- a/web/src/lib/agent-versions.ts
+++ b/web/src/lib/agent-versions.ts
@@ -9,7 +9,7 @@ import { db } from "@/lib/db";
 // (workspace_id, agent_name) — see migration 0037 for the identity model.
 
 export type AgentStage = "stable" | "beta" | "draft" | "archived";
-export type AgentFramework = "pydantic-agentspec" | "cargo-ai";
+export type AgentFramework = "pydantic-agentspec" | "cargo-ai" | "eve";
 export type SpecFormat = "yaml" | "json";
 
 export type AgentVersion = {

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -150,6 +150,7 @@ export async function triggerRun(
       framework: r.framework,
       specContent: r.specContent,
       specFormat: r.specFormat,
+      agentFiles: r.agentFiles,
       toolsModuleContent: r.toolsModuleContent,
       skillsContent: r.skillsContent,
       userMessage: input.message ?? "",
@@ -282,6 +283,8 @@ export type RequestAgentChangeResult = {
 const FRAMEWORK_PATH: Record<Framework, { dir: string; ext: AgentFileFormat }> = {
   "pydantic-agentspec": { dir: "pydantic-agentspec", ext: "yaml" },
   "cargo-ai": { dir: "cargo-ai", ext: "json" },
+  // Eve agents are directories; entrypoint path computed specially below.
+  eve: { dir: "eve", ext: "json" },
 };
 
 // Not audited explicitly: this creates an improvement row, which projects into
@@ -375,7 +378,10 @@ export async function requestAgentChange(
   const { dir, ext } = FRAMEWORK_PATH[framework];
   kind = "create";
   agentName = agentSlug;
-  agentPath = `agents/${dir}/${agentSlug}.${ext}`;
+  agentPath =
+    framework === "eve"
+      ? `agents/eve/${agentSlug}/agent/agent.ts`
+      : `agents/${dir}/${agentSlug}.${ext}`;
 
   const row = await createImprovement({
     workspaceId: ctx.workspace.id,

--- a/web/src/lib/cap-api.ts
+++ b/web/src/lib/cap-api.ts
@@ -3,11 +3,19 @@ import "server-only";
 import {
   GUIDANCE_ADDITIONAL_PATH,
   GUIDANCE_CARGO_AI_PATH,
+  GUIDANCE_EVE_PATH,
   GUIDANCE_INDEX_PATH,
   GUIDANCE_PYDANTIC_PATH,
   GUIDANCE_ROOT_PATH,
 } from "@/lib/agent-guidance";
 import type { Framework } from "@/lib/agent-framework";
+
+/** The per-framework guide path for prompt pointers. */
+function frameworkGuidePath(framework: Framework): string {
+  if (framework === "eve") return GUIDANCE_EVE_PATH;
+  if (framework === "cargo-ai") return GUIDANCE_CARGO_AI_PATH;
+  return GUIDANCE_PYDANTIC_PATH;
+}
 import type { CommitMode } from "@/lib/commit-mode-constants";
 
 // Thin client for the Tembo Coding Agent Platform task API. The task
@@ -119,6 +127,7 @@ export async function createTemboTask(args: {
 // it's the safer default.
 function frameworkFromAgentPath(path: string): Framework {
   if (path.startsWith("agents/cargo-ai/")) return "cargo-ai";
+  if (path.startsWith("agents/eve/")) return "eve";
   return "pydantic-agentspec";
 }
 
@@ -133,8 +142,7 @@ function frameworkFromAgentPath(path: string): Framework {
 // this PR touches so Tembo doesn't waste tokens reading the other
 // framework's guide.
 function buildGuidancePointerBlock(framework: Framework): string {
-  const frameworkGuide =
-    framework === "cargo-ai" ? GUIDANCE_CARGO_AI_PATH : GUIDANCE_PYDANTIC_PATH;
+  const frameworkGuide = frameworkGuidePath(framework);
   return [
     "**Step 1 — Read the agent guidance first**",
     "",
@@ -224,8 +232,7 @@ export function buildCreateAgentPrompt(args: {
   /** Signed token CAP appends as `?key=` when fetching the reference. */
   nativeToolsKey?: string;
 }): string {
-  const frameworkGuide =
-    args.framework === "cargo-ai" ? GUIDANCE_CARGO_AI_PATH : GUIDANCE_PYDANTIC_PATH;
+  const frameworkGuide = frameworkGuidePath(args.framework);
   return [
     `Create an agent at \`${args.agentPath}\` named \`${args.agentName}\` using these docs in the connected repo as your guide:`,
     "",

--- a/web/src/lib/runs-api.ts
+++ b/web/src/lib/runs-api.ts
@@ -28,9 +28,13 @@ export type CreateRunInput = {
   // upstream tool — Pydantic agents through the bundled Python
   // wrapper, Cargo AI agents through the bundled cargo-ai CLI. The
   // runner needs the raw file contents and format for both.
-  framework?: "pydantic-agentspec" | "cargo-ai";
+  framework?: "pydantic-agentspec" | "cargo-ai" | "eve";
   specContent?: string;
   specFormat?: "yaml" | "json";
+  // The whole Eve agent directory as { project-relative path: content }. Set
+  // only for framework "eve" (Eve agents are directories, not single files);
+  // the API forwards it to the Node harness. Runtime-only (not persisted).
+  agentFiles?: Record<string, string>;
   // Optional sidecar Python module (the agent's `tools_module:`) whose
   // functions the pydantic wrapper exposes to the model as tools. Read
   // from the repo at dispatch time; runtime-only (not persisted).
@@ -147,6 +151,7 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunRespons
       framework: input.framework,
       spec_content: input.specContent,
       spec_format: input.specFormat,
+      agent_files: input.agentFiles,
       tools_module_content: input.toolsModuleContent,
       skills_content: input.skillsContent,
       trigger: input.trigger,

--- a/web/src/lib/scheduler.ts
+++ b/web/src/lib/scheduler.ts
@@ -149,6 +149,7 @@ async function maybeFire(a: Automation, now: Date) {
       framework: r.framework,
       spec_content: r.specContent,
       spec_format: r.specFormat,
+      agent_files: r.agentFiles,
       tools_module_content: r.toolsModuleContent,
       skills_content: r.skillsContent,
       trigger: "schedule",

--- a/web/src/lib/slack-dispatch.ts
+++ b/web/src/lib/slack-dispatch.ts
@@ -276,6 +276,7 @@ export async function dispatchToAgent(args: {
       framework: r.framework,
       specContent: r.specContent,
       specFormat: r.specFormat,
+      agentFiles: r.agentFiles,
       toolsModuleContent: r.toolsModuleContent,
       skillsContent: r.skillsContent,
       trigger: "event",

--- a/web/src/lib/workspace-agents.ts
+++ b/web/src/lib/workspace-agents.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import {
+  buildEveSpec,
   detectFormat,
   parseAgentContent,
   parseAgentFile,
@@ -38,9 +39,97 @@ const AGENTS_DIR = "agents";
 const FRAMEWORK_DIRS: Record<Framework, string> = {
   "pydantic-agentspec": "pydantic-agentspec",
   "cargo-ai": "cargo-ai",
+  eve: "eve",
 };
 
-const FRAMEWORK_DIR_VALUES = Object.values(FRAMEWORK_DIRS);
+// File-based frameworks only — Eve is a directory per agent and is scanned
+// separately (listEveAgents), so it's excluded from the one-file-per-agent walk.
+const FILE_FRAMEWORK_DIR_VALUES = [
+  FRAMEWORK_DIRS["pydantic-agentspec"],
+  FRAMEWORK_DIRS["cargo-ai"],
+];
+
+const EVE_DIR = `${AGENTS_DIR}/${FRAMEWORK_DIRS.eve}`;
+// Eve agent directory total-size cap (TS + config; deps are NOT included — the
+// runner installs them from package.json at run time).
+const EVE_DIR_MAX_BYTES = 2 * 1024 * 1024;
+const EVE_MAX_DEPTH = 8;
+
+/**
+ * Read a whole Eve agent directory (`agents/eve/<name>/`) as
+ * `{ project-relative path: content }` — e.g. `agent/agent.ts`. Skips
+ * `node_modules` and the build output. Returns ok:false when the directory has
+ * no `agent/agent.ts` (not an Eve agent) or exceeds the size cap.
+ */
+export async function readEveAgentDir(
+  token: string,
+  ref: RepoRef,
+  name: string,
+): Promise<
+  { ok: true; files: Record<string, string> } | { ok: false; detail: string }
+> {
+  const root = `${EVE_DIR}/${name}`;
+  const files: Record<string, string> = {};
+  let total = 0;
+
+  async function walk(path: string, depth: number): Promise<string | null> {
+    if (depth > EVE_MAX_DEPTH) return null;
+    const listing = await listDirectory(token, ref, path);
+    if (!listing.ok) return listing.detail ?? listing.error;
+    if ("missing" in listing && listing.missing) {
+      return depth === 0 ? `Eve agent "${root}" not found` : null;
+    }
+    for (const entry of listing.entries) {
+      if (entry.name === "node_modules" || entry.name === ".output") continue;
+      if (entry.type === "dir") {
+        const err = await walk(entry.path, depth + 1);
+        if (err) return err;
+      } else if (entry.type === "file") {
+        const read = await readFile(token, ref, entry.path);
+        if (!read.ok) return read.detail ?? read.error;
+        total += read.content.length;
+        if (total > EVE_DIR_MAX_BYTES) {
+          return `Eve agent "${name}" exceeds the ${EVE_DIR_MAX_BYTES}-byte limit`;
+        }
+        // Strip the `agents/eve/<name>/` prefix → project-relative path.
+        const rel = entry.path.slice(root.length + 1);
+        files[rel] = read.content;
+      }
+    }
+    return null;
+  }
+
+  const err = await walk(root, 0);
+  if (err) return { ok: false, detail: err };
+  if (!files["agent/agent.ts"]) {
+    return { ok: false, detail: `Eve agent "${name}" has no agent/agent.ts` };
+  }
+  return { ok: true, files };
+}
+
+/** List Eve agents — one per subdirectory of `agents/eve/` with an agent.ts. */
+async function listEveAgents(
+  token: string,
+  ref: RepoRef,
+): Promise<ListedAgent[]> {
+  const listing = await listDirectory(token, ref, EVE_DIR);
+  if (!listing.ok || ("missing" in listing && listing.missing)) return [];
+  const out: ListedAgent[] = [];
+  for (const entry of listing.entries) {
+    if (entry.type !== "dir") continue;
+    const name = entry.name;
+    const agentTs = await readFile(token, ref, `${entry.path}/agent/agent.ts`);
+    if (!agentTs.ok) continue; // not an Eve agent dir
+    out.push({
+      filename: name,
+      path: entry.path,
+      format: "json",
+      ok: true,
+      spec: buildEveSpec(name, agentTs.content),
+    });
+  }
+  return out;
+}
 
 // ── Sidecar tools module ─────────────────────────────────────────────
 //
@@ -213,7 +302,7 @@ export async function listAgents(workspaceId: string): Promise<ListAgentsResult>
   // fresh repo won't have an agents/cargo-ai/ directory yet) — those
   // surface as `entries: []` from listDirectory's `missing: true` path.
   const subfolderListings = await Promise.all(
-    FRAMEWORK_DIR_VALUES.map((dir) =>
+    FILE_FRAMEWORK_DIR_VALUES.map((dir) =>
       listDirectory(token, ref, `${AGENTS_DIR}/${dir}`),
     ),
   );
@@ -266,6 +355,9 @@ export async function listAgents(workspaceId: string): Promise<ListAgentsResult>
     }),
   );
 
+  // Eve agents are directories, scanned separately, then merged in.
+  agents.push(...(await listEveAgents(token, ref)));
+
   // Stable order: valid first (by name), then invalid (by filename).
   agents.sort((a, b) => {
     if (a.ok !== b.ok) return a.ok ? -1 : 1;
@@ -315,6 +407,14 @@ export async function getAgentByName(
     name: repo.name,
     branch: repo.defaultBranch,
   };
+  // Eve agents are directories: there's no single file to read. Surface the
+  // entrypoint (agent/agent.ts) as `raw` for the definition view.
+  if (match.ok && match.spec.framework === "eve") {
+    const dir = await readEveAgentDir(token, ref, match.spec.name);
+    const raw = dir.ok ? (dir.files["agent/agent.ts"] ?? "") : "";
+    return { agent: match, raw };
+  }
+
   const read = await readFile(token, ref, match.path);
   if (!read.ok) return null;
 
@@ -367,6 +467,10 @@ export type ResolvedDispatch = {
   /** External services the agent declares (Pydantic only; [] otherwise).
    *  Used to pre-flight the acting user's connections before a run. */
   connections: AgentConnection[];
+  /** The whole Eve agent directory as { project-relative path: content }.
+   *  Set only for framework "eve" (its specContent is empty — the directory is
+   *  the agent). The runner ships this to the Node harness as agent_files. */
+  agentFiles?: Record<string, string>;
 };
 
 export type ResolveDispatchError =
@@ -476,6 +580,48 @@ export async function resolveAgentForDispatch(
       },
     };
   }
+
+  // Eve agents are directories with no stable snapshot (v1): always run the live
+  // directory. Ship the whole tree as agentFiles; the model lives in agent.ts so
+  // an empty `model` is fine here.
+  if (found.agent.spec.framework === "eve") {
+    const repo = await getWorkspaceRepo(workspaceId);
+    if (!repo) {
+      return { ok: false, error: { kind: "not-found", message: "no connected repo" } };
+    }
+    const token = await getWorkspaceSecretPlaintext(workspaceId, "github_pat");
+    const ref: RepoRef = {
+      owner: repo.owner,
+      name: repo.name,
+      branch: repo.defaultBranch,
+    };
+    const eveDir = await readEveAgentDir(token, ref, agentName);
+    if (!eveDir.ok) {
+      return {
+        ok: false,
+        error: {
+          kind: "invalid",
+          message: `Eve agent "${agentName}" couldn't be read: ${eveDir.detail}`,
+        },
+      };
+    }
+    return {
+      ok: true,
+      resolved: {
+        agentName: found.agent.spec.name,
+        agentPath: found.agent.path,
+        framework: "eve",
+        model: found.agent.spec.model ?? "",
+        specContent: "",
+        specFormat: "json",
+        versionId: null,
+        versionLabel: "draft",
+        agentFiles: eveDir.files,
+        connections: [],
+      },
+    };
+  }
+
   const spec = found.agent.spec;
   const model = spec.model ?? "";
   if (!model) {


### PR DESCRIPTION
Adds **Eve** (github.com/vercel/eve) as a third agent framework alongside Pydantic AgentSpec and Cargo AI. An Eve agent committed at `agents/eve/<name>/` is listed like any other agent and **Run** (plus scheduler / Slack / webhook / REST / Composio triggers) executes it — one turn, locally, in-process, with **no Eve HTTP server** — capturing reply + token usage into the `run`/`run_step` rows exactly like the other frameworks.

## Why this was non-trivial

Eve isn't a single-file spec — it's a *directory* of TypeScript files, and it has **no public server-less one-shot execution mode** (everything routes through its HTTP app + the Vercel Workflow SDK). A spike proved we can run a turn fully in-process with no listening socket by building the agent, patching out the Nitro `serve()` call to expose the fetch handler, pointing the Workflow SDK's local backend at a sentinel host, and looping its callbacks back through `globalThis.fetch`. See `api/scripts/EVE_SPIKE_NOTES.md`.

## What's in here

**Backend (execution path)**
- `api/scripts/run_eve.mjs` — the harness: materialize the agent dir → `pnpm install` → `eve build` → patch `serve()` → workflow loopback → drive via `eve/client` → emit `__TAS_USAGE__`/`__TAS_STEPS__`.
- `api/src/runs/eve.rs` — spawns the harness, reuses the Pydantic sentinel parsers.
- `runner.rs` / `handlers.rs` / `mod.rs` — `Framework::Eve` dispatch, `RunContext.agent_files`, `CreateRunRequest.agent_files`, `parse_framework "eve"`.
- `api/Dockerfile` — **Node 24 + pnpm@10** + the harness + a persistent pnpm store. *(Adds a third language runtime to the API image — see review note.)*

**Web (directory-as-agent modeling)**
- Registry (`FRAMEWORKS`/labels/`AgentFramework`), `EveSpec` + `buildEveSpec`/`extractEveModel`.
- `workspace-agents.ts`: `readEveAgentDir`, `listEveAgents` (scan subdirs), `getAgentByName` + `resolveAgentForDispatch` eve branches (live dir → `agentFiles`, no stable snapshot).
- `runs-api.ts` `agentFiles` → `agent_files`, threaded through every dispatch consumer.
- CAP (`cap-api.ts`), `agent-guidance.ts` Eve guide, docs.

## Critical authoring rule (baked into the Eve guide)

TAS runs with the workspace's Anthropic/OpenAI key and **no AI Gateway credentials**, so Eve agents must use a **direct `@ai-sdk` provider** model (`model: anthropic("claude-opus-4-8")`), not the default gateway string.

## Validated locally (all green)
- `cargo test` — 38 pass; `cargo check` clean
- web `tsc --noEmit` — 0 errors
- web `eslint` — 0 errors
- web `vitest` — 101 pass
- The spike ran a real Eve turn end-to-end in-process (text + token usage) with live API keys.

## NOT yet verified — test plan before merge
- [ ] **Build the API Docker image** (the new Node-24 layer) — unbuilt locally.
- [ ] **End-to-end on the internal Railway instance**: commit a sample `agents/eve/hello/` (direct-provider model), Run it, confirm output + token/step usage + cost render like a Pydantic run; confirm a second run hits the pnpm store cache.
- [ ] Confirm pnpm install at runtime works as the non-root `tas` user (HOME=/tmp, `/opt/eve-store`).

## v1 scope (flagged in code + docs)
- Eve agents always run the live directory (no versioned promotion); chat-run is disabled for them (use Run).
- Tool-using agents rely on Eve's local sandbox (`just-bash`); no Composio/native-MCP credential injection (Eve manages its own).

## Review note
This adds **Node 24 + pnpm to the production API container** and runs agent-authored TypeScript at run time (acceptable on TAS's single-tenant, customer-owned deployment, but worth a conscious look). If you'd prefer Eve execution in a separate sidecar/image rather than the main API container, that's a reasonable alternative the web dispatch could target instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
