### PR TITLE
fix: let Dismiss close direct-commit pending agent-creates

### DIFF
--- a/web/src/lib/improvements-api.ts
+++ b/web/src/lib/improvements-api.ts
@@ -205,13 +205,20 @@ export async function dismissPendingCreate(
   workspaceId: string,
   improvementId: string,
 ): Promise<boolean> {
+  // Match the SAME predicate listPendingCreatesForWorkspace uses to render a
+  // card — including the direct-commit (YOLO) case that's optimistically
+  // 'committed' but has no commit_url yet. Otherwise a direct-commit ghost card
+  // shows as Pending but Dismiss matches 0 rows and silently does nothing.
   const res = await db.query(
     `UPDATE improvement
         SET status = 'closed', updated_at = now()
       WHERE id = $1
         AND workspace_id = $2
         AND kind = 'create'
-        AND status IN ('submitted', 'pr_opened')`,
+        AND (
+          status IN ('submitted', 'pr_opened')
+          OR (delivery = 'direct' AND status = 'committed' AND commit_url IS NULL)
+        )`,
     [improvementId, workspaceId],
   );
   return (res.rowCount ?? 0) > 0;


### PR DESCRIPTION
## Symptom
On the Agents inventory, a stuck **Pending** create card (e.g. `attio-duplicate-detector`) couldn't be removed — clicking **Dismiss → Yes** did nothing.

## Cause
The predicate that *shows* a pending card and the one that *dismisses* it had drifted apart:

- `listPendingCreatesForWorkspace` shows a card for `status IN ('submitted','pr_opened')` **OR** a direct-commit (YOLO) create that's optimistically `committed` but has `commit_url IS NULL`.
- `dismissPendingCreate` only matched `status IN ('submitted','pr_opened')`.

So a **direct-commit ghost card** (committed, but the scan never attached its `commit_url`) renders as Pending yet Dismiss matches 0 rows → returns "no longer pending" → the card stays. This is also why it lingers even when the agent name matches the live repo agent exactly: it's not a name-dedup miss, it's an unreconciled direct-commit row.

## Fix
Broaden `dismissPendingCreate`'s WHERE to the same predicate the inventory uses, so Dismiss can always clear a card the inventory shows.

## Test
`tsc --noEmit` clean, `vitest run` 124 passing, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)