### PR TITLE
security: redact CAP payload logs (#44) + gate audit export on admin (#43)

### DIFF
--- a/web/src/app/api/workspaces/[workspace]/audit/export/route.ts
+++ b/web/src/app/api/workspaces/[workspace]/audit/export/route.ts
@@ -5,8 +5,7 @@ import {
   type AuditSource,
 } from "@/lib/audit";
 import { listAuditTimeline, writeAuditEvent } from "@/lib/audit-db";
-import { getServerSession } from "@/lib/session";
-import { getWorkspaceBySlug, userIsMember } from "@/lib/workspace";
+import { authorizeWorkspace } from "@/lib/auth-server";
 
 // US-0.4-04 — audit timeline export. JSON-only at v0.4 (streaming to
 // a SIEM is the v0.5 open question per the user story).
@@ -39,22 +38,26 @@ export async function GET(
 ): Promise<NextResponse> {
   const { workspace: slug } = await params;
 
-  const session = await getServerSession();
-  if (!session) {
-    return NextResponse.json({ error: "not signed in" }, { status: 401 });
+  // Bulk export of the full governance trail is an admin capability — gate on
+  // workspace_admin, not bare membership, so a low-trust member can't exfil
+  // every member's actions, connection authorizations, and secret events (#43).
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (!auth.ok) {
+    const status =
+      auth.reason === "no-session"
+        ? 401
+        : auth.reason === "no-workspace"
+          ? 404
+          : 403;
+    const error =
+      auth.reason === "no-session"
+        ? "not signed in"
+        : auth.reason === "no-workspace"
+          ? "unknown workspace"
+          : "workspace admin required";
+    return NextResponse.json({ error }, { status });
   }
-  const workspace = await getWorkspaceBySlug(slug);
-  if (!workspace) {
-    return NextResponse.json({ error: "unknown workspace" }, { status: 404 });
-  }
-  const ok = await userIsMember(workspace.id, session.user.id);
-  if (!ok) {
-    return NextResponse.json({ error: "not a member" }, { status: 403 });
-    // TODO(US-0.4-02): swap to requireWorkspaceRole(>= viewer) once
-    // RBAC lands. The viewer role gets read access (the AC for
-    // US-0.4-04 says exports honor RBAC); membership today is the
-    // closest stand-in.
-  }
+  const { workspace, userId } = auth;
 
   const sp = request.nextUrl.searchParams;
   const sources = parseMulti(sp.getAll("source"), ALL_AUDIT_SOURCES);
@@ -77,7 +80,7 @@ export async function GET(
 
   await writeAuditEvent({
     workspaceId: workspace.id,
-    actorUserId: session.user.id,
+    actorUserId: userId,
     source: "human_action",
     kind: "audit.exported",
     targetType: "workspace",
@@ -101,7 +104,7 @@ export async function GET(
   const envelope = {
     workspace: { id: workspace.id, slug: workspace.slug, name: workspace.name },
     exportedAt: new Date().toISOString(),
-    exportedByUserId: session.user.id,
+    exportedByUserId: userId,
     filters: {
       sources: sources.length ? sources : null,
       actor: actor ?? null,

--- a/web/src/lib/cap-api.ts
+++ b/web/src/lib/cap-api.ts
@@ -62,10 +62,9 @@ export async function createTemboTask(args: {
   };
 
   const url = `${baseUrl}/public-api/task/create`;
-  // Log the outbound payload so the docker logs make it obvious what
-  // we sent when CAP rejects us. v0.2 integration is brittle by
-  // design until we settle the contract.
-  console.log("[cap] POST", url, "payload=", JSON.stringify(body));
+  // Breadcrumb only — never log `body`: it embeds the prompt (run input/output,
+  // user data) and would leak to plaintext container logs / aggregators (#44).
+  console.log("[cap] POST", url);
 
   let res: Response;
   try {
@@ -90,7 +89,9 @@ export async function createTemboTask(args: {
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    console.log("[cap] ←", res.status, text);
+    // Status only — the response body can echo submitted content (#44). The
+    // full body is still returned to the caller for handling, just not logged.
+    console.log("[cap] ←", res.status);
     return { ok: false, error: { kind: "http", status: res.status, body: text, url } };
   }
 


### PR DESCRIPTION
Two verified security fixes (both confirmed present in current code):

### #44 — CAP client logged full prompt payloads (medium, data exposure)
`cap-api.ts` logged the entire task-create `body` (which embeds the prompt — run input/output and user data) and the response body to plaintext container logs on every call. Now logs a URL/status breadcrumb only; the response body is still returned to the caller for handling, just not logged.

### #43 — audit export gated on membership, not role (medium, RBAC gap)
The audit-log export route gated only on `userIsMember`, so any **viewer** could download up to 10,000 governance rows — every member's actions, connection authorizations, secret-rotation events, improvement text. Now gated on **workspace_admin** via `authorizeWorkspace` (a bulk export of the full governance trail is an admin capability). The export stays self-audited (`audit.exported`).

Closes #44, closes #43.

Verified: tsc + eslint + 124 vitest green.

> Remaining security backlog (#45 cargo-ai argv key, #46 OAuth state TTL, #47 invite emailVerified, #48 permissive CORS) are legit hardening — follow-up PR, handled with care since #45/#47 touch the runner/auth interfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)