### PR TITLE
test(api): add pydantic runner smoke test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,3 +64,10 @@ jobs:
         run: cargo clippy --all-targets
       - name: Test (blocking)
         run: cargo test
+      - name: Pydantic runner smoke test (blocking)
+        run: |
+          python3 -m venv /tmp/pydantic-ai
+          /tmp/pydantic-ai/bin/pip install --no-cache-dir \
+            'pydantic-ai[mcp]==1.102.0' pyyaml==6.0.2 composio==0.13.1 \
+            pydantic-ai-skills==0.11.0 pytest==9.1.1
+          /tmp/pydantic-ai/bin/pytest tests/test_run_pydantic_build_agent.py

--- a/api/tests/test_run_pydantic_build_agent.py
+++ b/api/tests/test_run_pydantic_build_agent.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic_ai import Agent
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import run_pydantic
+
+
+@pytest.fixture(autouse=True)
+def provider_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {
+            "name": "anthropic-basic",
+            "model": "anthropic:claude-sonnet-4-5",
+            "instructions": "Reply briefly.",
+        },
+        {
+            "name": "openai-basic",
+            "model": "openai:gpt-5-mini",
+            "instructions": "Reply briefly.",
+        },
+        {
+            "name": "anthropic-settings",
+            "model": "anthropic:claude-sonnet-4-5",
+            "instructions": "Reply briefly.",
+            "model_settings": {
+                "temperature": 0,
+                "parallel_tool_calls": True,
+            },
+        },
+    ],
+)
+def test_build_agent_constructs_provider_models(spec: dict) -> None:
+    assert isinstance(run_pydantic.build_agent(spec), Agent)
+
+
+def test_build_agent_constructs_with_tools_module() -> None:
+    tools = run_pydantic.load_tools_module(
+        """
+def echo(message: str) -> str:
+    \"\"\"Return the provided message.\"\"\"
+    return message
+
+tools = [echo]
+"""
+    )
+
+    agent = run_pydantic.build_agent(
+        {
+            "name": "openai-tools",
+            "model": "openai:gpt-5-mini",
+            "instructions": "Use the echo tool when helpful.",
+            "tools_module": "agent_tools.py",
+        },
+        tools=tools,
+    )
+
+    assert isinstance(agent, Agent)


### PR DESCRIPTION
## Summary
- Add an offline pytest smoke test for `run_pydantic.build_agent` across Anthropic and OpenAI model strings.
- Cover Anthropic `model_settings` construction and sidecar `tools_module` loading.
- Run the smoke test in the API checks workflow using the pinned pydantic-ai runner venv dependencies.

Closes #182.

## Tests
- `/tmp/pydantic-ai-agent-studio/bin/pytest tests/test_run_pydantic_build_agent.py`
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/4d4db224-02eb-447e-a431-b662917fa9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11" height="28"></picture></a> 