### PR TITLE
security: honor invites only for IdP-verified emails (#47)

### DIFF
--- a/web/src/lib/invitations.ts
+++ b/web/src/lib/invitations.ts
@@ -165,6 +165,22 @@ export async function resolvePendingInvitesForUser(
   email: string,
 ): Promise<number> {
   const e = email.trim().toLowerCase();
+  // Honor an invite only when the IdP verified the email (#47). better-auth
+  // stores `emailVerified` from the provider's `email_verified` claim (false
+  // when absent); Google/Microsoft verify. Without this, a user who can assert
+  // an unverified / attacker-controlled email at a permissive IdP could
+  // auto-join the invited workspace at the invited role. Central gate — both
+  // user-driven paths (first-sign-in hook + home-page resolve) funnel here.
+  const { rows: verified } = await db.query<{ emailVerified: boolean }>(
+    `SELECT "emailVerified" FROM "user" WHERE id = $1`,
+    [userId],
+  );
+  if (!verified[0]?.emailVerified) {
+    console.warn(
+      `[invites] skipping invite resolve for ${userId}: email not verified by the IdP`,
+    );
+    return 0;
+  }
   const client = await db.connect();
   try {
     await client.query("BEGIN");


### PR DESCRIPTION
## #47 — invitations honored on email match without a verified-email guarantee

`resolvePendingInvitesForUser` granted workspace membership purely on a `lower(email)` match between the OAuth profile and a pending invite — never checking the IdP actually verified the address. A permissive IdP (e.g. a misconfigured generic OIDC) that lets a user assert an unverified/attacker-controlled email could auto-join the invited workspace at the invited role.

**Fix:** gate centrally on the user's `emailVerified`. Confirmed safe by reading better-auth's source — `genericOAuth` sets `emailVerified` from the provider's `email_verified` claim (`generic-oauth/routes.mjs`), defaulting **false** when absent; Google/Microsoft verify. So:
- Google / Microsoft → verified → invites resolve as before.
- Generic OIDC that asserts `email_verified` → resolves; one that doesn't → **secure deny** (no auto-join; an admin can still add them, or configure the IdP to send the claim). No sign-in breakage — only the auto-join is gated.

Both user-driven paths (first-sign-in `user.create.after` hook + home-page `resolvePendingInvitesForUserId`) funnel through this function, so a single check covers them. Admin-initiated immediate-add (`createInvitation` for an existing account) is unaffected.

Closes #47.

Verified: tsc + eslint + 124 vitest (auth/invitation tests unchanged — gate is inside the function they mock).

> Remaining: **#45** (cargo-ai key as argv) — still needs the cargo-ai CLI's token interface confirmed (env/stdin/file) before changing; low real risk single-tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)