### PR TITLE
security: CodeQL batch — workflow perms, markdown escaping, log hardening

### DIFF
--- a/.github/workflows/deploy-internal.yml
+++ b/.github/workflows/deploy-internal.yml
@@ -28,6 +28,12 @@ concurrency:
   group: deploy-internal
   cancel-in-progress: true
 
+# Least-privilege default for GITHUB_TOKEN. The build-and-deploy job widens its
+# own scope (packages: write) where it needs to; every other job inherits this
+# read-only default.
+permissions:
+  contents: read
+
 jobs:
   checks:
     if: github.repository == 'tembo/agent-studio'

--- a/web/src/app/api/connections/composio/callback/route.ts
+++ b/web/src/app/api/connections/composio/callback/route.ts
@@ -185,8 +185,11 @@ export async function GET(request: NextRequest) {
       })),
     });
   } catch (e) {
+    // Pass the user-influenced toolkit as an argument, not interpolated into
+    // the format string, so a `%s`-style value can't garble the log line.
     console.error(
-      `[composio/${payload.toolkit}] tool-cache prime failed:`,
+      "[composio/%s] tool-cache prime failed:",
+      payload.toolkit,
       (e as Error).message,
     );
   }

--- a/web/src/lib/for-agents-markdown.ts
+++ b/web/src/lib/for-agents-markdown.ts
@@ -10,9 +10,15 @@ export type ForAgentsTool = {
   description: string | null;
 };
 
-// Escape a cell for a GitHub-flavored markdown table (pipes + newlines).
+// Escape a cell for a GitHub-flavored markdown table (backslashes + pipes +
+// newlines). Backslashes are escaped first so an input backslash can't combine
+// with the pipe-escaping we add (or escape the trailing cell boundary).
 function cell(s: string | null): string {
-  return (s ?? "").replace(/\|/g, "\\|").replace(/\r?\n+/g, " ").trim();
+  return (s ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n+/g, " ")
+    .trim();
 }
 
 /** One provider's tool reference. `tools` is the workspace's cached catalog


### PR DESCRIPTION
Triage + fixes for the open CodeQL code-scanning alerts.

## Fixed (real)
- **#29 missing-workflow-permissions** — `deploy-internal.yml` gains a top-level `permissions: contents: read` default so the `checks` job stops inheriting the broad `GITHUB_TOKEN`. `build-and-deploy` still widens to `packages: write` for GHCR.
- **#36 incomplete-sanitization** — `for-agents-markdown.ts` `cell()` now escapes backslashes before pipes, so an input backslash can't combine with our pipe-escaping or escape the table-cell boundary in the agent-facing markdown.
- **#71 tainted-format-string** (low) — the Composio callback logs the user-influenced `toolkit` as a `console.error` argument (`%s`) instead of interpolating it into the format string, so a `%s`-style value can't garble the log line.

## Dismissed as false positives (separately, via the Security tab)
- **#37 insufficient-password-hash** (`for-agents-token.ts:39`) — that's `createHmac("sha256", …)` **signing a short-lived bearer token** with `BETTER_AUTH_SECRET`, not hashing a user password. Fast HMAC/SHA256 is the correct primitive; bcrypt/scrypt would be wrong. (Same for the SHA256 API-key lookup — keys are high-entropy `tas_…` strings.)
- **#32 xss-through-dom** (`add-native-mcp-connection-form.tsx:40`) — a same-origin `window.location.href` **navigation**, not an `innerHTML` sink; `providerSlug` comes from a fixed server catalog and `name` is URL-encoded via `URLSearchParams`.

## Test
`tsc --noEmit` clean, `vitest run` 124 passing, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)