### PR TITLE
Stop-run button: dedicated 'cancelled' status + subprocess kill

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2094,6 +2095,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/api/migrations/0063_run_cancelled.sql
+++ b/api/migrations/0063_run_cancelled.sql
@@ -1,0 +1,8 @@
+-- Add a 'cancelled' terminal run status for user-killed runs, distinct from
+-- 'failed' (a real error). Set by the kill-run path; the runner SIGKILLs the
+-- subprocess and writes this status. Keeps killed runs out of the failure
+-- dashboards/badges.
+ALTER TABLE run DROP CONSTRAINT IF EXISTS run_status_check;
+ALTER TABLE run
+    ADD CONSTRAINT run_status_check
+    CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled'));

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 use axum::{middleware, routing::get, routing::post, Router};
 use sqlx::postgres::PgPoolOptions;
+use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
@@ -16,11 +18,18 @@ mod runs;
 mod slack_mrkdwn;
 mod workspace;
 
+/// Cancellation handles for in-flight runs, keyed by run id. Inserted when a run
+/// starts executing and removed when it finishes; the cancel endpoint fires the
+/// token to kill a running run's subprocess. In-process only (runs are
+/// in-memory tasks on this api instance).
+pub type RunCancels = Arc<Mutex<HashMap<uuid::Uuid, CancellationToken>>>;
+
 #[derive(Clone)]
 pub struct AppState {
     pub db: sqlx::PgPool,
     pub http: reqwest::Client,
     pub encryption_key: Arc<crypto::MasterKey>,
+    pub run_cancels: RunCancels,
 }
 
 #[tokio::main]
@@ -93,11 +102,13 @@ async fn main() -> anyhow::Result<()> {
         db,
         http,
         encryption_key,
+        run_cancels: Arc::new(Mutex::new(HashMap::new())),
     };
 
     let internal_routes = Router::new()
         .route("/runs", post(runs::handlers::create_run))
         .route("/runs/{id}", get(runs::handlers::get_run))
+        .route("/runs/{id}/cancel", post(runs::handlers::cancel_run))
         .layer(middleware::from_fn(auth::require_internal_token))
         .layer(axum::Extension(internal_token));
 

--- a/api/src/runs/handlers.rs
+++ b/api/src/runs/handlers.rs
@@ -239,3 +239,50 @@ pub async fn get_run(
 
     row.map(Json).ok_or(StatusCode::NOT_FOUND)
 }
+
+#[derive(Debug, Serialize)]
+pub struct CancelRunResponse {
+    /// True if this call transitioned the run to 'cancelled'; false if it was
+    /// already terminal (succeeded/failed/cancelled) and nothing changed.
+    pub cancelled: bool,
+}
+
+/// Kill an in-flight run. Flips the row to 'cancelled' (only while still
+/// queued/running and owned by this workspace) and fires the in-memory
+/// cancellation token so the runner SIGKILLs the wrapper subprocess. Writing
+/// the row first means the runner's `mark_*` status guards refuse to clobber
+/// the 'cancelled' state as the killed process unwinds.
+pub async fn cancel_run(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<GetRunQuery>,
+) -> Result<Json<CancelRunResponse>, StatusCode> {
+    let res = sqlx::query(
+        "UPDATE run SET status = 'cancelled', \
+                error_message = COALESCE(error_message, 'Cancelled by user'), \
+                completed_at = now(), streamed_output = NULL \
+          WHERE id = $1 AND workspace_id = $2 AND status IN ('queued', 'running')",
+    )
+    .bind(id)
+    .bind(query.workspace_id)
+    .execute(&state.db)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Fire the token if this run is executing on this api instance. (An orphaned
+    // run — e.g. from a prior restart — has no live token; the row flip above is
+    // all that's needed since nothing is actually running to kill.)
+    let token = state
+        .run_cancels
+        .lock()
+        .expect("run_cancels mutex poisoned")
+        .get(&id)
+        .cloned();
+    if let Some(token) = token {
+        token.cancel();
+    }
+
+    Ok(Json(CancelRunResponse {
+        cancelled: res.rows_affected() > 0,
+    }))
+}

--- a/api/src/runs/pydantic.rs
+++ b/api/src/runs/pydantic.rs
@@ -26,6 +26,7 @@ use std::process::Stdio;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 const PYDANTIC_PY: &str = "/opt/pydantic-ai/bin/python3";
@@ -191,6 +192,9 @@ pub struct PydanticArgs<'a> {
     /// The run row to stream partial output into while it's still running.
     pub run_id: Uuid,
     pub db: &'a sqlx::PgPool,
+    /// Fired by the kill-run endpoint to cancel this run. When cancelled, the
+    /// read loop SIGKILLs the wrapper subprocess and bails out.
+    pub cancel: &'a CancellationToken,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -395,10 +399,21 @@ async fn spawn_and_wait(args: &PydanticArgs<'_>) -> anyhow::Result<std::process:
 
     loop {
         line_buf.clear();
-        let n = reader
-            .read_until(b'\n', &mut line_buf)
-            .await
-            .context("reading pydantic-ai wrapper stdout")?;
+        let n = tokio::select! {
+            // Check cancellation first so a kill takes effect even under a
+            // steady stream of output.
+            biased;
+            _ = args.cancel.cancelled() => {
+                // User killed the run: SIGKILL the wrapper (and its model/tool
+                // subprocesses via the process group it leads) and bail. The
+                // run row was already written to 'cancelled' by the endpoint.
+                let _ = child.start_kill();
+                anyhow::bail!("run cancelled by user");
+            }
+            res = reader.read_until(b'\n', &mut line_buf) => {
+                res.context("reading pydantic-ai wrapper stdout")?
+            }
+        };
         if n == 0 {
             break;
         }

--- a/api/src/runs/runner.rs
+++ b/api/src/runs/runner.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{anyhow, Context};
 use chrono::Utc;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::runs::{cargo_ai, pydantic};
@@ -90,6 +91,23 @@ struct Usage {
 /// updates the run row even on error so the UI never sees a row stuck
 /// in `running` forever.
 pub async fn execute_run(state: &AppState, ctx: RunContext) {
+    // Register a cancellation token so the kill-run endpoint can SIGKILL this
+    // run's subprocess. Always removed on exit, so the registry only ever holds
+    // genuinely in-flight runs.
+    let run_id = ctx.run_id;
+    let cancel = CancellationToken::new();
+    {
+        let mut cancels = state.run_cancels.lock().expect("run_cancels mutex poisoned");
+        cancels.insert(run_id, cancel.clone());
+    }
+
+    execute_run_inner(state, ctx, &cancel).await;
+
+    let mut cancels = state.run_cancels.lock().expect("run_cancels mutex poisoned");
+    cancels.remove(&run_id);
+}
+
+async fn execute_run_inner(state: &AppState, ctx: RunContext, cancel: &CancellationToken) {
     if let Err(e) = mark_running(state, ctx.run_id).await {
         tracing::error!(run_id = %ctx.run_id, ?e, "mark_running failed");
         // Best-effort write the failure to the run row so the UI sees it.
@@ -97,7 +115,7 @@ pub async fn execute_run(state: &AppState, ctx: RunContext) {
         return;
     }
 
-    let (result, tool_calls, steps) = run_inner(state, &ctx).await;
+    let (result, tool_calls, steps) = run_inner(state, &ctx, cancel).await;
     // Persist per-step usage + what the agent called (success or failure)
     // before we mark the terminal state. Best-effort — a logging hiccup must
     // not fail the run.
@@ -129,6 +147,14 @@ pub async fn execute_run(state: &AppState, ctx: RunContext) {
             deliver_slack_result(state, ctx.run_id, &body).await;
         }
         Err(e) => {
+            // A user-cancelled run already had its row written to 'cancelled' by
+            // the cancel endpoint; the error here is just the killed subprocess
+            // unwinding. Don't overwrite it with 'failed' or send a Slack
+            // "failed" message — the cancellation was intentional.
+            if cancel.is_cancelled() {
+                tracing::info!(run_id = %ctx.run_id, "run cancelled by user");
+                return;
+            }
             let reason = format!("{e:#}");
             tracing::warn!(run_id = %ctx.run_id, ?e, "run failed");
             if let Err(db_err) = mark_failed(state, ctx.run_id, &reason).await {
@@ -150,6 +176,7 @@ pub async fn execute_run(state: &AppState, ctx: RunContext) {
 async fn run_inner(
     state: &AppState,
     ctx: &RunContext,
+    cancel: &CancellationToken,
 ) -> (
     anyhow::Result<RunOutcome>,
     Vec<pydantic::ToolCall>,
@@ -180,7 +207,7 @@ async fn run_inner(
                 Vec::new(),
             )
         }
-        Framework::Pydantic => run_pydantic(state, ctx).await,
+        Framework::Pydantic => run_pydantic(state, ctx, cancel).await,
     }
 }
 
@@ -267,6 +294,7 @@ async fn run_cargo_ai(
 async fn run_pydantic(
     state: &AppState,
     ctx: &RunContext,
+    cancel: &CancellationToken,
 ) -> (
     anyhow::Result<RunOutcome>,
     Vec<pydantic::ToolCall>,
@@ -496,6 +524,7 @@ async fn run_pydantic(
         acting_user_id: ctx.acting_user_id.as_str(),
         run_id: ctx.run_id,
         db: &state.db,
+        cancel,
     })
     .await;
 
@@ -569,11 +598,16 @@ fn render_output(user_message: &str, text: &str) -> String {
 }
 
 async fn mark_running(state: &AppState, run_id: Uuid) -> anyhow::Result<()> {
-    sqlx::query("UPDATE run SET status = 'running', started_at = $1 WHERE id = $2")
-        .bind(Utc::now())
-        .bind(run_id)
-        .execute(&state.db)
-        .await?;
+    // Guard on 'queued': if the run was cancelled in the gap between being
+    // queued and starting, leave the 'cancelled' status alone.
+    sqlx::query(
+        "UPDATE run SET status = 'running', started_at = $1 \
+              WHERE id = $2 AND status = 'queued'",
+    )
+    .bind(Utc::now())
+    .bind(run_id)
+    .execute(&state.db)
+    .await?;
     Ok(())
 }
 
@@ -606,7 +640,7 @@ async fn mark_succeeded(
         "UPDATE run SET status = 'succeeded', output = $1, completed_at = $2, \
                         tokens_input = $3, tokens_output = $4, cost_usd = $5, \
                         streamed_output = NULL \
-                  WHERE id = $6",
+                  WHERE id = $6 AND status = 'running'",
     )
     .bind(output)
     .bind(Utc::now())
@@ -671,7 +705,8 @@ Run complete · 3.7s total
 async fn mark_failed(state: &AppState, run_id: Uuid, reason: &str) -> anyhow::Result<()> {
     sqlx::query(
         "UPDATE run SET status = 'failed', error_message = $1, completed_at = $2, \
-                        streamed_output = NULL WHERE id = $3",
+                        streamed_output = NULL \
+                  WHERE id = $3 AND status IN ('queued', 'running')",
     )
     .bind(reason)
     .bind(Utc::now())

--- a/api/src/runs/runner.rs
+++ b/api/src/runs/runner.rs
@@ -97,13 +97,19 @@ pub async fn execute_run(state: &AppState, ctx: RunContext) {
     let run_id = ctx.run_id;
     let cancel = CancellationToken::new();
     {
-        let mut cancels = state.run_cancels.lock().expect("run_cancels mutex poisoned");
+        let mut cancels = state
+            .run_cancels
+            .lock()
+            .expect("run_cancels mutex poisoned");
         cancels.insert(run_id, cancel.clone());
     }
 
     execute_run_inner(state, ctx, &cancel).await;
 
-    let mut cancels = state.run_cancels.lock().expect("run_cancels mutex poisoned");
+    let mut cancels = state
+        .run_cancels
+        .lock()
+        .expect("run_cancels mutex poisoned");
     cancels.remove(&run_id);
 }
 

--- a/web/src/app/[workspace]/agents-inventory.tsx
+++ b/web/src/app/[workspace]/agents-inventory.tsx
@@ -58,7 +58,7 @@ export type InventoryAgent =
       /** Latest run regardless of window. Null when never run. */
       lastRun:
         | {
-            status: "queued" | "running" | "succeeded" | "failed";
+            status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
             createdAtIso: string;
           }
         | null;

--- a/web/src/app/[workspace]/agents/[agent]/recent-runs.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/recent-runs.tsx
@@ -12,16 +12,18 @@ const STATUS_LABELS: Record<RunSummary["status"], string> = {
   running: "Running",
   succeeded: "Succeeded",
   failed: "Failed",
+  cancelled: "Cancelled",
 };
 
 const STATUS_TONE: Record<
   RunSummary["status"],
-  { variant: "blue" | "yellow" | "green" | "red" }
+  { variant: "blue" | "yellow" | "green" | "red" | "gray" }
 > = {
   queued: { variant: "yellow" },
   running: { variant: "blue" },
   succeeded: { variant: "green" },
   failed: { variant: "red" },
+  cancelled: { variant: "gray" },
 };
 
 export function RecentRuns({

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
 
 import {
@@ -17,7 +18,7 @@ import {
   setImprovementCommitted,
   setImprovementTask,
 } from "@/lib/improvements-api";
-import { getRun } from "@/lib/runs-api";
+import { cancelRun, getRun } from "@/lib/runs-api";
 import {
   getWorkspaceRepo,
   getWorkspaceSecretPlaintext,
@@ -131,6 +132,43 @@ export async function improveAgentAction(args: {
     htmlUrl: res.result.htmlUrl,
     status: res.result.status,
   };
+}
+
+export type CancelRunResult =
+  | { ok: true; cancelled: boolean }
+  | { ok: false; error: string };
+
+/** Kill an in-flight run. Operator+ only. Returns cancelled=false when the run
+ *  had already finished (the page just refreshes to the terminal state). */
+export async function cancelRunAction(args: {
+  workspaceSlug: string;
+  agentName: string;
+  runId: string;
+}): Promise<CancelRunResult> {
+  const auth = await authorizeWorkspace(args.workspaceSlug, "operator");
+  if (!auth.ok) {
+    if (auth.reason === "denied") return { ok: false, error: DENIED_MESSAGE };
+    notFound();
+  }
+  const { workspace } = auth;
+
+  const run = await getRun(args.runId, workspace.id);
+  if (!run || run.workspaceId !== workspace.id) notFound();
+
+  let cancelled: boolean;
+  try {
+    cancelled = await cancelRun(run.id, workspace.id);
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Failed to cancel the run.",
+    };
+  }
+
+  revalidatePath(
+    `/${args.workspaceSlug}/agents/${encodeURIComponent(args.agentName)}/runs/${run.id}`,
+  );
+  return { ok: true, cancelled };
 }
 
 function formatCapError(error: CapError): string {

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/cancel-run-button.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/cancel-run-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+import { cancelRunAction } from "./actions";
+
+// Inline "Stop" control shown next to the status of a live (queued/running)
+// run. Calls the cancel action, which flips the row to 'cancelled' and SIGKILLs
+// the run's subprocess on the api. The page poller picks up the new status on
+// its next refresh; we also refresh immediately on success.
+export function CancelRunButton({
+  workspaceSlug,
+  agentName,
+  runId,
+}: {
+  workspaceSlug: string;
+  agentName: string;
+  runId: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function onClick() {
+    setError(null);
+    startTransition(async () => {
+      const res = await cancelRunAction({ workspaceSlug, agentName, runId });
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Button
+        size="small"
+        variant="secondary"
+        onClick={onClick}
+        disabled={pending}
+      >
+        {pending ? "Stopping…" : "Stop run"}
+      </Button>
+      {error && <span className="text-sentiment-negative text-xs">{error}</span>}
+    </span>
+  );
+}

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/page.tsx
@@ -21,6 +21,7 @@ import {
 import { getServerSession } from "@/lib/session";
 import { getWorkspaceBySlug, isTemboConfigured } from "@/lib/workspace";
 
+import { CancelRunButton } from "./cancel-run-button";
 import { CopyOutputButton } from "./copy-output-button";
 import { ImproveForm } from "./improve-form";
 import { RunPoller } from "./run-poller";
@@ -185,8 +186,17 @@ export default async function RunDetailPage({
             <dt className="text-foreground-weak w-24 shrink-0 font-medium">
               Status
             </dt>
-            <dd className={`${STATUS_TEXT_TONE[run.status]} font-medium`}>
-              {STATUS_LABELS[run.status]}
+            <dd className="flex items-center gap-3">
+              <span className={`${STATUS_TEXT_TONE[run.status]} font-medium`}>
+                {STATUS_LABELS[run.status]}
+              </span>
+              {isLive && (
+                <CancelRunButton
+                  workspaceSlug={workspace.slug}
+                  agentName={run.agentName}
+                  runId={run.id}
+                />
+              )}
             </dd>
           </div>
           <div className="flex gap-3">
@@ -554,6 +564,7 @@ const STATUS_LABELS: Record<RunRecord["status"], string> = {
   running: "Running",
   succeeded: "Succeeded",
   failed: "Failed",
+  cancelled: "Cancelled",
 };
 
 // Colored text tone per status, used inline in the meta <dl>. Replaces
@@ -564,6 +575,7 @@ const STATUS_TEXT_TONE: Record<RunRecord["status"], string> = {
   running: "text-[var(--color-blue-600)]",
   succeeded: "text-sentiment-positive",
   failed: "text-sentiment-negative",
+  cancelled: "text-foreground-muted",
 };
 
 // Historical runs (pre-9d5f2dc) have a `\n\n[stop_reason=...]`

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-poller.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-poller.tsx
@@ -19,7 +19,7 @@ const POLL_START_QUEUED = 3000;
 const POLL_MAX = 15000;
 const POLL_GROWTH = 1.5;
 
-export function RunPoller({ status }: { status: "queued" | "running" | "succeeded" | "failed" }) {
+export function RunPoller({ status }: { status: "queued" | "running" | "succeeded" | "failed" | "cancelled" }) {
   const router = useRouter();
 
   useEffect(() => {

--- a/web/src/app/[workspace]/dashboard/page.tsx
+++ b/web/src/app/[workspace]/dashboard/page.tsx
@@ -345,6 +345,7 @@ const RUN_STATUS_LABELS: Record<RunStatus, string> = {
   running: "Running",
   succeeded: "Succeeded",
   failed: "Failed",
+  cancelled: "Cancelled",
 };
 
 const RUN_STATUS_BADGE: Record<
@@ -355,6 +356,7 @@ const RUN_STATUS_BADGE: Record<
   running: "blue",
   succeeded: "green",
   failed: "red",
+  cancelled: "gray",
 };
 
 function RunStatusBadge({ status }: { status: RunStatus }) {

--- a/web/src/app/[workspace]/runs/page.tsx
+++ b/web/src/app/[workspace]/runs/page.tsx
@@ -19,6 +19,7 @@ const VALID_STATUSES: RunSummary["status"][] = [
   "running",
   "succeeded",
   "failed",
+  "cancelled",
 ];
 const VALID_TRIGGERS: RunTrigger[] = ["manual", "schedule", "event"];
 

--- a/web/src/app/[workspace]/runs/runs-list.tsx
+++ b/web/src/app/[workspace]/runs/runs-list.tsx
@@ -31,7 +31,13 @@ import type { LoadedRun } from "./shape";
 type RunStatus = LoadedRun["status"];
 type RunTrigger = LoadedRun["trigger"];
 
-const ALL_STATUSES: RunStatus[] = ["queued", "running", "succeeded", "failed"];
+const ALL_STATUSES: RunStatus[] = [
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+];
 const ALL_TRIGGERS: RunTrigger[] = ["manual", "schedule", "event"];
 const PAGE_SIZE = 50;
 
@@ -530,6 +536,7 @@ const STATUS_LABELS: Record<RunStatus, string> = {
   running: "Running",
   succeeded: "Succeeded",
   failed: "Failed",
+  cancelled: "Cancelled",
 };
 
 const TRIGGER_LABELS: Record<RunTrigger, string> = {
@@ -546,6 +553,7 @@ const STATUS_BADGE: Record<
   running: "blue",
   succeeded: "green",
   failed: "red",
+  cancelled: "gray",
 };
 
 function formatDuration(ms: number): string {

--- a/web/src/app/[workspace]/settings/members/[userId]/page.tsx
+++ b/web/src/app/[workspace]/settings/members/[userId]/page.tsx
@@ -173,6 +173,7 @@ const RUN_BADGE: Record<string, "green" | "red" | "yellow" | "blue" | "gray"> = 
   running: "blue",
   succeeded: "green",
   failed: "red",
+  cancelled: "gray",
 };
 
 function ConnRow({

--- a/web/src/app/api/v1/runs/route.ts
+++ b/web/src/app/api/v1/runs/route.ts
@@ -17,7 +17,13 @@ import {
 
 export const dynamic = "force-dynamic";
 
-const STATUSES = ["queued", "running", "succeeded", "failed"] as const;
+const STATUSES = [
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+] as const;
 type RunStatus = (typeof STATUSES)[number];
 const TRIGGERS: RunTrigger[] = ["manual", "schedule", "event"];
 

--- a/web/src/lib/audit-db.ts
+++ b/web/src/lib/audit-db.ts
@@ -307,7 +307,7 @@ async function fetchRunEvents(
     actor_name: string | null;
     actor_email: string | null;
     at: Date;
-    status: "queued" | "running" | "succeeded" | "failed";
+    status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
     trigger: "manual" | "schedule" | "event";
     agent_name: string;
     duration_ms: string | null;

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -130,7 +130,7 @@ export function buildMcpServer(
         "cost, previews) — call get_run for full output.",
       inputSchema: {
         status: z
-          .enum(["queued", "running", "succeeded", "failed"])
+          .enum(["queued", "running", "succeeded", "failed", "cancelled"])
           .array()
           .optional()
           .describe("Only runs in these statuses."),

--- a/web/src/lib/runs-api.ts
+++ b/web/src/lib/runs-api.ts
@@ -66,7 +66,7 @@ export type RunRecord = {
   /** Optional user input the run started with ("" when none). */
   userMessage: string;
   model: string;
-  status: "queued" | "running" | "succeeded" | "failed";
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
   output: string;
   /** Live partial output while running (null once terminal). */
   streamedOutput: string | null;
@@ -200,4 +200,27 @@ export async function getRun(
   }
   const body = (await res.json()) as ApiRunRecord;
   return fromApi(body);
+}
+
+/** Kill an in-flight run. Returns true if this call transitioned the run to
+ *  'cancelled', false if it was already terminal (nothing to do). */
+export async function cancelRun(
+  runId: string,
+  workspaceId: string,
+): Promise<boolean> {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  const res = await fetch(
+    `${API_URL}/internal/runs/${encodeURIComponent(runId)}/cancel?${params}`,
+    {
+      method: "POST",
+      headers: { ...authHeader() },
+      cache: "no-store",
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Run API returned ${res.status}: ${text.slice(0, 400)}`);
+  }
+  const body = (await res.json()) as { cancelled: boolean };
+  return body.cancelled;
 }

--- a/web/src/lib/runs-db.ts
+++ b/web/src/lib/runs-db.ts
@@ -14,7 +14,7 @@ export type RunTrigger = "manual" | "schedule" | "event";
 export type ChildRun = {
   id: string;
   agentName: string;
-  status: "queued" | "running" | "succeeded" | "failed";
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
   costUsd: number | null;
   tokensInput: number | null;
   tokensOutput: number | null;
@@ -99,7 +99,7 @@ export async function listChildRuns(
 export type RunSummary = {
   id: string;
   agentName: string;
-  status: "queued" | "running" | "succeeded" | "failed";
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
   createdAt: Date;
   completedAt: Date | null;
   trigger: RunTrigger;
@@ -116,7 +116,7 @@ export type AgentSummary = {
    *  none — e.g. only cargo-ai runs or unpriced models). */
   avgCostUsd30d: number | null;
   /** Latest run regardless of age — null when the agent has never run. */
-  lastRunStatus: "queued" | "running" | "succeeded" | "failed" | null;
+  lastRunStatus: "queued" | "running" | "succeeded" | "failed" | "cancelled" | null;
   lastRunAt: Date | null;
 };
 
@@ -202,7 +202,7 @@ export async function listAgentSummaries30d(
 export interface ChatRun {
   id: string;
   agentName: string;
-  status: "queued" | "running" | "succeeded" | "failed";
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
   userMessage: string;
   output: string;
   errorMessage: string | null;


### PR DESCRIPTION
## Why

Runs execute as in-memory `tokio::spawn` tasks each owning a Python `pydantic-ai` subprocess. Until now there was no way to kill a run that was looping, stuck, or no longer wanted — you could only wait it out (or restart the api, which orphans *every* in-flight run).

## What

A **Stop run** button on the run detail page, shown while a run is queued/running.

- **New terminal status `cancelled`** (migration `0063`), distinct from `failed` so user-killed runs stay out of failure dashboards/badges. Threaded through every run status union, display map, filter, and the MCP `list_runs` enum.
- **Kill plumbing (api):** `AppState` gains a `run_cancels` registry (`run_id → CancellationToken`). `execute_run` registers a token per run and removes it on completion; the pydantic stdout read loop `tokio::select!`s the token against `read_until` and `start_kill()`s the wrapper subprocess on cancel.
- **Endpoint:** `POST /internal/runs/{id}/cancel` flips the row to `cancelled` (only while `queued`/`running`, workspace-scoped) and fires the token. `mark_running`/`mark_succeeded`/`mark_failed` gained status guards so the killed process unwinding can't clobber the `cancelled` row. A cancelled run also skips the Slack "failed" message.
- **Web:** `cancelRun` client + `cancelRunAction` (operator+), and a `CancelRunButton` client component inline next to the status.

An already-orphaned run (no live token — e.g. from a prior restart) still flips to `cancelled` by the row update alone; there's nothing running to kill.

## Test
- `cargo check` clean; `tsc --noEmit` clean; `vitest run` 124 passing; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)