### PR TITLE
Definition tab: draft + all versions selector

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
@@ -1,4 +1,5 @@
 import { Section } from "@/components/section";
+import { getStableVersion, listAgentVersions } from "@/lib/agent-versions";
 import {
   detectAgentSpecLanguage,
   highlightAgentSpec,
@@ -6,11 +7,16 @@ import {
 } from "@/lib/agent-spec-highlight";
 
 import { loadAgentContext } from "../agent-page-context";
+import {
+  SpecVersionViewer,
+  type SpecVersionItem,
+} from "./spec-version-viewer";
 
 export const dynamic = "force-dynamic";
 
-// Definition tab — the raw agent spec and (when declared) its sidecar Python
-// tools module, read-only. Edits go through Git / Chat-to-edit.
+// Definition tab — the agent spec (the live draft plus every stable version's
+// snapshot, switchable) and (when declared) its sidecar Python tools module,
+// read-only. Edits go through Git / Chat-to-edit.
 
 export default async function AgentDefinitionPage({
   params,
@@ -18,10 +24,13 @@ export default async function AgentDefinitionPage({
   params: Promise<{ workspace: string; agent: string }>;
 }) {
   const { workspace: slug, agent: agentName } = await params;
-  const { agent, raw, toolsModuleContent } = await loadAgentContext(
-    slug,
-    agentName,
-  );
+  const { workspace, canonicalName, agent, raw, toolsModuleContent } =
+    await loadAgentContext(slug, agentName);
+
+  const [versions, stable] = await Promise.all([
+    listAgentVersions(workspace.id, canonicalName),
+    getStableVersion(workspace.id, canonicalName),
+  ]);
 
   const toolsModule =
     agent.ok && agent.spec.framework === "pydantic-agentspec"
@@ -32,13 +41,34 @@ export default async function AgentDefinitionPage({
     agent.ok ? agent.spec.framework : undefined,
   );
 
+  // Draft first (the default view), then each version newest-first. Versions
+  // are the same agent/format, so reuse the detected language.
+  const draftDiffers = stable ? stable.specContent !== raw : versions.length > 0;
+  const specItems: SpecVersionItem[] = [
+    {
+      id: "draft",
+      label: draftDiffers ? "Draft (current file)" : "Draft",
+      block: <HighlightedCodeBlock source={raw} language={specLanguage} />,
+    },
+    ...versions.map((v) => ({
+      id: `v${v.versionNumber}`,
+      label:
+        stable?.versionNumber === v.versionNumber
+          ? `v${v.versionNumber} · stable`
+          : `v${v.versionNumber}`,
+      block: (
+        <HighlightedCodeBlock source={v.specContent} language={specLanguage} />
+      ),
+    })),
+  ];
+
   return (
     <>
       <Section
         title="Definition"
-        description="Edits go through Git. Framework and model changes go through the same review path as any other change — never edited in a live console."
+        description="The live draft plus every promoted version. Edits go through Git — framework and model changes take the same review path as any other change, never a live console."
       >
-        <HighlightedCodeBlock source={raw} language={specLanguage} />
+        <SpecVersionViewer items={specItems} />
       </Section>
 
       {toolsModule && (

--- a/web/src/app/[workspace]/agents/[agent]/definition/spec-version-viewer.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/definition/spec-version-viewer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+import { Select } from "@/components/ui/select";
+
+// Lets the Definition tab switch between the live draft and each stable
+// version's snapshotted spec. The blocks are rendered server-side (syntax
+// highlighting stays on the server) and passed in as ReactNodes; this just
+// picks which one to show. Defaults to the first item (the draft).
+
+export type SpecVersionItem = { id: string; label: string; block: ReactNode };
+
+export function SpecVersionViewer({ items }: { items: SpecVersionItem[] }) {
+  const [active, setActive] = useState(items[0]?.id ?? "");
+  const current = items.find((i) => i.id === active) ?? items[0];
+
+  return (
+    <div className="flex flex-col gap-3">
+      {items.length > 1 && (
+        <label className="text-foreground-weak flex items-center gap-2 text-sm">
+          <span>Showing</span>
+          <Select
+            value={active}
+            onValueChange={setActive}
+            options={items.map((i) => ({ value: i.id, label: i.label }))}
+            ariaLabel="Spec version"
+            className="min-w-[180px]"
+          />
+        </label>
+      )}
+      {current?.block}
+    </div>
+  );
+}


### PR DESCRIPTION
The agent **Definition** tab showed only the current on-disk spec with no version context. Adds a selector to switch between the live **Draft** and **every promoted version's** snapshotted spec.

- `listAgentVersions` (newest-first) + `getStableVersion` drive the options; the current stable is marked `vN · stable`, the draft labeled `Draft (current file)` when it differs from stable.
- Spec blocks are rendered **server-side** (syntax highlighting stays on the server) and passed as ReactNodes to a small client `SpecVersionViewer` that just toggles which one shows. Defaults to Draft — selector only appears when there's more than one option, so agents with no versions look exactly as before.
- Spec-only (versions snapshot the spec, not the tools module); the Tools-module section is unchanged.

Verified: tsc + eslint + 124 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)