### PR TITLE
security: OAuth state TTL (#46) + drop permissive CORS on api (#48)

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use axum::{middleware, routing::get, routing::post, Router};
 use sqlx::postgres::PgPoolOptions;
-use tower_http::{cors::CorsLayer, trace::TraceLayer};
+use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
 mod auth;
@@ -79,8 +79,11 @@ async fn main() -> anyhow::Result<()> {
         .route("/health", get(routes::health::health))
         .nest("/internal", internal_routes)
         .with_state(state)
-        .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive());
+        .layer(TraceLayer::new_for_http());
+    // No CORS layer: the api serves only /health and bearer-gated /internal
+    // routes, all server-to-server (the web container over the internal
+    // network) — never browser cross-origin. A permissive layer was needless
+    // attack surface (#48); add a scoped one only if a browser ever calls this.
 
     tracing::info!("tas-api listening on {bind_addr}");
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;

--- a/web/src/lib/oauth-state.ts
+++ b/web/src/lib/oauth-state.ts
@@ -13,6 +13,17 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 const SIG_LEN = 32; // sha-256 output
 
+// OAuth / install state is short-lived: reject anything older than this so a
+// leaked callback URL (referer, logs, history) can't be replayed indefinitely
+// (#46). `iat` lives inside the HMAC-signed body, so it can't be forged.
+const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes — flows complete in seconds
+
+function isStateFresh(iat: number): boolean {
+  const now = Date.now();
+  // Reject stale; tolerate small clock skew on the future side.
+  return iat <= now + 60_000 && now - iat <= STATE_TTL_MS;
+}
+
 function getSecret(): Buffer {
   const raw = process.env.BETTER_AUTH_SECRET;
   if (!raw) {
@@ -64,14 +75,17 @@ export type NativeMcpStatePayload = {
   instance?: string;
   /** Short random nonce — defends against state replay across users. */
   nonce: string;
+  /** Issued-at (epoch ms); states older than STATE_TTL_MS are rejected (#46). */
+  iat: number;
 };
 
 export function signNativeMcpState(
-  payload: Omit<NativeMcpStatePayload, "nonce">,
+  payload: Omit<NativeMcpStatePayload, "nonce" | "iat">,
 ): string {
   const full: NativeMcpStatePayload = {
     ...payload,
     nonce: randomBytes(8).toString("base64url"),
+    iat: Date.now(),
   };
   const body = Buffer.from(JSON.stringify(full), "utf8");
   const sig = createHmac("sha256", getSecret()).update(body).digest();
@@ -100,6 +114,7 @@ export function verifyNativeMcpState(
     return null;
   }
   if (!isNativeMcpStatePayload(parsed)) return null;
+  if (!isStateFresh(parsed.iat)) return null;
   return parsed;
 }
 
@@ -115,7 +130,8 @@ function isNativeMcpStatePayload(value: unknown): value is NativeMcpStatePayload
     typeof v.pkceVerifier === "string" &&
     typeof v.clientId === "string" &&
     typeof v.tokenEndpoint === "string" &&
-    typeof v.nonce === "string"
+    typeof v.nonce === "string" &&
+    typeof v.iat === "number"
   );
 }
 
@@ -134,14 +150,17 @@ export type ComposioStatePayload = {
   /** Workspace-scoped name slot for the connection (e.g. "default", "work"). */
   connectionName: string;
   nonce: string;
+  /** Issued-at (epoch ms); states older than STATE_TTL_MS are rejected (#46). */
+  iat: number;
 };
 
 export function signComposioState(
-  payload: Omit<ComposioStatePayload, "nonce">,
+  payload: Omit<ComposioStatePayload, "nonce" | "iat">,
 ): string {
   const full: ComposioStatePayload = {
     ...payload,
     nonce: randomBytes(8).toString("base64url"),
+    iat: Date.now(),
   };
   const body = Buffer.from(JSON.stringify(full), "utf8");
   const sig = createHmac("sha256", getSecret()).update(body).digest();
@@ -168,6 +187,7 @@ export function verifyComposioState(state: string): ComposioStatePayload | null 
     return null;
   }
   if (!isComposioStatePayload(parsed)) return null;
+  if (!isStateFresh(parsed.iat)) return null;
   return parsed;
 }
 
@@ -180,7 +200,8 @@ function isComposioStatePayload(value: unknown): value is ComposioStatePayload {
     typeof v.userId === "string" &&
     typeof v.toolkit === "string" &&
     typeof v.connectionName === "string" &&
-    typeof v.nonce === "string"
+    typeof v.nonce === "string" &&
+    typeof v.iat === "number"
   );
 }
 
@@ -194,14 +215,17 @@ export type SlackInstallStatePayload = {
   workspaceId: string;
   workspaceSlug: string;
   nonce: string;
+  /** Issued-at (epoch ms); states older than STATE_TTL_MS are rejected (#46). */
+  iat: number;
 };
 
 export function signSlackInstallState(
-  payload: Omit<SlackInstallStatePayload, "nonce">,
+  payload: Omit<SlackInstallStatePayload, "nonce" | "iat">,
 ): string {
   const full: SlackInstallStatePayload = {
     ...payload,
     nonce: randomBytes(8).toString("base64url"),
+    iat: Date.now(),
   };
   const body = Buffer.from(JSON.stringify(full), "utf8");
   const sig = createHmac("sha256", getSecret()).update(body).digest();
@@ -230,6 +254,7 @@ export function verifySlackInstallState(
     return null;
   }
   if (!isSlackInstallStatePayload(parsed)) return null;
+  if (!isStateFresh(parsed.iat)) return null;
   return parsed;
 }
 
@@ -242,6 +267,7 @@ function isSlackInstallStatePayload(
     typeof v.slackAppId === "string" &&
     typeof v.workspaceId === "string" &&
     typeof v.workspaceSlug === "string" &&
-    typeof v.nonce === "string"
+    typeof v.nonce === "string" &&
+    typeof v.iat === "number"
   );
 }


### PR DESCRIPTION
Two more verified security fixes:

### #46 — OAuth state had no TTL / single-use (replay)
State tokens (native-MCP, Composio, Slack install) were HMAC-signed but carried only a random nonce — no timestamp — so a leaked callback URL (referer, logs, history) was replayable by the same user indefinitely. Added an `iat` (epoch ms) **inside the signed body** and reject states older than 10 minutes on verify, across all three flows. Tamper-proof (iat is covered by the HMAC); callers unchanged (they already omit `nonce`).

### #48 — `CorsLayer::permissive()` on the control-plane api
The api serves only `/health` + bearer-gated `/internal/*`, all server-to-server (web → api over the docker network) — never browser cross-origin. A permissive CORS layer (reflect any origin + credentials) was needless attack surface. Dropped it; CORS is browser-enforced only so server-to-server calls are unaffected.

Closes #46, closes #48.

Verified: web tsc + eslint + 124 vitest; api `cargo check` clean.

---
**Not in this PR — need an interface I can't verify here, so not changing blind:**
- **#45** (cargo-ai key as argv) — cargo-ai's stdin is already consumed by the spec, and I can't confirm the binary reads the token from an env var; switching blind would break every cargo-ai run. Low real risk single-tenant.
- **#47** (invite without `emailVerified`) — the generic OIDC provider has no custom `getUserInfo`, so I can't confirm whether better-auth's default sets `user.emailVerified` from the claim. Gating the invite on it could either no-op or **lock out all legit OIDC invite-joins**. Needs the OIDC emailVerified behavior pinned (likely a custom `getUserInfo` mapping `email_verified`) before it's safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)