### PR TITLE
Reconcile orphaned runs on api boot

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -55,6 +55,32 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("failed to apply database migrations")?;
 
+    // Reconcile orphaned runs on boot. A run executes as an in-memory tokio task
+    // owning a subprocess, so any run still 'queued'/'running' when the api last
+    // stopped (crash, deploy, restart) is orphaned — its task is gone and nothing
+    // will ever finalize it, so the row would hang in 'running' forever and look
+    // like it's still working. Mark them failed with a clear reason. (Durable,
+    // resumable execution is the larger #170 effort.)
+    match sqlx::query(
+        "UPDATE run SET status = 'failed', \
+                completed_at = now(), streamed_output = NULL, \
+                error_message = COALESCE(error_message, \
+                    'Interrupted — the server restarted while this run was in progress.') \
+          WHERE status IN ('queued', 'running')",
+    )
+    .execute(&db)
+    .await
+    {
+        Ok(res) if res.rows_affected() > 0 => {
+            tracing::warn!(
+                count = res.rows_affected(),
+                "marked orphaned in-flight runs as failed on boot"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => tracing::error!(?e, "failed to reconcile orphaned runs on boot"),
+    }
+
     let encryption_key = Arc::new(crypto::MasterKey::from_env()?);
     let internal_token = auth::InternalToken::from_env()?;
     let http = reqwest::Client::builder()


### PR DESCRIPTION
## Problem

Runs execute as in-memory `tokio::spawn` tasks owning a Python subprocess (in the api process). When the api restarts — a deploy, crash, or OOM — that task and subprocess die, but **nothing finalizes the run row**. There was no boot-time reconciliation, so an interrupted run hangs in `status='running'` **forever** and looks like it's still working when it's actually dead.

This is what's behind runs that appear stuck "running" on the dogfood — every `deploy-internal` redeploy orphans whatever was in flight.

## Fix

On boot (right after migrations), mark any run still `queued`/`running` as `failed` with a clear reason ("Interrupted — the server restarted while this run was in progress"). Since runs can't survive a restart, anything in those states at startup is provably orphaned.

This immediately clears existing stuck runs (on next deploy) and prevents new ones from hanging. Durable, *resumable* execution is the larger #170 effort; this is the safe minimal reconciler.

Verified: `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)