### PR TITLE
docs(home): mention Pydantic + tighten Start-here copy

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -25,9 +25,9 @@ with your own model keys.
 
 <CardGrid>
   <Card title="Agents as code" icon="seti:git">
-    Every agent is a file in a Git repo you own. Author by chat-to-PR or by hand —
-    either way the change is a reviewed pull request, with draft → stable versions
-    and a full audit trail.
+    Every agent is a **Pydantic AgentSpec** file in a Git repo you own. Author by
+    chat-to-PR or by hand — either way the change is a reviewed pull request, with
+    draft → stable versions and a full audit trail.
   </Card>
   <Card title="Self-hosted & multi-model" icon="setting">
     Runs in your environment with your own Anthropic and OpenAI keys. Agent
@@ -47,16 +47,19 @@ with your own model keys.
 
 <CardGrid>
   <Card title="Introduction" icon="open-book">
-    What TAS is and the ideas behind it.
-    [Read the introduction →](/agent-studio/introduction/)
+    What TAS is and why.
+
+    [Read the intro →](/agent-studio/introduction/)
   </Card>
   <Card title="Set up an instance" icon="setting">
-    Stand up TAS on your own infrastructure.
-    [Customer setup →](/agent-studio/customer-setup/)
+    Run it on your own infra.
+
+    [Set up →](/agent-studio/customer-setup/)
   </Card>
   <Card title="Author an agent" icon="pencil">
-    Write your first agent spec and open a PR.
-    [Authoring agents →](/agent-studio/authoring-agents/)
+    Write a spec, open a PR.
+
+    [Authoring guide →](/agent-studio/authoring-agents/)
   </Card>
 </CardGrid>
 


### PR DESCRIPTION
Two homepage tweaks:

- **Mention Pydantic** — the *Agents as code* card now names the **Pydantic AgentSpec** file format.
- **Fix the wrapping** — shortened the three *Start here* card descriptions and moved each link to its own line so the `→` no longer wraps to a second line.

Built clean (`pnpm build`); no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)