### PR TITLE
test(auth): cover mocked oidc sign-in contract

### DIFF
--- a/web/src/components/auth-setup-guide.tsx
+++ b/web/src/components/auth-setup-guide.tsx
@@ -4,7 +4,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { getConfiguredAuthProviders } from "@/lib/auth-providers";
+import {
+  authProviderRedirectUri,
+  getConfiguredAuthProviders,
+} from "@/lib/auth-providers";
 import { getPublicOrigin } from "@/lib/config";
 
 const code =
@@ -61,12 +64,6 @@ export function AuthSetupGuide() {
   const origin = getPublicOrigin();
   const configured = new Set(getConfiguredAuthProviders().map((p) => p.id));
 
-  function redirectUri(g: ProviderGuide): string {
-    return g.kind === "social"
-      ? `${origin}/api/auth/callback/${g.id}`
-      : `${origin}/api/auth/oauth2/callback/${g.id}`;
-  }
-
   return (
     <Card className="w-full max-w-md p-3">
       <CardHeader className="px-1 pb-2 pt-1">
@@ -93,7 +90,8 @@ export function AuthSetupGuide() {
               )}
             </div>
             <p className="text-foreground-weak text-sm">
-              Redirect URI: <code className={code}>{redirectUri(g)}</code>
+              Redirect URI:{" "}
+              <code className={code}>{authProviderRedirectUri(g, origin)}</code>
             </p>
             <p className="text-foreground-weak text-sm">
               Env:{" "}

--- a/web/src/lib/auth-providers.test.ts
+++ b/web/src/lib/auth-providers.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  authProviderRedirectUri,
+  emailPasswordEnabled,
+  genericOAuthConfigs,
+  getConfiguredAuthProviders,
+  microsoftDiscoveryUrl,
+} from "./auth-providers";
+
+const ORIGINAL_ENV = process.env;
+
+function setEnv(env: Record<string, string>) {
+  process.env = { ...ORIGINAL_ENV, ...env };
+}
+
+function clearProviderEnv() {
+  process.env = { ...ORIGINAL_ENV };
+  for (const key of [
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "MICROSOFT_CLIENT_ID",
+    "MICROSOFT_CLIENT_SECRET",
+    "MICROSOFT_TENANT_ID",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_DISCOVERY_URL",
+    "OIDC_PROVIDER_NAME",
+    "OIDC_SCOPES",
+  ]) {
+    delete process.env[key];
+  }
+}
+
+function unsignedJwt(claims: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString(
+    "base64url",
+  );
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.`;
+}
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("auth provider configuration", () => {
+  it("renders every configured provider independently", () => {
+    clearProviderEnv();
+    setEnv({
+      GOOGLE_CLIENT_ID: "google-id",
+      GOOGLE_CLIENT_SECRET: "google-secret",
+      MICROSOFT_CLIENT_ID: "microsoft-id",
+      MICROSOFT_CLIENT_SECRET: "microsoft-secret",
+      OIDC_CLIENT_ID: "oidc-id",
+      OIDC_CLIENT_SECRET: "oidc-secret",
+      OIDC_DISCOVERY_URL: "https://idp.example.com/.well-known/openid-configuration",
+      OIDC_PROVIDER_NAME: "Acme SSO",
+    });
+
+    expect(getConfiguredAuthProviders()).toEqual([
+      { id: "google", label: "Google", kind: "social" },
+      { id: "microsoft", label: "Microsoft", kind: "oauth2" },
+      { id: "oidc", label: "Acme SSO", kind: "oauth2" },
+    ]);
+    expect(emailPasswordEnabled()).toBe(false);
+  });
+
+  it("builds the redirect URIs expected by each provider type", () => {
+    expect(
+      authProviderRedirectUri(
+        { id: "google", kind: "social" },
+        "https://tas.example.com/",
+      ),
+    ).toBe("https://tas.example.com/api/auth/callback/google");
+    expect(
+      authProviderRedirectUri(
+        { id: "microsoft", kind: "oauth2" },
+        "https://tas.example.com/",
+      ),
+    ).toBe("https://tas.example.com/api/auth/oauth2/callback/microsoft");
+    expect(
+      authProviderRedirectUri(
+        { id: "oidc", kind: "oauth2" },
+        "https://tas.example.com",
+      ),
+    ).toBe("https://tas.example.com/api/auth/oauth2/callback/oidc");
+  });
+
+  it("configures Microsoft and generic OIDC through genericOAuth", () => {
+    clearProviderEnv();
+    setEnv({
+      MICROSOFT_CLIENT_ID: "microsoft-id",
+      MICROSOFT_CLIENT_SECRET: "microsoft-secret",
+      MICROSOFT_TENANT_ID: "tenant-123",
+      OIDC_CLIENT_ID: "oidc-id",
+      OIDC_CLIENT_SECRET: "oidc-secret",
+      OIDC_DISCOVERY_URL: "https://idp.example.com/.well-known/openid-configuration",
+      OIDC_SCOPES: "openid profile email groups",
+    });
+
+    expect(microsoftDiscoveryUrl()).toBe(
+      "https://login.microsoftonline.com/tenant-123/v2.0/.well-known/openid-configuration",
+    );
+    expect(genericOAuthConfigs()).toMatchObject([
+      {
+        providerId: "microsoft",
+        discoveryUrl:
+          "https://login.microsoftonline.com/tenant-123/v2.0/.well-known/openid-configuration",
+        clientId: "microsoft-id",
+        clientSecret: "microsoft-secret",
+        scopes: ["openid", "profile", "email"],
+      },
+      {
+        providerId: "oidc",
+        discoveryUrl: "https://idp.example.com/.well-known/openid-configuration",
+        clientId: "oidc-id",
+        clientSecret: "oidc-secret",
+        scopes: ["openid", "profile", "email", "groups"],
+      },
+    ]);
+  });
+
+  it("maps Microsoft preferred_username into a verified email", async () => {
+    clearProviderEnv();
+    setEnv({
+      MICROSOFT_CLIENT_ID: "microsoft-id",
+      MICROSOFT_CLIENT_SECRET: "microsoft-secret",
+    });
+    const microsoft = genericOAuthConfigs().find(
+      (config) => config.providerId === "microsoft",
+    );
+
+    await expect(
+      microsoft?.getUserInfo?.({
+        idToken: unsignedJwt({
+          sub: "entra-user-1",
+          preferred_username: "invited@example.com",
+          name: "Invited User",
+        }),
+      }),
+    ).resolves.toEqual({
+      id: "entra-user-1",
+      email: "invited@example.com",
+      emailVerified: true,
+      name: "Invited User",
+      image: undefined,
+    });
+  });
+});

--- a/web/src/lib/auth-providers.ts
+++ b/web/src/lib/auth-providers.ts
@@ -64,6 +64,16 @@ export function getConfiguredAuthProviders(): AuthProvider[] {
   return out;
 }
 
+export function authProviderRedirectUri(
+  provider: Pick<AuthProvider, "id" | "kind">,
+  origin: string,
+): string {
+  const base = origin.replace(/\/$/, "");
+  return provider.kind === "social"
+    ? `${base}/api/auth/callback/${provider.id}`
+    : `${base}/api/auth/oauth2/callback/${provider.id}`;
+}
+
 export function isAnyAuthConfigured(): boolean {
   return getConfiguredAuthProviders().length > 0;
 }

--- a/web/src/lib/auth.test.ts
+++ b/web/src/lib/auth.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class MockAPIError extends Error {
+    status: string;
+
+    constructor(status: string, options: { message: string }) {
+      super(options.message);
+      this.status = status;
+    }
+  }
+
+  return {
+    betterAuth: vi.fn((config: unknown) => ({ config })),
+    genericOAuth: vi.fn((options: unknown) => ({
+      id: "genericOAuth",
+      options,
+    })),
+    isInstanceAdminEmail: vi.fn(),
+    hasPendingInvite: vi.fn(),
+    resolvePendingInvitesForUser: vi.fn(),
+    listWorkspacesForUser: vi.fn(),
+    writeAuditEvent: vi.fn(),
+    MockAPIError,
+  };
+});
+
+vi.mock("better-auth", () => ({
+  betterAuth: mocks.betterAuth,
+}));
+
+vi.mock("better-auth/api", () => ({
+  APIError: mocks.MockAPIError,
+}));
+
+vi.mock("better-auth/plugins", () => ({
+  genericOAuth: mocks.genericOAuth,
+}));
+
+vi.mock("pg", () => ({
+  Pool: vi.fn(function Pool() {
+    return {};
+  }),
+}));
+
+vi.mock("@/lib/auth-secret", () => ({
+  resolveAuthSecret: () => "test-secret-with-enough-entropy",
+}));
+
+vi.mock("@/lib/audit-db", () => ({
+  writeAuditEvent: mocks.writeAuditEvent,
+}));
+
+vi.mock("@/lib/config", () => ({
+  isInstanceAdminEmail: mocks.isInstanceAdminEmail,
+}));
+
+vi.mock("@/lib/invitations", () => ({
+  hasPendingInvite: mocks.hasPendingInvite,
+  resolvePendingInvitesForUser: mocks.resolvePendingInvitesForUser,
+}));
+
+vi.mock("@/lib/workspace", () => ({
+  listWorkspacesForUser: mocks.listWorkspacesForUser,
+}));
+
+type AuthConfig = {
+  databaseHooks: {
+    user: {
+      create: {
+        before: (user: TestUser) => Promise<{ data: TestUser }>;
+        after: (user: TestUser) => Promise<void>;
+      };
+    };
+  };
+  emailAndPassword: { enabled: boolean };
+  plugins?: unknown[];
+};
+
+type TestUser = {
+  id: string;
+  email: string;
+  name?: string;
+};
+
+const ORIGINAL_ENV = process.env;
+
+function resetProviderEnv() {
+  process.env = {
+    ...ORIGINAL_ENV,
+    BETTER_AUTH_SECRET: "test-secret-with-enough-entropy",
+    DATABASE_URL: "postgres://user:pass@localhost:5432/tas_test",
+  };
+  for (const key of [
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "MICROSOFT_CLIENT_ID",
+    "MICROSOFT_CLIENT_SECRET",
+    "MICROSOFT_TENANT_ID",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_DISCOVERY_URL",
+    "OIDC_PROVIDER_NAME",
+    "OIDC_SCOPES",
+  ]) {
+    delete process.env[key];
+  }
+}
+
+async function loadAuthConfig(): Promise<AuthConfig> {
+  await import("./auth");
+  expect(mocks.betterAuth).toHaveBeenCalledTimes(1);
+  return mocks.betterAuth.mock.calls[0][0] as AuthConfig;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  resetProviderEnv();
+  mocks.hasPendingInvite.mockResolvedValue(false);
+  mocks.resolvePendingInvitesForUser.mockResolvedValue(0);
+  mocks.listWorkspacesForUser.mockResolvedValue([]);
+});
+
+describe("better-auth account creation hooks", () => {
+  it("rejects new OAuth users who are neither instance admins nor invited", async () => {
+    mocks.isInstanceAdminEmail.mockReturnValue(false);
+    mocks.hasPendingInvite.mockResolvedValue(false);
+    const config = await loadAuthConfig();
+
+    await expect(
+      config.databaseHooks.user.create.before({
+        id: "user-1",
+        email: "outsider@example.com",
+        name: "Outsider",
+      }),
+    ).rejects.toThrow(
+      "This instance is invite-only. Ask an admin to invite your email.",
+    );
+  });
+
+  it("allows an instance admin account without requiring an invite", async () => {
+    mocks.isInstanceAdminEmail.mockReturnValue(true);
+    const config = await loadAuthConfig();
+    const user = {
+      id: "user-admin",
+      email: "admin@example.com",
+      name: "Admin User",
+    };
+
+    await expect(config.databaseHooks.user.create.before(user)).resolves.toEqual(
+      { data: user },
+    );
+    expect(mocks.hasPendingInvite).not.toHaveBeenCalled();
+  });
+
+  it("allows invited OAuth users and resolves their workspaces after create", async () => {
+    mocks.isInstanceAdminEmail.mockReturnValue(false);
+    mocks.hasPendingInvite.mockResolvedValue(true);
+    const config = await loadAuthConfig();
+    const user = {
+      id: "user-invited",
+      email: "invited@example.com",
+      name: "Invited User",
+    };
+
+    await expect(config.databaseHooks.user.create.before(user)).resolves.toEqual(
+      { data: user },
+    );
+    await config.databaseHooks.user.create.after(user);
+
+    expect(mocks.hasPendingInvite).toHaveBeenCalledWith("invited@example.com");
+    expect(mocks.resolvePendingInvitesForUser).toHaveBeenCalledWith(
+      "user-invited",
+      "invited@example.com",
+    );
+  });
+});
+
+describe("better-auth provider wiring", () => {
+  it("enables mocked Microsoft and OIDC providers without email/password", async () => {
+    process.env.MICROSOFT_CLIENT_ID = "microsoft-id";
+    process.env.MICROSOFT_CLIENT_SECRET = "microsoft-secret";
+    process.env.OIDC_CLIENT_ID = "oidc-id";
+    process.env.OIDC_CLIENT_SECRET = "oidc-secret";
+    process.env.OIDC_DISCOVERY_URL =
+      "https://idp.example.com/.well-known/openid-configuration";
+    const config = await loadAuthConfig();
+
+    expect(config.emailAndPassword).toEqual({ enabled: false });
+    expect(mocks.genericOAuth).toHaveBeenCalledWith({
+      config: expect.arrayContaining([
+        expect.objectContaining({ providerId: "microsoft" }),
+        expect.objectContaining({ providerId: "oidc" }),
+      ]),
+    });
+    expect(config.plugins).toHaveLength(1);
+  });
+});

--- a/web/src/test/README.md
+++ b/web/src/test/README.md
@@ -42,6 +42,21 @@ whole point of recording, so we keep the safety on.
 - **One outbound HTTP call** → Polly with a recorded cassette.
 - **Multi-page user flow** → Cucumber feature + Playwright.
 
+## Microsoft / OIDC sign-in
+
+Most of the Microsoft Entra ID and generic OIDC sign-in contract is
+testable without a live IdP: provider discovery/client config, redirect
+URI construction, profile email/name mapping, and the invite-only
+`user.create.before` / invite-resolution hooks are covered by Vitest
+with mocked better-auth boundaries.
+
+A live Microsoft/Okta/Auth0/Keycloak app is only needed for final smoke
+coverage of the provider-owned surfaces: tenant/app registration,
+consent/login UI, and the real authorization-code/token exchange. CI
+should use mocks for deterministic coverage; run the live IdP smoke test
+manually when changing provider env or before declaring a deployment's
+external IdP setup verified.
+
 ## Server-only shim
 
 Most `lib/*.ts` files start with `import "server-only"`, which throws


### PR DESCRIPTION
## Summary
- Add deterministic Vitest coverage for the Microsoft Entra ID and generic OIDC auth contract without requiring live IdP resources.
- Extract and test auth redirect URI construction used by the setup guide.
- Document that CI should mock the IdP-owned flow, while live IdP smoke testing is only needed for app registration, consent/login UI, and real code/token exchange.

Addresses #35.

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm lint` (passes with existing unrelated warnings in native-mcp-actions.ts and settings/actions.ts)
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/c8f71526-b03e-47cc-9545-93befe664156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11" height="28"></picture></a> 