### PR TITLE
Definition tab: spec file GitHub commit history

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
@@ -1,3 +1,4 @@
+import { LocalTime } from "@/components/local-time";
 import { Section } from "@/components/section";
 import { getStableVersion, listAgentVersions } from "@/lib/agent-versions";
 import {
@@ -5,6 +6,8 @@ import {
   highlightAgentSpec,
   type AgentSpecHighlightKind,
 } from "@/lib/agent-spec-highlight";
+import { listFileCommits, type FileCommit } from "@/lib/github";
+import { getWorkspaceSecretPlaintext } from "@/lib/workspace";
 
 import { loadAgentContext } from "../agent-page-context";
 import {
@@ -24,13 +27,32 @@ export default async function AgentDefinitionPage({
   params: Promise<{ workspace: string; agent: string }>;
 }) {
   const { workspace: slug, agent: agentName } = await params;
-  const { workspace, canonicalName, agent, raw, toolsModuleContent } =
+  const { workspace, canonicalName, repo, agent, raw, toolsModuleContent } =
     await loadAgentContext(slug, agentName);
 
   const [versions, stable] = await Promise.all([
     listAgentVersions(workspace.id, canonicalName),
     getStableVersion(workspace.id, canonicalName),
   ]);
+
+  // Commit history of the spec file on GitHub — every version that landed in
+  // the repo, newest first (distinct from the promoted stable snapshots above).
+  // Skipped in local-agents dev mode (no connected repo).
+  let commits: FileCommit[] = [];
+  if (repo && agent.path) {
+    try {
+      const token = await getWorkspaceSecretPlaintext(workspace.id, "github_pat");
+      const res = await listFileCommits(
+        token,
+        { owner: repo.owner, name: repo.name, branch: repo.defaultBranch },
+        agent.path,
+        50,
+      );
+      if (res.ok) commits = res.commits;
+    } catch {
+      // No token / repo unreachable — just omit the history section.
+    }
+  }
 
   const toolsModule =
     agent.ok && agent.spec.framework === "pydantic-agentspec"
@@ -70,6 +92,42 @@ export default async function AgentDefinitionPage({
       >
         <SpecVersionViewer items={specItems} />
       </Section>
+
+      {commits.length > 0 && repo && (
+        <Section
+          title="History"
+          description="Every version of this spec file that landed on GitHub, newest first. Click a hash to view that version on GitHub."
+        >
+          <ul className="flex flex-col divide-y divide-[var(--color-border-weak)]">
+            {commits.map((c) => (
+              <li
+                key={c.sha}
+                className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 py-2 text-sm"
+              >
+                <a
+                  href={`https://github.com/${repo.owner}/${repo.name}/blob/${c.sha}/${agent.path}`}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-foreground-category-blue font-mono hover:underline"
+                >
+                  {c.shortSha}
+                </a>
+                {c.date && (
+                  <span className="text-foreground-weak">
+                    <LocalTime iso={c.date} />
+                  </span>
+                )}
+                <span className="text-foreground min-w-0 flex-1 truncate">
+                  {c.summary}
+                </span>
+                {c.authorName && (
+                  <span className="text-foreground-muted">{c.authorName}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
 
       {toolsModule && (
         <Section

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -258,6 +258,72 @@ export async function readFile(
   return { ok: true, content, sha: body.sha };
 }
 
+export type FileCommit = {
+  sha: string;
+  shortSha: string;
+  /** ISO timestamp of the commit (author date). */
+  date: string;
+  /** First line of the commit message. */
+  summary: string;
+  authorName: string | null;
+  /** github.com link to the commit. */
+  htmlUrl: string;
+};
+
+export type ListFileCommitsResult =
+  | { ok: true; commits: FileCommit[] }
+  | { ok: false; error: GitHubFileError; detail?: string };
+
+/**
+ * GET /repos/{o}/{r}/commits?path={path}&sha={branch} — the commit history of
+ * one file on a branch, newest first. Used by the Definition tab to show every
+ * version of an agent spec that landed on GitHub (commit hash + date).
+ */
+export async function listFileCommits(
+  token: string,
+  ref: RepoRef,
+  path: string,
+  limit = 30,
+): Promise<ListFileCommitsResult> {
+  const url =
+    `https://api.github.com/repos/${ref.owner}/${ref.name}/commits` +
+    `?path=${encodePath(path)}&sha=${encodeURIComponent(ref.branch)}` +
+    `&per_page=${Math.min(Math.max(limit, 1), 100)}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: GITHUB_HEADERS(token),
+      next: { revalidate: READ_CACHE_TTL_SECONDS, tags: [repoCacheTag(ref)] },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: "network",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (res.status === 401) return { ok: false, error: "invalid-token" };
+  if (res.status === 404) return { ok: false, error: "not-found" };
+  if (res.status === 403) return { ok: false, error: "rate-limited" };
+  if (!res.ok) {
+    return { ok: false, error: "network", detail: `GitHub returned ${res.status}` };
+  }
+  const body = (await res.json()) as Array<{
+    sha: string;
+    html_url: string;
+    commit: { message: string; author: { name?: string; date?: string } | null };
+  }>;
+  const commits: FileCommit[] = body.map((c) => ({
+    sha: c.sha,
+    shortSha: c.sha.slice(0, 7),
+    date: c.commit.author?.date ?? "",
+    summary: (c.commit.message ?? "").split("\n")[0],
+    authorName: c.commit.author?.name ?? null,
+    htmlUrl: c.html_url,
+  }));
+  return { ok: true, commits };
+}
+
 export type CreateFileResult =
   | { ok: true; commitSha: string }
   | { ok: false; error: GitHubFileError; detail?: string };


### PR DESCRIPTION
Builds on the draft+versions selector (#211): adds a **History** section to the Definition tab listing every version of the agent's spec file that landed on GitHub.

- Each row: **commit hash** (links to that version of the file on GitHub) + **date** (`LocalTime`) + summary + author, newest first.
- This is the full **git history** of the spec file — distinct from the promoted **stable snapshots** in the selector above (which are TAS `agent_version` rows).
- New `github.listFileCommits` (`GET /commits?path=&sha=`, 60s-cached via the existing repo cache tag). Uses the workspace `github_pat`.
- Skipped in local-agents dev mode (no connected repo); degrades gracefully (no section) if the token/repo is unavailable or rate-limited.

Verified: tsc + eslint + 124 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)