### PR TITLE
feat(web): highlight agent definition specs

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
@@ -1,4 +1,9 @@
 import { Section } from "@/components/section";
+import {
+  detectAgentSpecLanguage,
+  highlightAgentSpec,
+  type AgentSpecHighlightKind,
+} from "@/lib/agent-spec-highlight";
 
 import { loadAgentContext } from "../agent-page-context";
 
@@ -22,6 +27,10 @@ export default async function AgentDefinitionPage({
     agent.ok && agent.spec.framework === "pydantic-agentspec"
       ? agent.spec.toolsModule
       : undefined;
+  const specLanguage = detectAgentSpecLanguage(
+    raw,
+    agent.ok ? agent.spec.framework : undefined,
+  );
 
   return (
     <>
@@ -29,9 +38,7 @@ export default async function AgentDefinitionPage({
         title="Definition"
         description="Edits go through Git. Framework and model changes go through the same review path as any other change — never edited in a live console."
       >
-        <pre className="bg-surface border-border text-foreground overflow-x-auto rounded-lg border p-4 font-mono text-sm leading-5">
-          {raw}
-        </pre>
+        <HighlightedCodeBlock source={raw} language={specLanguage} />
       </Section>
 
       {toolsModule && (
@@ -54,5 +61,41 @@ export default async function AgentDefinitionPage({
         </Section>
       )}
     </>
+  );
+}
+
+const tokenClasses: Partial<Record<AgentSpecHighlightKind, string>> = {
+  key: "text-foreground-category-blue font-semibold",
+  string: "text-foreground-category-green",
+  number: "text-foreground-category-purple",
+  literal: "text-foreground-category-orange",
+  comment: "text-foreground-muted",
+  punctuation: "text-foreground-weak",
+};
+
+function HighlightedCodeBlock({
+  source,
+  language,
+}: {
+  source: string;
+  language: "yaml" | "json";
+}) {
+  const tokens = highlightAgentSpec(source, language);
+
+  return (
+    <pre className="bg-surface border-border text-foreground overflow-x-auto rounded-lg border p-4 font-mono text-sm leading-5">
+      <code>
+        {tokens.map((token, index) => {
+          const className = tokenClasses[token.kind];
+          return className ? (
+            <span key={index} className={className}>
+              {token.text}
+            </span>
+          ) : (
+            token.text
+          );
+        })}
+      </code>
+    </pre>
   );
 }

--- a/web/src/lib/agent-spec-highlight.test.ts
+++ b/web/src/lib/agent-spec-highlight.test.ts
@@ -64,6 +64,26 @@ describe("highlightAgentSpec", () => {
     ]);
   });
 
+  it("highlights quoted YAML keys without regex backtracking", () => {
+    const escaped = "\\!".repeat(2000);
+    const tokens = byKind(
+      [
+        `"display name": "LinkedIn inbox"`,
+        `'owner''s key': support`,
+        `"${escaped}": value`,
+        "",
+      ].join("\n"),
+      "yaml",
+    );
+
+    expect(tokens.key).toEqual([
+      '"display name"',
+      "'owner''s key'",
+      `"${escaped}"`,
+    ]);
+    expect(tokens.string).toEqual(['"LinkedIn inbox"', "support", "value"]);
+  });
+
   it("does not parse block scalar body lines as YAML keys", () => {
     const tokens = byKind(
       [

--- a/web/src/lib/agent-spec-highlight.test.ts
+++ b/web/src/lib/agent-spec-highlight.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectAgentSpecLanguage,
+  highlightAgentSpec,
+  type AgentSpecHighlightKind,
+} from "./agent-spec-highlight";
+
+function byKind(source: string, language: "json" | "yaml") {
+  return highlightAgentSpec(source, language).reduce(
+    (acc, token) => {
+      (acc[token.kind] ??= []).push(token.text);
+      return acc;
+    },
+    {} as Partial<Record<AgentSpecHighlightKind, string[]>>,
+  );
+}
+
+describe("detectAgentSpecLanguage", () => {
+  it("treats cargo-ai specs as JSON", () => {
+    expect(detectAgentSpecLanguage("name: hello\n", "cargo-ai")).toBe("json");
+  });
+
+  it("recognizes JSON pydantic specs from their first non-space character", () => {
+    expect(
+      detectAgentSpecLanguage('  {"name":"hello"}', "pydantic-agentspec"),
+    ).toBe("json");
+  });
+});
+
+describe("highlightAgentSpec", () => {
+  it("highlights JSON object keys separately from values", () => {
+    const tokens = byKind(
+      '{\n  "name": "hello",\n  "parallel": true,\n  "retries": 2\n}\n',
+      "json",
+    );
+
+    expect(tokens.key).toEqual(['"name"', '"parallel"', '"retries"']);
+    expect(tokens.string).toEqual(['"hello"']);
+    expect(tokens.literal).toEqual(["true"]);
+    expect(tokens.number).toEqual(["2"]);
+  });
+
+  it("highlights YAML keys, scalar values, numbers, literals, and comments", () => {
+    const tokens = byKind(
+      [
+        "# Sample",
+        "name: hello-world",
+        "parallel: true",
+        "retries: 2",
+        "model: anthropic:claude-sonnet-4-6 # default",
+        "",
+      ].join("\n"),
+      "yaml",
+    );
+
+    expect(tokens.comment).toEqual(["# Sample", "# default"]);
+    expect(tokens.key).toEqual(["name", "parallel", "retries", "model"]);
+    expect(tokens.literal).toEqual(["true"]);
+    expect(tokens.number).toEqual(["2"]);
+    expect(tokens.string).toEqual([
+      "hello-world",
+      "anthropic:claude-sonnet-4-6",
+    ]);
+  });
+
+  it("does not parse block scalar body lines as YAML keys", () => {
+    const tokens = byKind(
+      [
+        "instructions: |",
+        "  Subject: keep this as instruction text",
+        "  Count: 3",
+        "model: anthropic:claude-sonnet-4-6",
+        "",
+      ].join("\n"),
+      "yaml",
+    );
+
+    expect(tokens.key).toEqual(["instructions", "model"]);
+    expect(tokens.plain?.join("")).toContain(
+      "  Subject: keep this as instruction text",
+    );
+    expect(tokens.plain?.join("")).toContain("  Count: 3");
+  });
+});

--- a/web/src/lib/agent-spec-highlight.ts
+++ b/web/src/lib/agent-spec-highlight.ts
@@ -1,0 +1,305 @@
+export type AgentSpecHighlightLanguage = "json" | "yaml";
+
+export type AgentSpecHighlightKind =
+  | "plain"
+  | "key"
+  | "string"
+  | "number"
+  | "literal"
+  | "comment"
+  | "punctuation";
+
+export type AgentSpecHighlightToken = {
+  kind: AgentSpecHighlightKind;
+  text: string;
+};
+
+export function detectAgentSpecLanguage(
+  source: string,
+  framework?: "pydantic-agentspec" | "cargo-ai",
+): AgentSpecHighlightLanguage {
+  if (framework === "cargo-ai") return "json";
+
+  const first = source.trimStart()[0];
+  return first === "{" || first === "[" ? "json" : "yaml";
+}
+
+export function highlightAgentSpec(
+  source: string,
+  language: AgentSpecHighlightLanguage,
+): AgentSpecHighlightToken[] {
+  return language === "json" ? highlightJson(source) : highlightYaml(source);
+}
+
+function pushToken(
+  tokens: AgentSpecHighlightToken[],
+  kind: AgentSpecHighlightKind,
+  text: string,
+) {
+  if (!text) return;
+
+  const previous = tokens[tokens.length - 1];
+  if (previous?.kind === kind) {
+    previous.text += text;
+    return;
+  }
+
+  tokens.push({ kind, text });
+}
+
+function highlightJson(source: string): AgentSpecHighlightToken[] {
+  const tokens: AgentSpecHighlightToken[] = [];
+  let i = 0;
+
+  while (i < source.length) {
+    const char = source[i];
+
+    if (/\s/.test(char)) {
+      const start = i;
+      while (i < source.length && /\s/.test(source[i])) i += 1;
+      pushToken(tokens, "plain", source.slice(start, i));
+      continue;
+    }
+
+    if (char === '"') {
+      const end = scanJsonString(source, i);
+      const text = source.slice(i, end);
+      pushToken(tokens, isJsonObjectKey(source, end) ? "key" : "string", text);
+      i = end;
+      continue;
+    }
+
+    const rest = source.slice(i);
+    const number = rest.match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/);
+    if (number) {
+      pushToken(tokens, "number", number[0]);
+      i += number[0].length;
+      continue;
+    }
+
+    const literal = rest.match(/^(?:true|false|null)\b/);
+    if (literal) {
+      pushToken(tokens, "literal", literal[0]);
+      i += literal[0].length;
+      continue;
+    }
+
+    if ("{}[]:,".includes(char)) {
+      pushToken(tokens, "punctuation", char);
+      i += 1;
+      continue;
+    }
+
+    pushToken(tokens, "plain", char);
+    i += 1;
+  }
+
+  return tokens;
+}
+
+function scanJsonString(source: string, start: number): number {
+  let i = start + 1;
+
+  while (i < source.length) {
+    if (source[i] === "\\") {
+      i += 2;
+      continue;
+    }
+
+    if (source[i] === '"') return i + 1;
+    i += 1;
+  }
+
+  return source.length;
+}
+
+function isJsonObjectKey(source: string, stringEnd: number): boolean {
+  let i = stringEnd;
+  while (i < source.length && /\s/.test(source[i])) i += 1;
+  return source[i] === ":";
+}
+
+function highlightYaml(source: string): AgentSpecHighlightToken[] {
+  const tokens: AgentSpecHighlightToken[] = [];
+  const lines = source.match(/[^\n]*(?:\n|$)/g) ?? [];
+  let blockScalarIndent: number | null = null;
+
+  for (const line of lines) {
+    if (line === "") continue;
+
+    const content = line.endsWith("\n") ? line.slice(0, -1) : line;
+    const newline = line.endsWith("\n") ? "\n" : "";
+    const indent = countIndent(content);
+
+    if (blockScalarIndent !== null) {
+      if (content.trim() === "" || indent > blockScalarIndent) {
+        pushToken(tokens, "plain", line);
+        continue;
+      }
+
+      blockScalarIndent = null;
+    }
+
+    const keyMatch = content.match(
+      /^(\s*(?:-\s*)?)([A-Za-z0-9_.-]+|"(?:\\.|[^"])*"|'(?:''|[^'])*')(\s*:\s*)(.*)$/,
+    );
+
+    if (keyMatch) {
+      const [, prefix, key, colon, value] = keyMatch;
+      pushToken(tokens, "plain", prefix);
+      pushToken(tokens, "key", key);
+      pushToken(tokens, "punctuation", colon);
+
+      const valueTokens = highlightYamlInlineValue(value);
+      for (const token of valueTokens) pushToken(tokens, token.kind, token.text);
+
+      if (startsBlockScalar(value)) blockScalarIndent = indent;
+      pushToken(tokens, "plain", newline);
+      continue;
+    }
+
+    const sequenceMatch = content.match(/^(\s*-\s+)(.*)$/);
+    if (sequenceMatch) {
+      const [, prefix, value] = sequenceMatch;
+      pushToken(tokens, "punctuation", prefix);
+      const valueTokens = highlightYamlInlineValue(value);
+      for (const token of valueTokens) pushToken(tokens, token.kind, token.text);
+      pushToken(tokens, "plain", newline);
+      continue;
+    }
+
+    if (content.trimStart().startsWith("#")) {
+      pushToken(tokens, "comment", content);
+      pushToken(tokens, "plain", newline);
+      continue;
+    }
+
+    pushToken(tokens, "plain", line);
+  }
+
+  return tokens;
+}
+
+function countIndent(line: string): number {
+  const match = line.match(/^\s*/);
+  return match?.[0].length ?? 0;
+}
+
+function startsBlockScalar(value: string): boolean {
+  const beforeComment = splitYamlComment(value).value.trim();
+  return beforeComment.startsWith("|") || beforeComment.startsWith(">");
+}
+
+function highlightYamlInlineValue(value: string): AgentSpecHighlightToken[] {
+  const tokens: AgentSpecHighlightToken[] = [];
+  const { value: beforeComment, comment } = splitYamlComment(value);
+  let i = 0;
+
+  while (i < beforeComment.length) {
+    const char = beforeComment[i];
+
+    if (/\s/.test(char)) {
+      const start = i;
+      while (i < beforeComment.length && /\s/.test(beforeComment[i])) i += 1;
+      pushToken(tokens, "plain", beforeComment.slice(start, i));
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      const end = scanYamlQuotedString(beforeComment, i, char);
+      pushToken(tokens, "string", beforeComment.slice(i, end));
+      i = end;
+      continue;
+    }
+
+    const rest = beforeComment.slice(i);
+    const number = rest.match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?\b/);
+    if (number) {
+      pushToken(tokens, "number", number[0]);
+      i += number[0].length;
+      continue;
+    }
+
+    const literal = rest.match(/^(?:true|false|null|yes|no|on|off)\b/i);
+    if (literal) {
+      pushToken(tokens, "literal", literal[0]);
+      i += literal[0].length;
+      continue;
+    }
+
+    if ("[]{}:,|>&*-".includes(char)) {
+      pushToken(tokens, "punctuation", char);
+      i += 1;
+      continue;
+    }
+
+    const scalar = rest.match(/^[^\s,[\]{}#]+/);
+    if (scalar) {
+      pushToken(tokens, "string", scalar[0]);
+      i += scalar[0].length;
+      continue;
+    }
+
+    pushToken(tokens, "plain", char);
+    i += 1;
+  }
+
+  if (comment) pushToken(tokens, "comment", comment);
+  return tokens;
+}
+
+function splitYamlComment(value: string): { value: string; comment: string } {
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+
+    if (quote === '"') {
+      if (char === "\\") i += 1;
+      else if (char === '"') quote = null;
+      continue;
+    }
+
+    if (quote === "'") {
+      if (char === "'" && value[i + 1] === "'") i += 1;
+      else if (char === "'") quote = null;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "#" && (i === 0 || /\s/.test(value[i - 1]))) {
+      return { value: value.slice(0, i), comment: value.slice(i) };
+    }
+  }
+
+  return { value, comment: "" };
+}
+
+function scanYamlQuotedString(
+  source: string,
+  start: number,
+  quote: '"' | "'",
+): number {
+  let i = start + 1;
+
+  while (i < source.length) {
+    if (quote === '"' && source[i] === "\\") {
+      i += 2;
+      continue;
+    }
+
+    if (quote === "'" && source[i] === "'" && source[i + 1] === "'") {
+      i += 2;
+      continue;
+    }
+
+    if (source[i] === quote) return i + 1;
+    i += 1;
+  }
+
+  return source.length;
+}

--- a/web/src/lib/agent-spec-highlight.ts
+++ b/web/src/lib/agent-spec-highlight.ts
@@ -140,12 +140,10 @@ function highlightYaml(source: string): AgentSpecHighlightToken[] {
       blockScalarIndent = null;
     }
 
-    const keyMatch = content.match(
-      /^(\s*(?:-\s*)?)([A-Za-z0-9_.-]+|"(?:\\.|[^"])*"|'(?:''|[^'])*')(\s*:\s*)(.*)$/,
-    );
+    const keyMatch = parseYamlKeyLine(content);
 
     if (keyMatch) {
-      const [, prefix, key, colon, value] = keyMatch;
+      const { prefix, key, colon, value } = keyMatch;
       pushToken(tokens, "plain", prefix);
       pushToken(tokens, "key", key);
       pushToken(tokens, "punctuation", colon);
@@ -178,6 +176,55 @@ function highlightYaml(source: string): AgentSpecHighlightToken[] {
   }
 
   return tokens;
+}
+
+function parseYamlKeyLine(
+  line: string,
+): { prefix: string; key: string; colon: string; value: string } | null {
+  let i = 0;
+
+  while (i < line.length && /\s/.test(line[i])) i += 1;
+  if (line[i] === "-") {
+    i += 1;
+    while (i < line.length && /\s/.test(line[i])) i += 1;
+  }
+
+  const keyStart = i;
+  let keyEnd: number;
+
+  const quote = line[i];
+  if (quote === '"' || quote === "'") {
+    keyEnd = scanYamlQuotedString(line, i, quote);
+  } else {
+    while (i < line.length && isYamlBareKeyChar(line[i])) i += 1;
+    keyEnd = i;
+  }
+
+  if (keyEnd === keyStart) return null;
+
+  i = keyEnd;
+  while (i < line.length && /\s/.test(line[i])) i += 1;
+  if (line[i] !== ":") return null;
+  i += 1;
+  while (i < line.length && /\s/.test(line[i])) i += 1;
+
+  return {
+    prefix: line.slice(0, keyStart),
+    key: line.slice(keyStart, keyEnd),
+    colon: line.slice(keyEnd, i),
+    value: line.slice(i),
+  };
+}
+
+function isYamlBareKeyChar(char: string): boolean {
+  return (
+    (char >= "A" && char <= "Z") ||
+    (char >= "a" && char <= "z") ||
+    (char >= "0" && char <= "9") ||
+    char === "_" ||
+    char === "." ||
+    char === "-"
+  );
 }
 
 function countIndent(line: string): number {


### PR DESCRIPTION
## Summary
- Add read-only syntax highlighting for agent Definition specs.
- Highlight YAML/JSON keys distinctly, with themed colors for strings, numbers, literals, comments, and punctuation.
- Keep the highlighter dependency-free and backed by focused unit tests.

Fixes #180

## Verification
- pnpm test -- src/lib/agent-spec-highlight.test.ts
- pnpm lint (passes with existing unrelated warnings in native-mcp-actions.ts and settings/actions.ts)
- pnpm exec tsc --noEmit
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/5f87c480-8614-4b9d-9099-16f5f0482900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11" height="28"></picture></a> 