### PR TITLE
fix: auto-reconcile pending agent-creates once the agent lands

### DIFF
--- a/web/src/app/[workspace]/page.tsx
+++ b/web/src/app/[workspace]/page.tsx
@@ -7,7 +7,10 @@ import { listStarredAgentNames } from "@/lib/agent-stars";
 import { listOwnedAgentNames } from "@/lib/agent-versions";
 import { toolkitLabel } from "@/lib/composio-label";
 import { scanImprovementsForPRs } from "@/lib/improvement-scan";
-import { listPendingCreatesForWorkspace } from "@/lib/improvements-api";
+import {
+  listPendingCreatesForWorkspace,
+  reconcileLandedCreates,
+} from "@/lib/improvements-api";
 import { getMcpProvider } from "@/lib/mcp-providers";
 import { meetsMinRole } from "@/lib/rbac";
 import { listAgentSubAgentEdges, listAgentSummaries30d } from "@/lib/runs-db";
@@ -73,6 +76,23 @@ export default async function WorkspacePage({
   const validNames = agentsResult.ok
     ? agentsResult.agents.filter((a) => a.ok).map((a) => a.spec.name)
     : [];
+
+  // Auto-reconcile ghost Pending cards: if a create's agent has already landed
+  // in the repo (file present at its path, or a live agent under its name),
+  // close the row now — the marker-based commit scan can't always attach a
+  // commit_url, which otherwise leaves a direct-commit create stuck Pending
+  // forever. All repo files (parsing or not) count as "landed" via path; only
+  // run when the repo was actually read (agentsResult.ok) so a failed listing
+  // isn't misread as "nothing landed". Drop the closed ids from the in-memory
+  // pending list so they don't render this pass.
+  const livePaths = agentsResult.ok
+    ? agentsResult.agents.map((a) => a.path)
+    : [];
+  const reconciledIds = new Set(
+    await reconcileLandedCreates(workspace.id, livePaths, validNames),
+  );
+  const pendingActive = pendingStored.filter((p) => !reconciledIds.has(p.id));
+
   const [summaries, subAgentEdges] = await Promise.all([
     listAgentSummaries30d(workspace.id, validNames),
     listAgentSubAgentEdges(workspace.id),
@@ -137,7 +157,7 @@ export default async function WorkspacePage({
   // drop rows that have moved past the non-terminal window.
   const pendingScanned = await scanImprovementsForPRs(
     workspace.id,
-    pendingStored,
+    pendingActive,
   );
   const pending = pendingScanned.filter(
     (p) =>

--- a/web/src/lib/improvements-api.ts
+++ b/web/src/lib/improvements-api.ts
@@ -224,6 +224,49 @@ export async function dismissPendingCreate(
   return (res.rowCount ?? 0) > 0;
 }
 
+/**
+ * Presence-based reconcile: close out pending agent-creates whose agent has
+ * already landed in the repo, independent of commit-message markers.
+ *
+ * The marker-based commit scan (improvement-scan Path 3) can only attach a
+ * commit_url when the landed commit's message carries the per-improvement
+ * marker — which isn't guaranteed (CAP may reword/squash, or the file was
+ * committed outside that flow). When it can't, a direct-commit create sits in
+ * 'committed' with a null commit_url forever and shows as a ghost Pending card.
+ *
+ * This closes that gap by the more reliable signal — the agent file actually
+ * exists. A create is "landed" when a live agent now exists at its path
+ * (covers files that don't parse / whose name diverged) or under its name.
+ * Such rows are marked 'merged' (terminal success), distinct from a user
+ * Dismiss ('closed'). Only the workspace's own non-terminal create rows are
+ * touched. Returns the ids closed so the caller can drop them from the
+ * already-fetched pending list without a re-query.
+ *
+ * Pass live paths/names only when the repo was actually read — an empty repo
+ * listing (e.g. GitHub down) must NOT be read as "nothing landed".
+ */
+export async function reconcileLandedCreates(
+  workspaceId: string,
+  livePaths: string[],
+  liveNames: string[],
+): Promise<string[]> {
+  if (livePaths.length === 0 && liveNames.length === 0) return [];
+  const res = await db.query<{ id: string }>(
+    `UPDATE improvement
+        SET status = 'merged', updated_at = now()
+      WHERE workspace_id = $1
+        AND kind = 'create'
+        AND (
+          status IN ('submitted', 'pr_opened')
+          OR (delivery = 'direct' AND status = 'committed' AND commit_url IS NULL)
+        )
+        AND (agent_path = ANY($2::text[]) OR agent_name = ANY($3::text[]))
+      RETURNING id`,
+    [workspaceId, livePaths, liveNames],
+  );
+  return res.rows.map((r) => r.id);
+}
+
 export async function setImprovementTask(input: {
   id: string;
   temboTaskId: string | null;


### PR DESCRIPTION
Follow-up to #220. That made **Dismiss** able to clear a direct-commit ghost Pending card; this removes the need to dismiss at all by reconciling automatically.

## Why
The only reconciler for a pending "create" was **marker-based**: `improvement-scan` Path 3 attaches a `commit_url` only when the landed commit's message contains the per-improvement marker. That marker is advisory prompt text handed to CAP — it can be reworded/squashed, or the file may be committed outside that flow — so `search/commits` never matches, `commit_url` stays null, and a direct-commit (YOLO) create sits in `committed` forever as an un-clearable ghost **Pending** card. (This is why `attio-duplicate-detector` lingered even though its name matched the live agent exactly.)

## What
A **presence-based** reconcile on the Agents inventory load:

- New `reconcileLandedCreates(workspaceId, livePaths, liveNames)` marks the workspace's non-terminal create rows `merged` (terminal success — distinct from a user **Dismiss**, which is `closed`) when the agent has actually landed: matched by **file path** (covers files that don't parse or whose `name:` diverged) **or** by **live agent name**.
- Only runs when the repo was actually read (`agentsResult.ok`), so a failed GitHub listing isn't misread as "nothing landed".
- Returns the closed ids; the page drops them from the in-memory pending list so the ghost card disappears the same render.

The marker-based scan stays for attribution (it still attaches the real commit URL when the marker *is* present); this just stops a missing marker from stranding the card.

## Test
`tsc --noEmit` clean, `vitest run` 124 passing, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)