### PR TITLE
Auto-assign agent owner on first run

### DIFF
--- a/web/src/lib/agent-versions.ts
+++ b/web/src/lib/agent-versions.ts
@@ -259,3 +259,22 @@ export async function setAgentOwner(
     [workspaceId, agentName, ownerUserId, updatedBy],
   );
 }
+
+/**
+ * Claim ownership of an agent only if it has none yet (first writer wins; a
+ * no-op once owned). Used to auto-assign an owner on first run — chat-created
+ * agents already get an owner at create time, but agents committed straight to
+ * the repo don't, so whoever first runs one becomes its owner.
+ */
+export async function claimAgentOwner(
+  workspaceId: string,
+  agentName: string,
+  userId: string,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO agent_owner (workspace_id, agent_name, owner_user_id, updated_by)
+     VALUES ($1, $2, $3, $3)
+     ON CONFLICT (workspace_id, agent_name) DO NOTHING`,
+    [workspaceId, agentName, userId],
+  );
+}

--- a/web/src/lib/runs-api.ts
+++ b/web/src/lib/runs-api.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { claimAgentOwner } from "@/lib/agent-versions";
+
 // Typed client for the Rust API's /internal/runs surface. Auth is a
 // shared bearer (INTERNAL_API_TOKEN env var); the web container reaches
 // the API service via the docker network at API_INTERNAL_URL.
@@ -167,6 +169,14 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunRespons
     throw new Error(`Run API returned ${res.status}: ${text.slice(0, 400)}`);
   }
   const body = (await res.json()) as { run_id: string };
+  // First run claims ownership if the agent has none yet (chat-created agents
+  // already have an owner; repo-committed ones don't). Best-effort — never let
+  // an ownership write fail a run that was just accepted.
+  try {
+    await claimAgentOwner(input.workspaceId, input.agentName, input.userId);
+  } catch (e) {
+    console.error("claimAgentOwner failed (non-fatal)", e);
+  }
   return { runId: body.run_id };
 }
 


### PR DESCRIPTION
## Summary

Set a new agent's owner to **the person who created it, or — failing that — whoever first runs it.**

- **Created via chat-to-PR** → already owned by the creator (`requestAgentChange` sets `agent_owner`). Unchanged.
- **Committed straight to the repo** (the AGENTS.md / coding-agent path) → had **no owner**, so it showed *Unassigned* and never appeared in anyone's default *Mine + Starred* list. Now the **first run claims ownership** for the acting user.

## How
- New `claimAgentOwner(workspaceId, agentName, userId)` — `INSERT … ON CONFLICT (workspace_id, agent_name) DO NOTHING`, so the first writer wins and it's a no-op once an owner exists (an already-owned agent run by someone else doesn't reassign).
- Called from `createRun` — the single chokepoint every run path funnels through (run-now, chat probe, inbound webhook, Slack, REST/MCP `trigger_run`). Best-effort (try/catch) so an ownership write can never fail a just-accepted run.

No migration (reuses `agent_owner`). tsc + eslint + 124 vitest green; no import cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)