### PR TITLE
Make the Stop-run button red

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/cancel-run-button.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/cancel-run-button.tsx
@@ -40,7 +40,7 @@ export function CancelRunButton({
     <span className="inline-flex items-center gap-2">
       <Button
         size="small"
-        variant="secondary"
+        variant="destructive"
         onClick={onClick}
         disabled={pending}
       >


### PR DESCRIPTION
Switch the inline Stop-run button (on live run detail pages) from the muted `secondary` tone to the red `destructive` variant so the kill action stands out next to the run's status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)