### PR TITLE
Bind AES-GCM ciphertext to row context via AAD (#49)

### DIFF
--- a/api/src/crypto.rs
+++ b/api/src/crypto.rs
@@ -37,6 +37,23 @@ pub mod aad {
     pub fn secret_connection(workspace_id: uuid::Uuid, slug: &str) -> String {
         format!("secret_connection{SEP}{workspace_id}{SEP}{slug}")
     }
+
+    pub fn native_connection(
+        workspace_id: uuid::Uuid,
+        user_id: &str,
+        conn_type: &str,
+        name: &str,
+    ) -> String {
+        format!("workspace_connection{SEP}{workspace_id}{SEP}{user_id}{SEP}{conn_type}{SEP}{name}")
+    }
+
+    pub fn native_oauth_client(workspace_id: uuid::Uuid, provider: &str, instance: &str) -> String {
+        format!("native_oauth_client{SEP}{workspace_id}{SEP}{provider}{SEP}{instance}")
+    }
+
+    pub fn slack_secret(slack_app_id: uuid::Uuid, column: &str) -> String {
+        format!("slack_app{SEP}{slack_app_id}{SEP}{column}")
+    }
 }
 
 pub struct MasterKey(Key<Aes256Gcm>);

--- a/api/src/crypto.rs
+++ b/api/src/crypto.rs
@@ -6,7 +6,7 @@
 //! refreshed native-MCP OAuth token).
 
 use aes_gcm::{
-    aead::{Aead, AeadCore, KeyInit, OsRng},
+    aead::{Aead, AeadCore, KeyInit, OsRng, Payload},
     Aes256Gcm, Key, Nonce,
 };
 use anyhow::{anyhow, Context};
@@ -15,6 +15,29 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 const NONCE_LEN: usize = 12;
 const TAG_LEN: usize = 16;
 const KEY_LEN: usize = 32;
+
+/// Versioned-blob marker (#49). Mirrors `VERSION_AAD` in web/src/lib/crypto.ts:
+/// blobs that bind row context as AAD are written as `0x01 || nonce ||
+/// ciphertext || tag`; legacy blobs keep `nonce || ciphertext || tag` with no
+/// version byte. Decryption tries the versioned path when the marker + an AAD
+/// are present and falls back to legacy, so old ciphertext keeps decrypting.
+const VERSION_AAD: u8 = 0x01;
+
+/// Canonical AAD strings binding a ciphertext to its row. Must stay
+/// byte-identical to web/src/lib/crypto-aad.ts for the rows both sides touch.
+/// Fields are joined with the unit separator (0x1f); UUIDs use the
+/// lowercase-hyphenated form (`Uuid`'s `Display`, same as Postgres text).
+pub mod aad {
+    const SEP: char = '\u{1f}';
+
+    pub fn workspace_secret(workspace_id: uuid::Uuid, kind: &str) -> String {
+        format!("workspace_secret{SEP}{workspace_id}{SEP}{kind}")
+    }
+
+    pub fn secret_connection(workspace_id: uuid::Uuid, slug: &str) -> String {
+        format!("secret_connection{SEP}{workspace_id}{SEP}{slug}")
+    }
+}
 
 pub struct MasterKey(Key<Aes256Gcm>);
 
@@ -46,27 +69,126 @@ impl MasterKey {
     /// 12-byte nonce is generated per call (AES-GCM is catastrophic on
     /// nonce reuse — never make this deterministic).
     pub fn encrypt(&self, plaintext: &str) -> anyhow::Result<Vec<u8>> {
+        self.encrypt_aad(plaintext, &[])
+    }
+
+    /// Encrypt, optionally binding `aad` as additional authenticated data.
+    /// Empty `aad` produces the legacy `nonce || ciphertext || tag` layout
+    /// (byte-identical to pre-#49 blobs); a non-empty `aad` produces the
+    /// versioned `0x01 || nonce || ciphertext || tag` layout. The matching
+    /// `decrypt_aad` must pass the same `aad`.
+    pub fn encrypt_aad(&self, plaintext: &str, aad: &[u8]) -> anyhow::Result<Vec<u8>> {
         let cipher = Aes256Gcm::new(&self.0);
         let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
-        let ciphertext = cipher
-            .encrypt(&nonce, plaintext.as_bytes())
-            .map_err(|e| anyhow!("encrypt failed: {e}"))?;
-        let mut out = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        let ciphertext = if aad.is_empty() {
+            cipher.encrypt(&nonce, plaintext.as_bytes())
+        } else {
+            cipher.encrypt(
+                &nonce,
+                Payload {
+                    msg: plaintext.as_bytes(),
+                    aad,
+                },
+            )
+        }
+        .map_err(|e| anyhow!("encrypt failed: {e}"))?;
+        let mut out = Vec::with_capacity(1 + NONCE_LEN + ciphertext.len());
+        if !aad.is_empty() {
+            out.push(VERSION_AAD);
+        }
         out.extend_from_slice(nonce.as_slice());
         out.extend_from_slice(&ciphertext);
         Ok(out)
     }
 
     pub fn decrypt(&self, blob: &[u8]) -> anyhow::Result<String> {
+        self.decrypt_aad(blob, &[])
+    }
+
+    /// Inverse of `encrypt_aad`. A versioned (0x01-prefixed) blob is decrypted
+    /// with `aad`; anything else falls back to the legacy unbound layout — so
+    /// pre-#49 ciphertext keeps decrypting even once a caller passes `aad`.
+    pub fn decrypt_aad(&self, blob: &[u8], aad: &[u8]) -> anyhow::Result<String> {
+        let cipher = Aes256Gcm::new(&self.0);
+
+        // Versioned + AAD-bound layout, when both the marker and an AAD exist.
+        if !aad.is_empty() && blob.len() >= 1 + NONCE_LEN + TAG_LEN && blob[0] == VERSION_AAD {
+            let (nonce_bytes, body_and_tag) = blob[1..].split_at(NONCE_LEN);
+            let nonce = Nonce::from_slice(nonce_bytes);
+            if let Ok(plain) = cipher.decrypt(
+                nonce,
+                Payload {
+                    msg: body_and_tag,
+                    aad,
+                },
+            ) {
+                return String::from_utf8(plain).context("decrypted bytes are not valid UTF-8");
+            }
+            // Fall through: a legacy blob whose first byte is coincidentally
+            // 0x01, or a real mismatch the legacy path will also reject.
+        }
+
+        // Legacy layout: nonce || ciphertext || tag, no AAD.
         if blob.len() < NONCE_LEN + TAG_LEN {
             return Err(anyhow!("encrypted blob shorter than nonce+tag"));
         }
-        let cipher = Aes256Gcm::new(&self.0);
         let (nonce_bytes, body_and_tag) = blob.split_at(NONCE_LEN);
         let nonce = Nonce::from_slice(nonce_bytes);
         let plain = cipher
             .decrypt(nonce, body_and_tag)
             .map_err(|e| anyhow!("decrypt failed: {e}"))?;
         String::from_utf8(plain).context("decrypted bytes are not valid UTF-8")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> MasterKey {
+        MasterKey(Key::<Aes256Gcm>::clone_from_slice(&[0u8; KEY_LEN]))
+    }
+
+    #[test]
+    fn legacy_round_trip() {
+        let k = test_key();
+        let blob = k.encrypt("hunter2").unwrap();
+        assert_eq!(k.decrypt(&blob).unwrap(), "hunter2");
+    }
+
+    #[test]
+    fn aad_round_trip_and_marker() {
+        let k = test_key();
+        let aad = aad::workspace_secret(uuid::Uuid::nil(), "anthropic_api_key");
+        let blob = k.encrypt_aad("sk-secret", aad.as_bytes()).unwrap();
+        assert_eq!(blob[0], VERSION_AAD);
+        assert_eq!(k.decrypt_aad(&blob, aad.as_bytes()).unwrap(), "sk-secret");
+    }
+
+    #[test]
+    fn aad_mismatch_rejected() {
+        let k = test_key();
+        let a = aad::workspace_secret(uuid::Uuid::nil(), "k");
+        let b = aad::secret_connection(uuid::Uuid::nil(), "k");
+        let blob = k.encrypt_aad("v", a.as_bytes()).unwrap();
+        assert!(k.decrypt_aad(&blob, b.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn legacy_blob_reads_even_when_aad_passed() {
+        // Pre-#49 ciphertext keeps decrypting after a reader starts passing aad.
+        let k = test_key();
+        let legacy = k.encrypt("old-value").unwrap();
+        let aad = aad::workspace_secret(uuid::Uuid::nil(), "k");
+        assert_eq!(k.decrypt_aad(&legacy, aad.as_bytes()).unwrap(), "old-value");
+    }
+
+    #[test]
+    fn cross_language_aad_format() {
+        // Must match web/src/lib/crypto-aad.ts byte-for-byte.
+        assert_eq!(
+            aad::workspace_secret(uuid::Uuid::nil(), "kind"),
+            "workspace_secret\u{1f}00000000-0000-0000-0000-000000000000\u{1f}kind"
+        );
     }
 }

--- a/api/src/native_oauth.rs
+++ b/api/src/native_oauth.rs
@@ -143,8 +143,10 @@ pub async fn refresh_expiring_native_connections(
             key,
             http,
             workspace_id,
+            user_id,
             id,
             &provider,
+            &name,
             &mcp_url,
             &ciphertext,
             &metadata,
@@ -168,8 +170,10 @@ async fn refresh_one(
     key: &MasterKey,
     http: &reqwest::Client,
     workspace_id: uuid::Uuid,
+    user_id: &str,
     id: uuid::Uuid,
     provider: &str,
+    name: &str,
     mcp_url: &Option<String>,
     ciphertext: &[u8],
     metadata: &serde_json::Value,
@@ -179,7 +183,10 @@ async fn refresh_one(
         .filter(|u| !u.is_empty())
         .ok_or_else(|| anyhow!("connection has no mcp_server_url"))?;
 
-    let plaintext = key.decrypt(ciphertext).context("decrypt credentials")?;
+    let conn_aad = crate::crypto::aad::native_connection(workspace_id, user_id, provider, name);
+    let plaintext = key
+        .decrypt_aad(ciphertext, conn_aad.as_bytes())
+        .context("decrypt credentials")?;
     let creds: serde_json::Value =
         serde_json::from_str(&plaintext).context("credentials not JSON")?;
     let refresh_token = creds
@@ -281,7 +288,7 @@ async fn refresh_one(
         "token_type": token.token_type,
     });
     let blob = key
-        .encrypt(&new_creds.to_string())
+        .encrypt_aad(&new_creds.to_string(), conn_aad.as_bytes())
         .context("encrypt refreshed credentials")?;
 
     sqlx::query(
@@ -323,7 +330,12 @@ async fn native_oauth_client_secret(
     let (client_id, ciphertext) = row.ok_or_else(|| {
         anyhow!("no OAuth app \"{instance}\" configured for native provider {provider}")
     })?;
-    let secret = key.decrypt(&ciphertext).context("decrypt client_secret")?;
+    let secret = key
+        .decrypt_aad(
+            &ciphertext,
+            crate::crypto::aad::native_oauth_client(workspace_id, provider, instance).as_bytes(),
+        )
+        .context("decrypt client_secret")?;
     Ok((client_id, secret))
 }
 

--- a/api/src/runs/runner.rs
+++ b/api/src/runs/runner.rs
@@ -750,6 +750,7 @@ struct SlackDeliveryRow {
     channel: String,
     thread_ts: Option<String>,
     bot_token: Vec<u8>,
+    slack_app_id: Uuid,
 }
 
 /// Post a Slack-dispatched run's result back into the thread it came from.
@@ -758,7 +759,7 @@ struct SlackDeliveryRow {
 /// hiccup are all logged and swallowed so the run itself is never affected.
 async fn deliver_slack_result(state: &AppState, run_id: Uuid, body: &str) {
     let row = match sqlx::query_as::<_, SlackDeliveryRow>(
-        "SELECT d.channel, d.thread_ts, a.bot_token \
+        "SELECT d.channel, d.thread_ts, a.bot_token, a.id AS slack_app_id \
            FROM slack_delivery d \
            JOIN workspace_slack_app a ON a.id = d.slack_app_id \
           WHERE d.run_id = $1 AND d.delivered_at IS NULL AND a.bot_token IS NOT NULL",
@@ -775,7 +776,10 @@ async fn deliver_slack_result(state: &AppState, run_id: Uuid, body: &str) {
         }
     };
 
-    let token = match state.encryption_key.decrypt(&row.bot_token) {
+    let token = match state.encryption_key.decrypt_aad(
+        &row.bot_token,
+        crate::crypto::aad::slack_secret(row.slack_app_id, "bot_token").as_bytes(),
+    ) {
         Ok(t) => t,
         Err(e) => {
             tracing::warn!(run_id = %run_id, ?e, "slack bot token decrypt failed");

--- a/api/src/workspace.rs
+++ b/api/src/workspace.rs
@@ -156,7 +156,8 @@ pub async fn list_workspace_secret_connections(
 
     let mut out = Vec::with_capacity(rows.len());
     for (slug, ciphertext) in rows {
-        match key.decrypt(&ciphertext) {
+        let aad = crate::crypto::aad::secret_connection(workspace_id, &slug);
+        match key.decrypt_aad(&ciphertext, aad.as_bytes()) {
             Ok(value) => out.push((slug, value)),
             Err(e) => {
                 tracing::warn!(?e, %slug, "skipping secret: decrypt failed")
@@ -188,5 +189,8 @@ pub async fn get_workspace_secret_plaintext(
     let ciphertext = row
         .ok_or_else(|| anyhow!("workspace secret {} not set", kind.as_db_str()))?
         .0;
-    key.decrypt(&ciphertext)
+    key.decrypt_aad(
+        &ciphertext,
+        crate::crypto::aad::workspace_secret(workspace_id, kind.as_db_str()).as_bytes(),
+    )
 }

--- a/api/src/workspace.rs
+++ b/api/src/workspace.rs
@@ -99,7 +99,8 @@ pub async fn list_active_native_connections(
                 continue;
             }
         };
-        let plaintext = match key.decrypt(&ciphertext) {
+        let aad = crate::crypto::aad::native_connection(workspace_id, user_id, &provider, &name);
+        let plaintext = match key.decrypt_aad(&ciphertext, aad.as_bytes()) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(?e, %provider, %name, "skipping native connection: decrypt failed");

--- a/web/src/lib/api-keys-db.ts
+++ b/web/src/lib/api-keys-db.ts
@@ -1,8 +1,14 @@
 import "server-only";
 
-import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import {
+  createHash,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto";
 
 import { decryptSecret, encryptSecret, last4 } from "@/lib/crypto";
+import { aadApiKeyToken } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
 
 // Per-user, workspace-bound API keys — the credential behind the public REST
@@ -109,7 +115,10 @@ export async function getApiKeyByToken(
 export function apiKeyTokenMatches(row: ApiKeyRow, presented: string): boolean {
   let stored: string;
   try {
-    stored = decryptSecret(row.tokenCiphertext);
+    stored = decryptSecret(
+      row.tokenCiphertext,
+      aadApiKeyToken(row.workspaceId, row.id),
+    );
   } catch {
     return false;
   }
@@ -128,18 +137,21 @@ export async function createApiKey(args: {
   createdBy: string;
 }): Promise<{ key: ApiKeyPreview; token: string }> {
   const token = generateApiKey();
+  // Generate the id up front so the token AAD can bind to it at encrypt time.
+  const id = randomUUID();
   const { rows } = await db.query<PreviewDbRow>(
     `INSERT INTO workspace_api_key
-       (workspace_id, user_id, name, token_lookup_hash, token_ciphertext,
+       (id, workspace_id, user_id, name, token_lookup_hash, token_ciphertext,
         token_last4, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        RETURNING ${PREVIEW_COLS}`,
     [
+      id,
       args.workspaceId,
       args.userId,
       args.name,
       sha256Hex(token),
-      encryptSecret(token),
+      encryptSecret(token, aadApiKeyToken(args.workspaceId, id)),
       last4(token),
       args.createdBy,
     ],

--- a/web/src/lib/connections.ts
+++ b/web/src/lib/connections.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { decryptSecret, encryptSecret } from "@/lib/crypto";
+import { aadNativeConnection } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
 import { type McpProviderSlug } from "@/lib/mcp-providers";
 
@@ -143,14 +144,27 @@ export async function getNativeConnectionById(
 export async function getNativeConnectionCredentials(
   connectionId: string,
 ): Promise<ConnectionCredentials> {
-  const { rows } = await db.query<{ credentials: Buffer }>(
-    `SELECT credentials FROM workspace_connection WHERE id = $1`,
+  const { rows } = await db.query<{
+    workspace_id: string;
+    user_id: string;
+    type: string;
+    name: string;
+    credentials: Buffer;
+  }>(
+    `SELECT workspace_id, user_id, type, name, credentials
+       FROM workspace_connection WHERE id = $1`,
     [connectionId],
   );
   if (!rows[0]) {
     throw new Error(`workspace_connection ${connectionId} not found`);
   }
-  return JSON.parse(decryptSecret(rows[0].credentials));
+  const r = rows[0];
+  return JSON.parse(
+    decryptSecret(
+      r.credentials,
+      aadNativeConnection(r.workspace_id, r.user_id, r.type, r.name),
+    ),
+  );
 }
 
 export type SaveNativeConnectionArgs = {
@@ -173,7 +187,10 @@ export type SaveNativeConnectionArgs = {
 export async function saveNativeConnection(
   args: SaveNativeConnectionArgs,
 ): Promise<WorkspaceConnection> {
-  const ciphertext = encryptSecret(JSON.stringify(args.credentials));
+  const ciphertext = encryptSecret(
+    JSON.stringify(args.credentials),
+    aadNativeConnection(args.workspaceId, args.userId, args.type, args.name),
+  );
   const expiresAt = args.credentials.expires_at
     ? new Date(args.credentials.expires_at)
     : null;

--- a/web/src/lib/crypto-aad.ts
+++ b/web/src/lib/crypto-aad.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+// Canonical AAD strings that bind a ciphertext to its row (#49). Passed to
+// encryptSecret/decryptSecret; the same string must be used on both the
+// encrypt and decrypt of a given row. For rows the Rust runtime also touches
+// (workspace secrets, native connection credentials, native OAuth client
+// secrets, Slack bot tokens), api/src/crypto.rs builds BYTE-IDENTICAL strings —
+// keep the two in lockstep or those rows stop decrypting cross-language.
+//
+// Fields are joined with a unit separator (0x1f) so a value that happens to
+// contain a separator-like character (':'/'|') can't be reshaped into a
+// different context. UUIDs are the lowercase-hyphenated Postgres text form on
+// both sides; `kind`/`type`/`slug`/`name` are passed through verbatim.
+const SEP = "\x1f";
+
+/** `workspace_secret` row, keyed by (workspace_id, kind). */
+export function aadWorkspaceSecret(workspaceId: string, kind: string): string {
+  return `workspace_secret${SEP}${workspaceId}${SEP}${kind}`;
+}
+
+/** `workspace_secret_connection` row, keyed by (workspace_id, slug). */
+export function aadSecretConnection(
+  workspaceId: string,
+  slug: string,
+): string {
+  return `secret_connection${SEP}${workspaceId}${SEP}${slug}`;
+}

--- a/web/src/lib/crypto-aad.ts
+++ b/web/src/lib/crypto-aad.ts
@@ -25,3 +25,37 @@ export function aadSecretConnection(
 ): string {
   return `secret_connection${SEP}${workspaceId}${SEP}${slug}`;
 }
+
+/** `workspace_connection` (native-MCP creds), keyed by its unique tuple. */
+export function aadNativeConnection(
+  workspaceId: string,
+  userId: string,
+  type: string,
+  name: string,
+): string {
+  return `workspace_connection${SEP}${workspaceId}${SEP}${userId}${SEP}${type}${SEP}${name}`;
+}
+
+/** `workspace_native_oauth_client` row, keyed by (workspace_id, provider, instance). */
+export function aadNativeOauthClient(
+  workspaceId: string,
+  provider: string,
+  instance: string,
+): string {
+  return `native_oauth_client${SEP}${workspaceId}${SEP}${provider}${SEP}${instance}`;
+}
+
+/** A secret column on a `workspace_slack_app` row, keyed by (id, column). */
+export function aadSlackSecret(slackAppId: string, column: string): string {
+  return `slack_app${SEP}${slackAppId}${SEP}${column}`;
+}
+
+/** `workspace_webhook` token, keyed by (workspace_id, id). */
+export function aadWebhookToken(workspaceId: string, id: string): string {
+  return `webhook${SEP}${workspaceId}${SEP}${id}`;
+}
+
+/** `workspace_api_key` token, keyed by (workspace_id, id). */
+export function aadApiKeyToken(workspaceId: string, id: string): string {
+  return `api_key${SEP}${workspaceId}${SEP}${id}`;
+}

--- a/web/src/lib/crypto.test.ts
+++ b/web/src/lib/crypto.test.ts
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+// 32 zero bytes, base64 — satisfies crypto.ts's KEY_LEN check. Set before the
+// module reads it (getMasterKey reads process.env lazily per call, but be safe).
+beforeAll(() => {
+  process.env.TAS_ENCRYPTION_KEY = Buffer.alloc(32).toString("base64");
+});
+
+// Imported after the env guard above is declared; getMasterKey reads env per
+// call so import order doesn't matter, but keep it explicit.
+const { encryptSecret, decryptSecret } = await import("./crypto");
+const { aadWorkspaceSecret } = await import("./crypto-aad");
+
+describe("crypto AES-GCM blobs", () => {
+  it("round-trips without AAD (legacy layout)", () => {
+    const blob = encryptSecret("hunter2");
+    expect(decryptSecret(blob)).toBe("hunter2");
+  });
+
+  it("legacy blobs carry no version byte; AAD blobs are 1 byte longer", () => {
+    const legacy = encryptSecret("x");
+    const bound = encryptSecret("x", "ctx");
+    expect(bound.length).toBe(legacy.length + 1);
+    expect(bound[0]).toBe(0x01);
+  });
+
+  it("builds the canonical cross-language AAD (must match api/src/crypto.rs)", () => {
+    expect(aadWorkspaceSecret("00000000-0000-0000-0000-000000000000", "kind")).toBe(
+      "workspace_secret\u{1f}00000000-0000-0000-0000-000000000000\u{1f}kind",
+    );
+  });
+
+  it("round-trips with matching AAD", () => {
+    const aad = aadWorkspaceSecret("ws-1", "anthropic_api_key");
+    const blob = encryptSecret("sk-secret", aad);
+    expect(decryptSecret(blob, aad)).toBe("sk-secret");
+  });
+
+  it("rejects a mismatched AAD (row-binding holds)", () => {
+    const blob = encryptSecret("sk-secret", aadWorkspaceSecret("ws-1", "k"));
+    expect(() =>
+      decryptSecret(blob, aadWorkspaceSecret("ws-2", "k")),
+    ).toThrow();
+  });
+
+  it("requires the AAD to read a bound blob", () => {
+    const blob = encryptSecret("sk-secret", aadWorkspaceSecret("ws-1", "k"));
+    expect(() => decryptSecret(blob)).toThrow();
+  });
+
+  it("falls back to legacy: a no-AAD blob still reads when an AAD is passed", () => {
+    // Pre-#49 ciphertext keeps decrypting even after a caller starts passing
+    // AAD on the read path.
+    const legacy = encryptSecret("old-value");
+    expect(decryptSecret(legacy, aadWorkspaceSecret("ws-1", "k"))).toBe(
+      "old-value",
+    );
+  });
+});

--- a/web/src/lib/crypto.ts
+++ b/web/src/lib/crypto.ts
@@ -10,6 +10,21 @@ const NONCE_LEN = 12;
 const TAG_LEN = 16;
 const KEY_LEN = 32;
 
+// Versioned-blob marker (#49). Blobs that bind row context as AAD are written
+// as VERSION_AAD || nonce || ciphertext || tag; legacy blobs (and any write
+// with no AAD) keep the original nonce || ciphertext || tag layout with no
+// version byte. decrypt() tries the versioned path when the marker is present
+// and falls back to legacy, so old ciphertext keeps decrypting untouched and a
+// table can adopt AAD one at a time. The Rust side (api/src/crypto.rs) mirrors
+// this exactly so cross-language rows round-trip.
+const VERSION_AAD = 0x01;
+
+function toAadBuffer(aad: Buffer | string | undefined): Buffer | undefined {
+  if (aad === undefined) return undefined;
+  const buf = Buffer.isBuffer(aad) ? aad : Buffer.from(aad, "utf8");
+  return buf.length > 0 ? buf : undefined;
+}
+
 function getMasterKey(): Buffer {
   const raw = process.env.TAS_ENCRYPTION_KEY;
   if (!raw) {
@@ -29,30 +44,72 @@ function getMasterKey(): Buffer {
 }
 
 /**
- * Encrypt a UTF-8 plaintext. Returns a packed blob: nonce || ciphertext || tag.
- * The whole blob is what goes into the `workspace_secret.ciphertext` column.
+ * Encrypt a UTF-8 plaintext. Returns a packed blob.
+ *
+ * Without `aad`: legacy layout `nonce || ciphertext || tag` (byte-identical to
+ * pre-#49 blobs). With `aad`: versioned layout `0x01 || nonce || ciphertext ||
+ * tag` that binds the ciphertext to its row context, so a blob moved into a
+ * different row fails to decrypt. Pass the row's stable identity (see
+ * `crypto-aad.ts`); the matching `decryptSecret` call must pass the same `aad`.
  */
-export function encryptSecret(plaintext: string): Buffer {
+export function encryptSecret(
+  plaintext: string,
+  aad?: Buffer | string,
+): Buffer {
   const key = getMasterKey();
+  const aadBuf = toAadBuffer(aad);
   const nonce = randomBytes(NONCE_LEN);
   const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  if (aadBuf) cipher.setAAD(aadBuf);
   const body = Buffer.concat([
     cipher.update(plaintext, "utf8"),
     cipher.final(),
   ]);
   const tag = cipher.getAuthTag();
-  return Buffer.concat([nonce, body, tag]);
+  return aadBuf
+    ? Buffer.concat([Buffer.from([VERSION_AAD]), nonce, body, tag])
+    : Buffer.concat([nonce, body, tag]);
 }
 
 /**
- * Inverse of `encryptSecret`. Throws if the blob is malformed or the
- * master key has changed since the blob was produced.
+ * Inverse of `encryptSecret`. Throws if the blob is malformed or the master
+ * key has changed since the blob was produced.
+ *
+ * Pass the same `aad` used at encrypt time. A versioned (0x01-prefixed) blob is
+ * decrypted with the AAD; anything else falls back to the legacy unbound layout
+ * — so pre-#49 ciphertext keeps decrypting even once a caller starts passing
+ * `aad`, and is rebound the next time it's rewritten.
  */
-export function decryptSecret(blob: Buffer): string {
+export function decryptSecret(blob: Buffer, aad?: Buffer | string): string {
+  const key = getMasterKey();
+  const aadBuf = toAadBuffer(aad);
+
+  // Versioned + AAD-bound layout, when both the marker and an AAD are present.
+  if (
+    aadBuf &&
+    blob.length >= 1 + NONCE_LEN + TAG_LEN &&
+    blob[0] === VERSION_AAD
+  ) {
+    try {
+      const nonce = blob.subarray(1, 1 + NONCE_LEN);
+      const body = blob.subarray(1 + NONCE_LEN, blob.length - TAG_LEN);
+      const tag = blob.subarray(blob.length - TAG_LEN);
+      const decipher = createDecipheriv("aes-256-gcm", key, nonce);
+      decipher.setAAD(aadBuf);
+      decipher.setAuthTag(tag);
+      return Buffer.concat([decipher.update(body), decipher.final()]).toString(
+        "utf8",
+      );
+    } catch {
+      // Fall through: a legacy blob whose first byte is coincidentally 0x01,
+      // or a real mismatch the legacy path will also reject.
+    }
+  }
+
+  // Legacy layout: nonce || ciphertext || tag, no AAD.
   if (blob.length < NONCE_LEN + TAG_LEN) {
     throw new Error("encrypted blob is shorter than nonce+tag");
   }
-  const key = getMasterKey();
   const nonce = blob.subarray(0, NONCE_LEN);
   const body = blob.subarray(NONCE_LEN, blob.length - TAG_LEN);
   const tag = blob.subarray(blob.length - TAG_LEN);

--- a/web/src/lib/native-oauth-clients.ts
+++ b/web/src/lib/native-oauth-clients.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { decryptSecret, encryptSecret, last4 } from "@/lib/crypto";
+import { aadNativeOauthClient } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
 
 // Bring-your-own OAuth app(s) for Native MCP providers that don't support DCR
@@ -107,7 +108,14 @@ export async function upsertNativeOAuthClient(args: {
       args.instance ?? DEFAULT_INSTANCE,
       args.label?.trim() || null,
       args.clientId.trim(),
-      encryptSecret(args.clientSecret),
+      encryptSecret(
+        args.clientSecret,
+        aadNativeOauthClient(
+          args.workspaceId,
+          args.provider,
+          args.instance ?? DEFAULT_INSTANCE,
+        ),
+      ),
       last4(args.clientSecret),
       args.userId,
     ],
@@ -150,6 +158,9 @@ export async function getNativeOAuthClientSecret(
   if (!r) return null;
   return {
     clientId: r.client_id,
-    clientSecret: decryptSecret(r.client_secret_ciphertext),
+    clientSecret: decryptSecret(
+      r.client_secret_ciphertext,
+      aadNativeOauthClient(workspaceId, provider, instance),
+    ),
   };
 }

--- a/web/src/lib/secret-connections.ts
+++ b/web/src/lib/secret-connections.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { decryptSecret, encryptSecret, last4 } from "@/lib/crypto";
+import { aadSecretConnection } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
 
 // Secrets — the 3rd connection substrate. Free-form, per-WORKSPACE API keys
@@ -82,7 +83,7 @@ export async function upsertSecretConnection(args: {
   );
   const existed = existingRows.length > 0;
 
-  const ciphertext = encryptSecret(value);
+  const ciphertext = encryptSecret(value, aadSecretConnection(args.workspaceId, slug));
   await db.query(
     `INSERT INTO workspace_secret_connection
        (workspace_id, slug, description, ciphertext, last4, created_by)
@@ -131,5 +132,5 @@ export async function getSecretConnectionValue(
     [workspaceId, slug],
   );
   if (rows.length === 0) return null;
-  return decryptSecret(rows[0].ciphertext);
+  return decryptSecret(rows[0].ciphertext, aadSecretConnection(workspaceId, slug));
 }

--- a/web/src/lib/slack-apps.ts
+++ b/web/src/lib/slack-apps.ts
@@ -1,6 +1,9 @@
 import "server-only";
 
+import { randomUUID } from "node:crypto";
+
 import { decryptSecret, encryptSecret } from "@/lib/crypto";
+import { aadSlackSecret } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
 import { listAgents } from "@/lib/workspace-agents";
 
@@ -120,19 +123,27 @@ export async function createSlackApp(
   input: CreateSlackAppInput,
   createdBy: string,
 ): Promise<SlackApp> {
+  // Generate the row id up front so the secret AAD can bind to it at encrypt
+  // time (it isn't known until after INSERT otherwise).
+  const id = randomUUID();
   const { rows } = await db.query<Row>(
     `INSERT INTO workspace_slack_app
-       (workspace_id, name, slack_app_id, signing_secret, client_id,
+       (id, workspace_id, name, slack_app_id, signing_secret, client_id,
         client_secret, default_owner_user_id, agent_labels, created_by)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
      RETURNING ${SELECT}`,
     [
+      id,
       workspaceId,
       input.name,
       input.slackAppId ?? null,
-      input.signingSecret ? encryptSecret(input.signingSecret) : null,
+      input.signingSecret
+        ? encryptSecret(input.signingSecret, aadSlackSecret(id, "signing_secret"))
+        : null,
       input.clientId ?? null,
-      input.clientSecret ? encryptSecret(input.clientSecret) : null,
+      input.clientSecret
+        ? encryptSecret(input.clientSecret, aadSlackSecret(id, "client_secret"))
+        : null,
       input.defaultOwnerUserId,
       input.agentLabels,
       createdBy,
@@ -171,9 +182,15 @@ export async function updateSlackApp(
   if (input.slackAppId !== undefined) set("slack_app_id", input.slackAppId);
   if (input.clientId !== undefined) set("client_id", input.clientId);
   if (input.signingSecret)
-    set("signing_secret", encryptSecret(input.signingSecret));
+    set(
+      "signing_secret",
+      encryptSecret(input.signingSecret, aadSlackSecret(id, "signing_secret")),
+    );
   if (input.clientSecret)
-    set("client_secret", encryptSecret(input.clientSecret));
+    set(
+      "client_secret",
+      encryptSecret(input.clientSecret, aadSlackSecret(id, "client_secret")),
+    );
   if (sets.length === 0) return;
   sets.push("updated_at = now()");
   params.push(workspaceId);
@@ -221,9 +238,15 @@ export async function getSlackAppSecrets(
   const r = rows[0];
   if (!r) return null;
   return {
-    signingSecret: r.signing_secret ? decryptSecret(r.signing_secret) : null,
-    clientSecret: r.client_secret ? decryptSecret(r.client_secret) : null,
-    botToken: r.bot_token ? decryptSecret(r.bot_token) : null,
+    signingSecret: r.signing_secret
+      ? decryptSecret(r.signing_secret, aadSlackSecret(id, "signing_secret"))
+      : null,
+    clientSecret: r.client_secret
+      ? decryptSecret(r.client_secret, aadSlackSecret(id, "client_secret"))
+      : null,
+    botToken: r.bot_token
+      ? decryptSecret(r.bot_token, aadSlackSecret(id, "bot_token"))
+      : null,
   };
 }
 
@@ -336,7 +359,7 @@ export async function setSlackAppInstall(
       WHERE id = $1`,
     [
       id,
-      encryptSecret(args.botToken),
+      encryptSecret(args.botToken, aadSlackSecret(id, "bot_token")),
       args.teamId,
       args.botUserId,
       args.slackAppId ?? null,

--- a/web/src/lib/webhooks-db.ts
+++ b/web/src/lib/webhooks-db.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 
 import { decryptSecret, encryptSecret, last4 } from "@/lib/crypto";
+import { aadWebhookToken } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
 
 // External webhook triggers — an inbound HTTP endpoint that fires an agent run.
@@ -132,7 +133,10 @@ export function webhookTokenMatches(
 ): boolean {
   let stored: string;
   try {
-    stored = decryptSecret(row.tokenCiphertext);
+    stored = decryptSecret(
+      row.tokenCiphertext,
+      aadWebhookToken(row.workspaceId, row.id),
+    );
   } catch {
     return false;
   }
@@ -152,18 +156,21 @@ export async function createWebhook(args: {
   createdBy: string;
 }): Promise<{ webhook: WebhookPreview; token: string }> {
   const token = generateToken();
+  // Generate the id up front so the token AAD can bind to it at encrypt time.
+  const id = randomUUID();
   const { rows } = await db.query<PreviewDbRow>(
     `INSERT INTO workspace_webhook
-       (workspace_id, agent_name, owner_user_id, name, token_ciphertext,
+       (id, workspace_id, agent_name, owner_user_id, name, token_ciphertext,
         token_last4, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        RETURNING ${PREVIEW_COLS}`,
     [
+      id,
       args.workspaceId,
       args.agentName,
       args.ownerUserId,
       args.name,
-      encryptSecret(token),
+      encryptSecret(token, aadWebhookToken(args.workspaceId, id)),
       last4(token),
       args.createdBy,
     ],
@@ -180,7 +187,12 @@ export async function rotateWebhookToken(
     `UPDATE workspace_webhook
         SET token_ciphertext = $3, token_last4 = $4, updated_at = NOW()
       WHERE workspace_id = $1 AND id = $2`,
-    [workspaceId, id, encryptSecret(token), last4(token)],
+    [
+      workspaceId,
+      id,
+      encryptSecret(token, aadWebhookToken(workspaceId, id)),
+      last4(token),
+    ],
   );
   return (rowCount ?? 0) > 0 ? token : null;
 }

--- a/web/src/lib/workspace.ts
+++ b/web/src/lib/workspace.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { decryptSecret, encryptSecret, last4 } from "@/lib/crypto";
+import { aadWorkspaceSecret } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
 import {
   parseRepoInput,
@@ -768,7 +769,7 @@ export async function getWorkspaceSecretPlaintext(
   if (!rows[0]) {
     throw new Error(`workspace secret not found: ${kind}`);
   }
-  return decryptSecret(rows[0].ciphertext);
+  return decryptSecret(rows[0].ciphertext, aadWorkspaceSecret(workspaceId, kind));
 }
 
 // ── Commit mode (PR vs direct / YOLO) ────────────────────────────────────
@@ -826,7 +827,7 @@ export async function setWorkspaceSecret(
     return { ok: false, error: "bad-prefix" };
   }
 
-  const ciphertext = encryptSecret(trimmed);
+  const ciphertext = encryptSecret(trimmed, aadWorkspaceSecret(workspaceId, kind));
   await db.query(
     `INSERT INTO workspace_secret (workspace_id, kind, ciphertext, last4)
        VALUES ($1, $2, $3, $4)
@@ -921,7 +922,7 @@ export async function connectWorkspaceRepo(
     return { ok: false, error: validation.error, detail: validation.detail };
   }
 
-  const ciphertext = encryptSecret(token);
+  const ciphertext = encryptSecret(token, aadWorkspaceSecret(workspaceId, "github_pat"));
   const tokenLast4 = last4(token);
 
   const client = await db.connect();


### PR DESCRIPTION
## Summary

Closes #49. Binds every encrypted secret to its row via AES-GCM **AAD**, so a ciphertext blob moved into a different row no longer decrypts.

**Non-breaking, versioned blob:** `encrypt(plaintext, aad)` writes the legacy `nonce||ct||tag` layout (byte-identical to before) when no AAD is given, and a `0x01`-prefixed AAD-bound layout when one is. `decrypt` tries the versioned path then falls back to legacy — so existing ciphertext keeps decrypting and each row is rebound the next time it's written. No re-auth / re-keying required.

A shared canonical AAD format (`web/src/lib/crypto-aad.ts` ↔ `api/src/crypto.rs::aad`) is byte-identical across languages (asserted by tests on both sides) for the rows both touch.

## Tables bound (all readers + writers, web + Rust)

| Table | AAD | Notes |
|---|---|---|
| `workspace_secret` | (workspace_id, kind) | provider keys, github_pat, composio key |
| `workspace_secret_connection` | (workspace_id, slug) | |
| `workspace_connection` (native creds) | (workspace_id, user_id, type, name) | web save/read + Rust list + refresh decrypt/re-encrypt |
| `workspace_native_oauth_client` | (workspace_id, provider, instance) | web + Rust |
| `workspace_slack_app` secrets | (id, column) | signing/client/bot; id generated app-side at create |
| `workspace_webhook` token | (workspace_id, id) | id generated app-side at create |
| `workspace_api_key` token | (workspace_id, id) | id generated app-side at create |

## Migration semantics

During rollout legacy blobs still decrypt (the fallback ignores AAD), so the bind only fully protects a row once it's been rewritten. Once all rows are versioned, the fallback can be removed to make legacy blobs hard-fail (future toggle).

## Tests

- New crypto unit tests both sides (round-trip, AAD-mismatch rejection, legacy fallback, exact cross-language AAD string): web `crypto.test.ts`, Rust `crypto::tests`.
- Full suites green: web `vitest` 124, `tsc`, `eslint`; Rust `cargo test` 43.
- Dogfood rebuilt clean; existing legacy secrets still decrypt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)