### PR TITLE
Inbox privacy: scope items to their owner (acting user)

### DIFF
--- a/api/migrations/0062_inbox_owner.sql
+++ b/api/migrations/0062_inbox_owner.sql
@@ -1,0 +1,25 @@
+-- Inboxes are PRIVATE per user. Before this, inbox_item was only scoped by
+-- workspace_id, so every member saw every member's items. Add an explicit
+-- owner: the user the producing run acted as (or the human who filed it).
+-- Reads (list/count/get) and mutations filter on it; items with no resolvable
+-- owner stay NULL and are visible to no one (safer than leaking).
+ALTER TABLE inbox_item
+    ADD COLUMN IF NOT EXISTS owner_user_id TEXT REFERENCES "user"(id) ON DELETE SET NULL;
+
+-- Backfill agent-produced items from the producing run's acting user
+-- (run.created_by is the acting/owner user the run executed as).
+UPDATE inbox_item i
+   SET owner_user_id = r.created_by
+  FROM run r
+ WHERE i.produced_by_run_id = r.id
+   AND i.owner_user_id IS NULL;
+
+-- Backfill human-filed items (created_by set when a person filed it directly).
+UPDATE inbox_item
+   SET owner_user_id = created_by
+ WHERE owner_user_id IS NULL
+   AND created_by IS NOT NULL;
+
+-- The hot path: "my active items in this workspace, newest first."
+CREATE INDEX IF NOT EXISTS inbox_item_owner_idx
+    ON inbox_item (workspace_id, owner_user_id, status, created_at DESC);

--- a/web/src/app/[workspace]/inbox/[id]/page.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/page.tsx
@@ -29,7 +29,7 @@ export default async function InboxItemPage({
   const workspace = await getWorkspaceBySlug(slug);
   if (!workspace) notFound();
 
-  const item = await getInboxItem(id, workspace.id);
+  const item = await getInboxItem(id, workspace.id, session.user.id);
   if (!item) notFound();
 
   const resolved = item.status === "done" || item.status === "dismissed";

--- a/web/src/app/[workspace]/inbox/actions.ts
+++ b/web/src/app/[workspace]/inbox/actions.ts
@@ -43,14 +43,14 @@ export async function submitInboxItemAction(args: {
   }
   const { workspace, userId } = auth;
 
-  const item = await getInboxItem(args.itemId, workspace.id);
+  const item = await getInboxItem(args.itemId, workspace.id, userId);
   if (!item) notFound();
 
   const finalAction = {
     ...(text ? { text } : {}),
     ...(args.fields ? { fields: args.fields } : {}),
   };
-  const ok = await completeInboxItem(args.itemId, workspace.id, finalAction);
+  const ok = await completeInboxItem(args.itemId, workspace.id, finalAction, userId);
   if (!ok) {
     return { ok: false, error: "This item was already resolved. Refresh the page." };
   }
@@ -81,7 +81,7 @@ export async function dismissInboxItemAction(args: {
   }
   const { workspace, userId } = auth;
 
-  const ok = await dismissInboxItem(args.itemId, workspace.id);
+  const ok = await dismissInboxItem(args.itemId, workspace.id, userId);
   if (!ok) {
     return { ok: false, error: "This item was already resolved. Refresh the page." };
   }
@@ -119,7 +119,7 @@ export async function executeInboxOptionAction(args: {
   }
   const { workspace, userId } = auth;
 
-  const item = await getInboxItem(args.itemId, workspace.id);
+  const item = await getInboxItem(args.itemId, workspace.id, userId);
   if (!item) notFound();
 
   const option = item.options?.find((o) => o.id === args.optionId);
@@ -140,7 +140,7 @@ export async function executeInboxOptionAction(args: {
     fields: { optionId: option.id },
     ...(option.kind === "reply" && args.text?.trim() ? { text: args.text.trim() } : {}),
   };
-  const ok = await completeInboxItem(args.itemId, workspace.id, finalAction);
+  const ok = await completeInboxItem(args.itemId, workspace.id, finalAction, userId);
   if (!ok) {
     return { ok: false, error: "This item was already resolved. Refresh the page." };
   }
@@ -177,7 +177,7 @@ export async function snoozeInboxItemAction(args: {
   const hours = Math.max(1, Math.min(Math.round(args.hours), 24 * 90)); // 1h … 90d
   const until = new Date(Date.now() + hours * 3_600_000);
 
-  const ok = await snoozeInboxItem(args.itemId, workspace.id, until);
+  const ok = await snoozeInboxItem(args.itemId, workspace.id, until, userId);
   if (!ok) {
     return { ok: false, error: "This item was already resolved. Refresh the page." };
   }
@@ -215,5 +215,5 @@ export async function getActiveInboxCountAction(
 ): Promise<number> {
   const auth = await authorizeWorkspace(workspaceSlug, "viewer");
   if (!auth.ok) return 0;
-  return countActiveInboxItems(auth.workspace.id);
+  return countActiveInboxItems(auth.workspace.id, auth.userId);
 }

--- a/web/src/app/[workspace]/inbox/page.tsx
+++ b/web/src/app/[workspace]/inbox/page.tsx
@@ -27,7 +27,7 @@ export default async function InboxPage({
 
   // Fetch the whole queue (single-tenant volumes are small); the client table
   // facets/filters/sorts in place. Default view shows active items.
-  const items = await listInboxItems(workspace.id, {}, 1000);
+  const items = await listInboxItems(workspace.id, session.user.id, {}, 1000);
   const rows: InboxRow[] = items.map((i) => ({
     id: i.id,
     title: i.title,

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -45,7 +45,7 @@ type FailingAgentAlert = {
 type Props = {
   workspace: Workspace;
   workspaces: { slug: string; name: string }[];
-  user: { name?: string | null; email: string };
+  user: { id: string; name?: string | null; email: string };
   /** The user's role in this workspace, shown as a badge by their name. */
   role?: WorkspaceRole | null;
   /**
@@ -81,7 +81,7 @@ export async function AppShell({
   const instanceName = await getInstanceName();
   const isInstanceAdmin = isInstanceAdminEmail(user.email);
   const home = `/${workspace.slug}`;
-  const inboxCount = await countActiveInboxItems(workspace.id);
+  const inboxCount = await countActiveInboxItems(workspace.id, user.id);
 
   // Collapse missing-connection alerts by the connection itself (substrate +
   // toolkit + slot). One HubSpot app needed by three agents is a single card

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -547,6 +547,9 @@ export async function produceInboxItemFor(
     // Provenance lives on produced_by_run_id; created_by is reserved for the
     // person who filed it (null when an agent did).
     createdBy: producedByRunId ? null : ctx.userId,
+    // Owner = the acting user (the run's identity for agent pushes, or the
+    // filer). Inboxes are private and scope reads/mutations to this.
+    ownerUserId: ctx.userId,
   });
   await auditApiMutation(ctx, {
     kind: "inbox.produced",
@@ -562,7 +565,7 @@ export async function listInboxItemsFor(
   filters: ListInboxFilters = {},
   limit?: number,
 ): Promise<{ ok: true; items: InboxItem[] }> {
-  const items = await listInboxItems(ctx.workspace.id, filters, limit);
+  const items = await listInboxItems(ctx.workspace.id, ctx.userId, filters, limit);
   return { ok: true, items };
 }
 
@@ -570,7 +573,7 @@ export async function getInboxItemFor(
   ctx: ApiCtx,
   id: string,
 ): Promise<{ ok: true; item: InboxItem } | ActionFailure> {
-  const item = await getInboxItem(id, ctx.workspace.id);
+  const item = await getInboxItem(id, ctx.workspace.id, ctx.userId);
   if (!item) return { ok: false, status: 404, error: `no inbox item "${id}"` };
   return { ok: true, item };
 }
@@ -581,12 +584,12 @@ export async function claimInboxItemFor(
 ): Promise<{ ok: true; item: InboxItem } | ActionFailure> {
   const agent = await actingAgentName(ctx, input.parentRunId);
   const ok = agent
-    ? await claimInboxItem(input.id, ctx.workspace.id, "agent", agent)
-    : await claimInboxItem(input.id, ctx.workspace.id, "human", ctx.userId);
+    ? await claimInboxItem(input.id, ctx.workspace.id, "agent", agent, ctx.userId)
+    : await claimInboxItem(input.id, ctx.workspace.id, "human", ctx.userId, ctx.userId);
   if (!ok) {
     return { ok: false, status: 409, error: "item not found or already claimed" };
   }
-  const item = await getInboxItem(input.id, ctx.workspace.id);
+  const item = await getInboxItem(input.id, ctx.workspace.id, ctx.userId);
   return { ok: true, item: item! };
 }
 
@@ -597,11 +600,16 @@ export async function proposeInboxActionFor(
   if (!input.proposedAction || (!input.proposedAction.text && !input.proposedAction.fields)) {
     return { ok: false, status: 400, error: "proposedAction must have text or fields" };
   }
-  const ok = await setProposedAction(input.id, ctx.workspace.id, input.proposedAction);
+  const ok = await setProposedAction(
+    input.id,
+    ctx.workspace.id,
+    input.proposedAction,
+    ctx.userId,
+  );
   if (!ok) {
     return { ok: false, status: 409, error: "item not found or not in a proposable state" };
   }
-  const item = await getInboxItem(input.id, ctx.workspace.id);
+  const item = await getInboxItem(input.id, ctx.workspace.id, ctx.userId);
   return { ok: true, item: item! };
 }
 
@@ -612,11 +620,16 @@ export async function completeInboxItemFor(
   if (!input.finalAction || (!input.finalAction.text && !input.finalAction.fields)) {
     return { ok: false, status: 400, error: "finalAction must have text or fields" };
   }
-  const ok = await completeInboxItem(input.id, ctx.workspace.id, input.finalAction);
+  const ok = await completeInboxItem(
+    input.id,
+    ctx.workspace.id,
+    input.finalAction,
+    ctx.userId,
+  );
   if (!ok) {
     return { ok: false, status: 409, error: "item not found or already resolved" };
   }
-  const item = await getInboxItem(input.id, ctx.workspace.id);
+  const item = await getInboxItem(input.id, ctx.workspace.id, ctx.userId);
   // Recorded as a HITL response even when an autonomous agent completes it —
   // the (proposed, final) pair is the signal the learning pass batches later.
   await auditApiMutation(ctx, {
@@ -633,7 +646,7 @@ export async function dismissInboxItemFor(
   ctx: ApiCtx,
   input: { id: string },
 ): Promise<{ ok: true } | ActionFailure> {
-  const ok = await dismissInboxItem(input.id, ctx.workspace.id);
+  const ok = await dismissInboxItem(input.id, ctx.workspace.id, ctx.userId);
   if (!ok) {
     return { ok: false, status: 409, error: "item not found or already resolved" };
   }

--- a/web/src/lib/inbox-api.ts
+++ b/web/src/lib/inbox-api.ts
@@ -173,6 +173,9 @@ export interface CreateInboxItemInput {
   assigneeId?: string | null;
   producedByRunId?: string | null;
   createdBy?: string | null;
+  /** The user who owns this item (the producing run's acting user, or the
+   *  human filer). Inboxes are private — reads/mutations scope to this. */
+  ownerUserId?: string | null;
 }
 
 /**
@@ -202,9 +205,9 @@ export async function createInboxItem(
        INSERT INTO inbox_item (
          workspace_id, source, external_ref, item_type, title, context,
          proposed_action, options, status, assignee_kind, assignee_id,
-         produced_by_run_id, created_by, external_ts, external_url
+         produced_by_run_id, created_by, external_ts, external_url, owner_user_id
        )
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb, $9, $10, $11, $12, $13, $14, $15)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb, $9, $10, $11, $12, $13, $14, $15, $16)
        ON CONFLICT (workspace_id, source, external_ref) WHERE external_ref IS NOT NULL
        DO UPDATE SET
          updated_at = NOW(),
@@ -218,7 +221,9 @@ export async function createInboxItem(
          resolved_at = CASE WHEN ${reopenable} THEN NULL ELSE inbox_item.resolved_at END,
          final_action = CASE WHEN ${reopenable} THEN NULL ELSE inbox_item.final_action END,
          -- A genuinely-new reply un-snoozes: the thing you were waiting for arrived.
-         snoozed_until = CASE WHEN ${reopenable} THEN NULL ELSE inbox_item.snoozed_until END
+         snoozed_until = CASE WHEN ${reopenable} THEN NULL ELSE inbox_item.snoozed_until END,
+         -- Keep the original owner; only fill it if a prior row had none.
+         owner_user_id = COALESCE(inbox_item.owner_user_id, EXCLUDED.owner_user_id)
        RETURNING *
      )
      SELECT ${COLUMNS}
@@ -240,6 +245,7 @@ export async function createInboxItem(
       input.createdBy ?? null,
       input.externalTs ?? null,
       input.url ?? null,
+      input.ownerUserId ?? null,
     ],
   );
   return rowToInboxItem(res.rows[0]);
@@ -278,11 +284,13 @@ export interface ListInboxFilters {
 
 export async function listInboxItems(
   workspaceId: string,
+  // Inboxes are private — always scope to the viewing user's own items.
+  ownerUserId: string,
   filters: ListInboxFilters = {},
   limit = 100,
 ): Promise<InboxItem[]> {
-  const params: unknown[] = [workspaceId];
-  const where: string[] = [`i.workspace_id = $1`];
+  const params: unknown[] = [workspaceId, ownerUserId];
+  const where: string[] = [`i.workspace_id = $1`, `i.owner_user_id = $2`];
   if (filters.statuses && filters.statuses.length > 0) {
     params.push(filters.statuses);
     where.push(`i.status = ANY($${params.length}::text[])`);
@@ -317,15 +325,18 @@ export async function listInboxItems(
   return res.rows.map(rowToInboxItem);
 }
 
-/** Count of active (unresolved, not snoozed) items — the sidebar badge. */
+/** Count of the viewing user's active (unresolved, not snoozed) items — the
+ *  sidebar badge. Private per user, like the list. */
 export async function countActiveInboxItems(
   workspaceId: string,
+  ownerUserId: string,
 ): Promise<number> {
   const res = await db.query<{ n: string }>(
     `SELECT count(*)::text AS n FROM inbox_item
-      WHERE workspace_id = $1 AND status IN ('open', 'claimed', 'awaiting_human')
+      WHERE workspace_id = $1 AND owner_user_id = $2
+        AND status IN ('open', 'claimed', 'awaiting_human')
         AND (snoozed_until IS NULL OR snoozed_until <= now())`,
-    [workspaceId],
+    [workspaceId, ownerUserId],
   );
   return Number(res.rows[0]?.n ?? 0);
 }
@@ -337,13 +348,14 @@ export async function snoozeInboxItem(
   id: string,
   workspaceId: string,
   until: Date,
+  ownerUserId: string,
 ): Promise<boolean> {
   const res = await db.query(
     `UPDATE inbox_item
         SET snoozed_until = $3, updated_at = NOW()
-      WHERE id = $1 AND workspace_id = $2
+      WHERE id = $1 AND workspace_id = $2 AND owner_user_id = $4
         AND status NOT IN ('done', 'dismissed')`,
-    [id, workspaceId, until],
+    [id, workspaceId, until, ownerUserId],
   );
   return (res.rowCount ?? 0) > 0;
 }
@@ -351,10 +363,13 @@ export async function snoozeInboxItem(
 export async function getInboxItem(
   id: string,
   workspaceId: string,
+  // Inboxes are private — only the owner may read a single item.
+  ownerUserId: string,
 ): Promise<InboxItem | null> {
   const res = await db.query<Row>(
-    `SELECT ${COLUMNS} ${FROM_JOIN} WHERE i.id = $1 AND i.workspace_id = $2`,
-    [id, workspaceId],
+    `SELECT ${COLUMNS} ${FROM_JOIN}
+      WHERE i.id = $1 AND i.workspace_id = $2 AND i.owner_user_id = $3`,
+    [id, workspaceId, ownerUserId],
   );
   return res.rows[0] ? rowToInboxItem(res.rows[0]) : null;
 }
@@ -369,12 +384,13 @@ export async function claimInboxItem(
   workspaceId: string,
   assigneeKind: InboxAssigneeKind,
   assigneeId: string,
+  ownerUserId: string,
 ): Promise<boolean> {
   const res = await db.query(
     `UPDATE inbox_item
         SET status = 'claimed', assignee_kind = $3, assignee_id = $4, updated_at = NOW()
-      WHERE id = $1 AND workspace_id = $2 AND status = 'open'`,
-    [id, workspaceId, assigneeKind, assigneeId],
+      WHERE id = $1 AND workspace_id = $2 AND owner_user_id = $5 AND status = 'open'`,
+    [id, workspaceId, assigneeKind, assigneeId, ownerUserId],
   );
   return (res.rowCount ?? 0) > 0;
 }
@@ -385,12 +401,14 @@ export async function setProposedAction(
   id: string,
   workspaceId: string,
   proposedAction: InboxAction,
+  ownerUserId: string,
 ): Promise<boolean> {
   const res = await db.query(
     `UPDATE inbox_item
         SET proposed_action = $3::jsonb, status = 'awaiting_human', updated_at = NOW()
-      WHERE id = $1 AND workspace_id = $2 AND status IN ('open', 'claimed')`,
-    [id, workspaceId, JSON.stringify(proposedAction)],
+      WHERE id = $1 AND workspace_id = $2 AND owner_user_id = $4
+        AND status IN ('open', 'claimed')`,
+    [id, workspaceId, JSON.stringify(proposedAction), ownerUserId],
   );
   return (res.rowCount ?? 0) > 0;
 }
@@ -401,14 +419,15 @@ export async function completeInboxItem(
   id: string,
   workspaceId: string,
   finalAction: InboxAction,
+  ownerUserId: string,
 ): Promise<boolean> {
   const res = await db.query(
     `UPDATE inbox_item
         SET final_action = $3::jsonb, status = 'done',
             resolved_at = NOW(), updated_at = NOW()
-      WHERE id = $1 AND workspace_id = $2
+      WHERE id = $1 AND workspace_id = $2 AND owner_user_id = $4
         AND status NOT IN ('done', 'dismissed')`,
-    [id, workspaceId, JSON.stringify(finalAction)],
+    [id, workspaceId, JSON.stringify(finalAction), ownerUserId],
   );
   return (res.rowCount ?? 0) > 0;
 }
@@ -417,13 +436,14 @@ export async function completeInboxItem(
 export async function dismissInboxItem(
   id: string,
   workspaceId: string,
+  ownerUserId: string,
 ): Promise<boolean> {
   const res = await db.query(
     `UPDATE inbox_item
         SET status = 'dismissed', resolved_at = NOW(), updated_at = NOW()
-      WHERE id = $1 AND workspace_id = $2
+      WHERE id = $1 AND workspace_id = $2 AND owner_user_id = $3
         AND status NOT IN ('done', 'dismissed')`,
-    [id, workspaceId],
+    [id, workspaceId, ownerUserId],
   );
   return (res.rowCount ?? 0) > 0;
 }


### PR DESCRIPTION
## Summary

**Bug:** the Tasks Inbox showed every member's items to all members — `listInboxItems` / `countActiveInboxItems` filtered only by `workspace_id`, and agent-produced items had no user owner at all (`created_by` is null for agent pushes). Inboxes must be private per user.

**Fix:** add `inbox_item.owner_user_id` and make every read + mutation private to the owner. Owner = the **run's acting user** (or the human filer); **strictly private** (no admin override).

## Changes
- **Migration `0062_inbox_owner.sql`** — adds `owner_user_id` (FK → user, ON DELETE SET NULL) + index `(workspace_id, owner_user_id, status, created_at DESC)`. Backfills agent items from `run.created_by` (the producing run's acting user) and human-filed items from `created_by`. Items with no provenance stay NULL → invisible to everyone (privacy-safe).
- **Produce** (`produceInboxItemFor`) stamps `owner_user_id = ctx.userId`.
- **Reads** — `listInboxItems` / `countActiveInboxItems` / `getInboxItem` take a **required** `ownerUserId` and filter on it. Making it required means `tsc` flags every call site, so no read path can silently leak. Wired through the inbox page, the sidebar badge (`app-shell`), the server actions, and the REST/MCP `api-v1` handlers (`ctx.userId`).
- **Mutations** (`snooze`/`claim`/`propose`/`complete`/`dismiss`) add `AND owner_user_id = $user` so a user can't act on another's item by guessing an id (defense-in-depth).
- Per-agent **learning aggregates** (`getAgentSignalStats`, `listAgentLearningBatches`) intentionally left workspace+agent scoped — they're agent-level counts for the agent's operators, not a per-user inbox view. Flagged for a later decision.

## Verification
- `tsc` green — required `ownerUserId` param proves every list/count/get caller is scoped.
- `eslint` + `vitest` (124) green.
- Dogfood rebuilt; migration 0062 applied (column + index + FK present). The 4 pre-existing dogfood items are stale LinkedIn samples with no provenance, so they orphan to NULL (invisible) as designed.

**Manual check to run with two users:** as user A run an agent that fills the inbox; confirm user B's inbox is empty / shows only B's, the badge counts per-user, and A can't resolve/dismiss/snooze B's item via the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)