### PR TITLE
Per-agent "Locked" toggle for governed agents (#12)

### DIFF
--- a/api/migrations/0061_agent_lock.sql
+++ b/api/migrations/0061_agent_lock.sql
@@ -1,0 +1,23 @@
+-- Per-agent "Locked" flag — an admin lockdown for governed agents (e.g.
+-- regulated drafting) so end users can't drive changes or adaptation. When an
+-- agent is locked, the in-app edit affordances (Chat to edit, Improve, and
+-- correction/learning capture) are removed and the change/learning history tabs
+-- (Versions, Activity, Learning) are hidden; the agent then changes ONLY via
+-- direct repo PRs. Setting it is Workspace-Admin-only and audited.
+--
+-- One row per (workspace, agent); a row with locked = true means locked.
+-- Web-owned table; the Rust API just applies the migration on boot.
+CREATE TABLE IF NOT EXISTS agent_lock (
+    workspace_id UUID        NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    agent_name   TEXT        NOT NULL,
+    locked       BOOLEAN     NOT NULL DEFAULT TRUE,
+    updated_by   TEXT        REFERENCES "user"(id) ON DELETE SET NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (workspace_id, agent_name)
+);
+
+-- "Which agents in this workspace are locked?" — the scheduler excludes locked
+-- agents from the learning loop and the UI hides edit affordances for them.
+CREATE INDEX IF NOT EXISTS agent_lock_locked_idx
+    ON agent_lock (workspace_id)
+    WHERE locked;

--- a/web/src/app/[workspace]/agents/[agent]/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/actions.ts
@@ -26,6 +26,7 @@ import {
   setAgentOwner,
 } from "@/lib/agent-versions";
 import { summarizeSpecDiff } from "@/lib/agent-version-summary";
+import { isAgentLocked, setAgentLock } from "@/lib/agent-lock";
 import {
   upsertAgentLearning,
   type LearningCadence,
@@ -640,6 +641,11 @@ export async function setAgentLearningAction(
   }
   const { workspace, userId } = auth;
 
+  // A locked agent must not capture/adapt — refuse to enable learning on it.
+  if (enabled && (await isAgentLocked(workspace.id, agentName))) {
+    return { error: "This agent is locked — learning is disabled." };
+  }
+
   // Attribute the batched improvement to whoever turned learning on (their
   // identity owns the resulting CAP task — improvement.created_by is NOT NULL).
   await upsertAgentLearning({
@@ -671,6 +677,48 @@ export async function setAgentLearningAction(
   };
 }
 
+export type LockFormState = { error?: string; message?: string };
+
+// Admin-only "Locked" toggle. When locked, the agent's in-app edit affordances
+// (Chat to edit, Improve, learning capture) are removed and its Versions /
+// Activity / Learning tabs are hidden — it changes only via repo PRs. The
+// scheduler skips locked agents, and the edit chokepoint (requestAgentChange)
+// rejects them, so hiding the UI isn't the only line of defense.
+export async function setAgentLockAction(
+  _prev: LockFormState,
+  formData: FormData,
+): Promise<LockFormState> {
+  const slug = String(formData.get("workspace") ?? "");
+  const agentName = String(formData.get("agent") ?? "");
+  const locked = formData.get("locked") === "on";
+
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (!auth.ok) {
+    if (auth.reason === "denied") return { error: DENIED_MESSAGE };
+    notFound();
+  }
+  const { workspace, userId } = auth;
+
+  await setAgentLock(workspace.id, agentName, locked, userId);
+  await writeAuditEvent({
+    workspaceId: workspace.id,
+    actorUserId: userId,
+    source: "policy_change",
+    kind: "agent.lock.changed",
+    targetType: "agent",
+    targetId: agentName,
+    agentName,
+    payload: { locked },
+  });
+
+  revalidatePath(`/${slug}/agents/${encodeURIComponent(agentName)}`, "layout");
+  return {
+    message: locked
+      ? "Agent locked. Users can't edit it and its history is hidden; change it via repo PRs."
+      : "Agent unlocked.",
+  };
+}
+
 const FORK_ERROR_MESSAGE: Partial<
   Record<Extract<ForkAgentResult, { ok: false }>["error"], string>
 > = {
@@ -691,6 +739,12 @@ export async function forkAgentAction(args: {
     notFound();
   }
   const { workspace, userId } = auth;
+
+  // A locked agent is change-controlled — it can't be copied out either.
+  if (await isAgentLocked(workspace.id, args.agentName)) {
+    return { ok: false, error: "This agent is locked and can't be forked." };
+  }
+
   const session = await getServerSession();
   const email = session?.user.email ?? "";
 

--- a/web/src/app/[workspace]/agents/[agent]/activity/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/activity/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from "next/navigation";
+
 import { listAuditTimeline } from "@/lib/audit-db";
 
 import { AgentTimeline } from "../agent-timeline";
@@ -16,7 +18,14 @@ export default async function AgentActivityPage({
   params: Promise<{ workspace: string; agent: string }>;
 }) {
   const { workspace: slug, agent: agentName } = await params;
-  const { workspace, canonicalName } = await loadAgentContext(slug, agentName);
+  const { workspace, canonicalName, locked } = await loadAgentContext(
+    slug,
+    agentName,
+  );
+  // Locked agents hide their history tabs (#12) — block the direct URL too.
+  if (locked) {
+    redirect(`/${slug}/agents/${encodeURIComponent(canonicalName)}`);
+  }
 
   const timeline = await listAuditTimeline(
     workspace.id,

--- a/web/src/app/[workspace]/agents/[agent]/agent-lock-control.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/agent-lock-control.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+// "Locked" control on the agent Settings tab (Workspace-Admin only). When on,
+// the agent's in-app edit affordances (Chat to edit, Improve, Fork, learning
+// capture) are removed and its Versions / Activity / Learning history tabs are
+// hidden — it then changes only via direct repo PRs. Mirrors
+// AgentLearningControl's useActionState + prop re-sync pattern.
+
+import { useActionState, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { useActionToast } from "@/lib/use-action-toast";
+
+import { setAgentLockAction, type LockFormState } from "./actions";
+
+const INITIAL: LockFormState = {};
+
+type Props = {
+  workspaceSlug: string;
+  agentName: string;
+  locked: boolean;
+  canManage: boolean;
+};
+
+export function AgentLockControl({
+  workspaceSlug,
+  agentName,
+  locked,
+  canManage,
+}: Props) {
+  const [on, setOn] = useState(locked);
+  // Re-sync to the server value after a save revalidates the page (render-phase
+  // "adjust state on prop change"), so the checkbox doesn't look like it reverted.
+  const [seen, setSeen] = useState(locked);
+  if (seen !== locked) {
+    setSeen(locked);
+    setOn(locked);
+  }
+  const [state, formAction, pending] = useActionState(
+    setAgentLockAction,
+    INITIAL,
+  );
+  useActionToast(state);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-3">
+      <input type="hidden" name="workspace" value={workspaceSlug} />
+      <input type="hidden" name="agent" value={agentName} />
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          name="locked"
+          checked={on}
+          onChange={(e) => setOn(e.target.checked)}
+          disabled={!canManage || pending}
+          className="h-4 w-4"
+        />
+        <span className="text-foreground">Lock this agent</span>
+      </label>
+
+      <p className="text-foreground-muted max-w-prose text-xs leading-5">
+        When locked, users can&apos;t change this agent in-app — Chat to edit,
+        Improve, Fork, and correction/learning capture are all disabled, and the
+        Versions, Activity, and Learning history tabs are hidden. The agent then
+        changes only through direct repo PRs. Admin-only; changes are audited.
+      </p>
+
+      {canManage && (
+        <div>
+          <Button type="submit" disabled={pending}>
+            {pending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/web/src/app/[workspace]/agents/[agent]/agent-nav.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/agent-nav.tsx
@@ -20,22 +20,30 @@ const ITEMS: Item[] = [
   { slug: "settings", label: "Settings" },
 ];
 
+// Tabs hidden when the agent is Locked — its change/learning history (#12).
+const LOCKED_HIDDEN = new Set(["versions", "activity", "learning"]);
+
 export function AgentNav({
   workspaceSlug,
   agentName,
+  locked,
 }: {
   workspaceSlug: string;
   agentName: string;
+  locked: boolean;
 }) {
   const pathname = usePathname();
   const base = `/${workspaceSlug}/agents/${encodeURIComponent(agentName)}`;
+  const items = locked
+    ? ITEMS.filter((i) => !LOCKED_HIDDEN.has(i.slug))
+    : ITEMS;
 
   return (
     <nav
       aria-label="Agent sections"
       className="flex w-full shrink-0 flex-row gap-1 overflow-x-auto sm:w-36 sm:flex-col"
     >
-      {ITEMS.map((item) => {
+      {items.map((item) => {
         const href = item.slug ? `${base}/${item.slug}` : base;
         const isActive = item.slug
           ? pathname === href || pathname.startsWith(`${href}/`)

--- a/web/src/app/[workspace]/agents/[agent]/agent-page-context.ts
+++ b/web/src/app/[workspace]/agents/[agent]/agent-page-context.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { notFound, redirect } from "next/navigation";
 
+import { isAgentLocked } from "@/lib/agent-lock";
 import { getServerSession } from "@/lib/session";
 import { getAgentByName, type ListedAgent } from "@/lib/workspace-agents";
 import { getWorkspaceBySlug, getWorkspaceRepo } from "@/lib/workspace";
@@ -23,6 +24,8 @@ export type AgentPageContext = {
   toolsModuleContent: string | undefined;
   /** The agent's declared name (falls back to the URL param for invalid files). */
   canonicalName: string;
+  /** Admin "Locked" flag — hides edit affordances + history tabs (#12). */
+  locked: boolean;
 };
 
 export async function loadAgentContext(
@@ -47,6 +50,7 @@ export async function loadAgentContext(
 
   const { agent, raw, toolsModuleContent } = result;
   const canonicalName = agent.ok ? agent.spec.name : agentName;
+  const locked = await isAgentLocked(workspace.id, canonicalName);
 
   return {
     session,
@@ -56,5 +60,6 @@ export async function loadAgentContext(
     raw,
     toolsModuleContent,
     canonicalName,
+    locked,
   };
 }

--- a/web/src/app/[workspace]/agents/[agent]/chat/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/chat/page.tsx
@@ -1,6 +1,7 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import { BackLink } from "@/components/back-link";
+import { isAgentLocked } from "@/lib/agent-lock";
 import { agentDisplayName } from "@/lib/agent-format";
 import { scanImprovementsForPRs } from "@/lib/improvement-scan";
 import { listImprovementsForAgent } from "@/lib/improvements-api";
@@ -31,6 +32,10 @@ export default async function AgentChatPage({
   if (!result) notFound();
   const { agent } = result;
   const canonicalName = agent.ok ? agent.spec.name : agentName;
+  // Locked agents (#12) take no in-app edits — chat-to-edit is disabled.
+  if (await isAgentLocked(workspace.id, canonicalName)) {
+    redirect(`/${slug}/agents/${encodeURIComponent(canonicalName)}`);
+  }
   const displayName = agent.ok ? agentDisplayName(agent.spec) : agentName;
 
   const [stored, chatRuns] = await Promise.all([

--- a/web/src/app/[workspace]/agents/[agent]/layout.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/layout.tsx
@@ -41,7 +41,7 @@ export default async function AgentLayout({
   params: Promise<{ workspace: string; agent: string }>;
 }) {
   const { workspace: slug, agent: agentName } = await params;
-  const { session, workspace, repo, agent, raw, canonicalName } =
+  const { session, workspace, repo, agent, raw, canonicalName, locked } =
     await loadAgentContext(slug, agentName);
 
   const [currentUserRole, temboConfigured, stable, owner, allMembers] =
@@ -117,6 +117,11 @@ export default async function AgentLayout({
                     Draft only
                   </Badge>
                 )}
+                {locked && (
+                  <Badge variant="red" size="small">
+                    Locked
+                  </Badge>
+                )}
                 <Badge variant="blue" size="small">
                   {FRAMEWORK_LABELS[agent.spec.framework]}
                 </Badge>
@@ -171,7 +176,7 @@ export default async function AgentLayout({
                 </a>
               </Button>
             )}
-            {agent.ok && canEdit && temboConfigured && (
+            {agent.ok && canEdit && temboConfigured && !locked && (
               <Button asChild variant="secondary">
                 <Link
                   href={`/${workspace.slug}/agents/${encodeURIComponent(canonicalName)}/chat`}
@@ -180,7 +185,7 @@ export default async function AgentLayout({
                 </Link>
               </Button>
             )}
-            {agent.ok && canEdit && (
+            {agent.ok && canEdit && !locked && (
               <ForkAgentButton
                 workspaceSlug={workspace.slug}
                 agentName={canonicalName}
@@ -214,7 +219,11 @@ export default async function AgentLayout({
       <hr className="border-[var(--color-border-weak)]" />
 
       <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:gap-10">
-        <AgentNav workspaceSlug={workspace.slug} agentName={canonicalName} />
+        <AgentNav
+          workspaceSlug={workspace.slug}
+          agentName={canonicalName}
+          locked={locked}
+        />
         <div className="flex min-w-0 flex-1 flex-col gap-8">{children}</div>
       </div>
     </div>

--- a/web/src/app/[workspace]/agents/[agent]/learning/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/learning/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from "next/navigation";
+
 import { LocalTime } from "@/components/local-time";
 import { Section } from "@/components/section";
 import { getAgentLearning } from "@/lib/agent-learning-api";
@@ -21,10 +23,14 @@ export default async function AgentLearningPage({
   params: Promise<{ workspace: string; agent: string }>;
 }) {
   const { workspace: slug, agent: agentName } = await params;
-  const { session, workspace, canonicalName } = await loadAgentContext(
+  const { session, workspace, canonicalName, locked } = await loadAgentContext(
     slug,
     agentName,
   );
+  // Locked agents hide their history tabs (#12) — block the direct URL too.
+  if (locked) {
+    redirect(`/${slug}/agents/${encodeURIComponent(canonicalName)}`);
+  }
 
   const [learning, stats, batches, role] = await Promise.all([
     getAgentLearning(workspace.id, canonicalName),

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { BackLink } from "@/components/back-link";
 import { LocalTime } from "@/components/local-time";
 import { Section } from "@/components/section";
+import { isAgentLocked } from "@/lib/agent-lock";
 import { scanImprovementsForPRs } from "@/lib/improvement-scan";
 import { listImprovementsForRun } from "@/lib/improvements-api";
 import { estimateRunCost, formatCurrency, formatTokens } from "@/lib/pricing";
@@ -121,8 +122,10 @@ export default async function RunDetailPage({
   const isLive = run.status === "running" || run.status === "queued";
 
   // "Improve the Agent" opens a Tembo CAP task — hide it when no Tembo
-  // API key is set (the run + its output still render).
+  // API key is set (the run + its output still render), or when the agent is
+  // locked (#12: no user-driven edits — changes go through repo PRs).
   const temboConfigured = await isTemboConfigured(workspace.id);
+  const locked = await isAgentLocked(workspace.id, run.agentName);
 
   const agentHref = `/${workspace.slug}/agents/${encodeURIComponent(run.agentName)}`;
   const totalTokens =
@@ -470,7 +473,8 @@ export default async function RunDetailPage({
           from the streaming output feels wrong. Fade it in two seconds
           after the output settles so the user finishes reading first. */}
       {(run.status === "succeeded" || run.status === "failed") &&
-        temboConfigured && (
+        temboConfigured &&
+        !locked && (
           <>
             <hr className="border-[var(--color-border-weak)]" />
             <ImproveForm

--- a/web/src/app/[workspace]/agents/[agent]/settings/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/settings/page.tsx
@@ -3,6 +3,7 @@ import { getAgentOwner } from "@/lib/agent-versions";
 import { meetsMinRole } from "@/lib/rbac";
 import { getWorkspaceRole, listWorkspaceMembers } from "@/lib/workspace";
 
+import { AgentLockControl } from "../agent-lock-control";
 import { AgentOwnerControl } from "../agent-owner-control";
 import { loadAgentContext } from "../agent-page-context";
 import { DeleteAgentButton } from "../delete-agent-button";
@@ -18,7 +19,7 @@ export default async function AgentSettingsPage({
   params: Promise<{ workspace: string; agent: string }>;
 }) {
   const { workspace: slug, agent: agentName } = await params;
-  const { session, workspace, canonicalName } = await loadAgentContext(
+  const { session, workspace, canonicalName, locked } = await loadAgentContext(
     slug,
     agentName,
   );
@@ -63,6 +64,18 @@ export default async function AgentSettingsPage({
             name: m.name,
             email: m.email,
           }))}
+        />
+      </Section>
+
+      <Section
+        title="Locked"
+        description="Lock a governed agent (e.g. regulated drafting) so users can't change it in-app and its history is hidden — it then changes only via repo PRs."
+      >
+        <AgentLockControl
+          workspaceSlug={workspace.slug}
+          agentName={canonicalName}
+          locked={locked}
+          canManage={isAdmin}
         />
       </Section>
 

--- a/web/src/app/[workspace]/agents/[agent]/versions/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/versions/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from "next/navigation";
+
 import { Section } from "@/components/section";
 import {
   getAgentOwner,
@@ -22,8 +24,12 @@ export default async function AgentVersionsPage({
   params: Promise<{ workspace: string; agent: string }>;
 }) {
   const { workspace: slug, agent: agentName } = await params;
-  const { session, workspace, agent, raw, canonicalName } =
+  const { session, workspace, agent, raw, canonicalName, locked } =
     await loadAgentContext(slug, agentName);
+  // Locked agents hide their history tabs (#12) — block the direct URL too.
+  if (locked) {
+    redirect(`/${slug}/agents/${encodeURIComponent(canonicalName)}`);
+  }
 
   const [versions, stable, owner, allMembers, currentUserRole] =
     await Promise.all([

--- a/web/src/lib/agent-learning-api.ts
+++ b/web/src/lib/agent-learning-api.ts
@@ -90,6 +90,13 @@ export async function listDueLearningConfigs(
     `SELECT ${COLUMNS} FROM agent_learning
       WHERE enabled
         AND owner_user_id IS NOT NULL
+        -- A locked agent (#12) never learns, regardless of its learning row.
+        AND NOT EXISTS (
+          SELECT 1 FROM agent_lock l
+           WHERE l.workspace_id = agent_learning.workspace_id
+             AND l.agent_name = agent_learning.agent_name
+             AND l.locked
+        )
         AND (
           last_learned_at IS NULL
           OR last_learned_at < $1::timestamptz - (

--- a/web/src/lib/agent-lock.ts
+++ b/web/src/lib/agent-lock.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+
+// The per-agent "Locked" flag (migration 0061). When an agent is locked, end
+// users can't drive changes: Chat to edit / Improve / learning capture are
+// removed, and the Versions / Activity / Learning history tabs are hidden. The
+// agent then changes only via direct repo PRs. Admin-set + audited (see
+// setAgentLockAction). Distinct from learning mode — locking also forces
+// learning off (the scheduler skips locked agents).
+
+export async function isAgentLocked(
+  workspaceId: string,
+  agentName: string,
+): Promise<boolean> {
+  const { rows } = await db.query<{ locked: boolean }>(
+    `SELECT locked FROM agent_lock WHERE workspace_id = $1 AND agent_name = $2`,
+    [workspaceId, agentName],
+  );
+  return rows[0]?.locked ?? false;
+}
+
+/** Names of every locked agent in the workspace — for list badges / scans. */
+export async function listLockedAgentNames(
+  workspaceId: string,
+): Promise<Set<string>> {
+  const { rows } = await db.query<{ agent_name: string }>(
+    `SELECT agent_name FROM agent_lock WHERE workspace_id = $1 AND locked`,
+    [workspaceId],
+  );
+  return new Set(rows.map((r) => r.agent_name));
+}
+
+/** Upsert the per-agent lock. `updatedBy` is the admin who flipped it. */
+export async function setAgentLock(
+  workspaceId: string,
+  agentName: string,
+  locked: boolean,
+  updatedBy: string,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO agent_lock (workspace_id, agent_name, locked, updated_by)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (workspace_id, agent_name)
+     DO UPDATE SET locked = $3, updated_by = $4, updated_at = NOW()`,
+    [workspaceId, agentName, locked, updatedBy],
+  );
+}

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -3,6 +3,7 @@ import "server-only";
 import type { AuthorizeApiSuccess } from "@/lib/api-auth";
 import { writeAuditEvent } from "@/lib/audit-db";
 import type { AuditSource } from "@/lib/audit";
+import { isAgentLocked } from "@/lib/agent-lock";
 import {
   detectFormat,
   parseAgentContent,
@@ -325,6 +326,15 @@ export async function requestAgentChange(
         ok: false,
         status: 422,
         error: `agent file failed to parse: ${found.agent.error}`,
+      };
+    }
+    // A locked agent is change-controlled — no in-app edits (chat / improve);
+    // it changes only via direct repo PRs.
+    if (await isAgentLocked(ctx.workspace.id, found.agent.spec.name)) {
+      return {
+        ok: false,
+        status: 409,
+        error: "this agent is locked — changes must go through a repo PR",
       };
     }
     kind = "edit";


### PR DESCRIPTION
## Summary

Implements #12 as a per-agent **Locked** toggle — an admin lockdown for governed agents (e.g. regulated drafting) so end users can't drive changes or adaptation. A locked agent changes only via direct repo PRs.

Reframed from the original "correction capture toggle": our per-agent **learning** toggle (off by default) already prevents adaptation; this adds the distinct, stronger "users can't edit it and its history is hidden" lockdown the issue was really after.

## Behavior when Locked

**Edit affordances removed** (UI + server-side):
- **Chat to edit** (header + `/chat` route redirect)
- **Improve the Agent** (run detail)
- **Fork** (header + `forkAgentAction` rejects)
- **Learning capture** (`setAgentLearningAction` won't enable; scheduler `listDueLearningConfigs` excludes locked agents, so corrections never batch into a PR)
- `requestAgentChange` (the chat/improve chokepoint) rejects edits to a locked agent

**History hidden:** the **Versions**, **Activity**, and **Learning** tabs are removed from the nav, and their routes redirect to the overview.

**Kept:** Run now, View source, Definition, Settings. A **Locked** badge shows on the agent header.

## Control & audit
- Toggle on the agent **Settings** tab, **Workspace-Admin only** (`authorizeWorkspace(…, "workspace_admin")`).
- Every change writes an audit event (`agent.lock.changed`, source `policy_change`) — satisfies "audited on change".

## Data
- `api/migrations/0061_agent_lock.sql` — `agent_lock (workspace_id, agent_name, locked, updated_by, updated_at)`, partial index on locked rows.
- `web/src/lib/agent-lock.ts` — `isAgentLocked` / `listLockedAgentNames` / `setAgentLock`. `locked` threaded through `loadAgentContext`.

## Tests / verification
- `tsc`, `eslint`, `vitest` (124) green; dogfood rebuilt, migration 0061 applied.

Follow-up option (not included): a Locked badge in the agents **list** view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)