### PR TITLE
feat(for-agents): publish tool parameter schemas; surface inbox links

### DIFF
--- a/api/migrations/0065_workspace_mcp_tool_input_schema.sql
+++ b/api/migrations/0065_workspace_mcp_tool_input_schema.sql
@@ -1,0 +1,7 @@
+-- Cache each MCP tool's input JSON Schema alongside its name/description, so the
+-- /for-agents tool reference can publish a tool's PARAMETERS (not just a
+-- one-line description). Agent authors (Tembo CAP) read that reference when
+-- writing an agent's `tools:` + instructions; without the param schema they
+-- can't discover fields like produce_inbox_item's `links`. Nullable: older
+-- cached rows stay until the connection is re-synced (Connections → Refresh).
+ALTER TABLE workspace_mcp_tool ADD COLUMN IF NOT EXISTS input_schema JSONB;

--- a/web/src/app/[workspace]/connections/native-mcp-actions.ts
+++ b/web/src/app/[workspace]/connections/native-mcp-actions.ts
@@ -149,6 +149,7 @@ export async function refreshNativeMcpToolsAction(
         slug: t.slug,
         displayName: t.name,
         description: t.description,
+        inputSchema: t.inputSchema,
       })),
     });
   } catch (e) {

--- a/web/src/app/api/connections/native/[provider]/callback/route.ts
+++ b/web/src/app/api/connections/native/[provider]/callback/route.ts
@@ -262,6 +262,7 @@ export async function GET(
         slug: t.slug,
         displayName: t.name,
         description: t.description,
+        inputSchema: t.inputSchema,
       })),
     });
   } catch (e) {

--- a/web/src/app/for-agents/[provider]/route.ts
+++ b/web/src/app/for-agents/[provider]/route.ts
@@ -58,7 +58,12 @@ export async function GET(
     if (t.source !== "native-mcp" || t.provider !== slug) continue;
     if (seen.has(t.slug)) continue; // same tool can be cached under many slots
     seen.add(t.slug);
-    tools.push({ slug: t.slug, name: t.displayName, description: t.description });
+    tools.push({
+      slug: t.slug,
+      name: t.displayName,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    });
   }
   tools.sort((a, b) => a.slug.localeCompare(b.slug));
 

--- a/web/src/lib/agent-guidance.ts
+++ b/web/src/lib/agent-guidance.ts
@@ -750,6 +750,17 @@ Make the orchestrator resilient to the user's actual setup: call
 source is connected — don't assume every source exists, and don't
 hard-code a slot name the user may not have authorized.
 
+### Surfacing review items to the Tasks Inbox
+
+To stage work a human should review, an agent calls \`produce_inbox_item\`
+(on the \`tembo-agent-studio\` Native MCP connection). To point one item at
+several things — e.g. "the top 10 Linear triage tickets" as a single task —
+pass \`links: [{ label, url }]\`; they render as a clickable list on the item,
+separate from the single source \`url\`. Prefer this over hand-rolling a
+Markdown link list in \`proposedActionText\`. The exact parameter list for any
+\`tembo-agent-studio\` tool is in its \`/for-agents\` reference — fetch it when
+you need a tool's full schema.
+
 ### retries
 
 Integer or struct. Default behavior is provider-determined. Set

--- a/web/src/lib/for-agents-markdown.test.ts
+++ b/web/src/lib/for-agents-markdown.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  renderProviderMarkdown,
+  type ForAgentsTool,
+} from "@/lib/for-agents-markdown";
+import type { McpProvider } from "@/lib/mcp-providers";
+
+// Only the fields renderProviderMarkdown reads; cast covers the rest.
+const provider = {
+  slug: "tembo-agent-studio",
+  displayName: "Tembo Agent Studio",
+  mcpServerUrl: "",
+} as McpProvider;
+
+describe("renderProviderMarkdown — parameter tables", () => {
+  it("renders a Parameters section with name/type/required/description from inputSchema", () => {
+    const tools: ForAgentsTool[] = [
+      {
+        slug: "produce_inbox_item",
+        name: "produce_inbox_item",
+        description: "Add an item to the inbox.",
+        inputSchema: {
+          type: "object",
+          required: ["title"],
+          properties: {
+            title: { type: "string", description: "Short label." },
+            links: {
+              type: "array",
+              description: "Deep links.",
+              items: { type: "object" },
+            },
+            priority: {
+              enum: ["low", "high"],
+              description: "How urgent.",
+            },
+          },
+        },
+      },
+    ];
+
+    const md = renderProviderMarkdown(provider, tools);
+    expect(md).toContain("## Parameters");
+    expect(md).toContain("### `produce_inbox_item`");
+    expect(md).toContain("| `title` | string | yes | Short label. |");
+    expect(md).toContain("| `links` | array<object> | no | Deep links. |");
+    // The `|` inside the enum is escaped so it can't break the markdown table.
+    expect(md).toContain("| `priority` | enum(low \\| high) | no | How urgent. |");
+  });
+
+  it("omits the Parameters section for tools without a schema or properties", () => {
+    const tools: ForAgentsTool[] = [
+      { slug: "a", name: "a", description: "no schema", inputSchema: null },
+      {
+        slug: "b",
+        name: "b",
+        description: "empty props",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+    const md = renderProviderMarkdown(provider, tools);
+    expect(md).not.toContain("## Parameters");
+  });
+});

--- a/web/src/lib/for-agents-markdown.ts
+++ b/web/src/lib/for-agents-markdown.ts
@@ -8,7 +8,57 @@ export type ForAgentsTool = {
   slug: string;
   name: string | null;
   description: string | null;
+  /** The tool's input JSON Schema (MCP `tool.inputSchema`), rendered as a
+   *  per-tool parameter table so authors see the exact fields. Null/absent for
+   *  tools cached before schemas were captured (re-sync to populate). */
+  inputSchema?: Record<string, unknown> | null;
 };
+
+// A minimal JSON-Schema property node — only the bits we render.
+type SchemaNode = {
+  type?: string | string[];
+  description?: string;
+  enum?: unknown[];
+  items?: SchemaNode;
+  anyOf?: SchemaNode[];
+  oneOf?: SchemaNode[];
+};
+
+// A one-line, human-readable type label for a JSON-Schema property node.
+// Defensive: any unknown shape falls back to "any".
+function schemaType(node: SchemaNode | undefined): string {
+  if (!node || typeof node !== "object") return "any";
+  if (Array.isArray(node.enum) && node.enum.length > 0) {
+    return `enum(${node.enum.map((v) => String(v)).join(" | ")})`;
+  }
+  const variants = node.anyOf ?? node.oneOf;
+  if (Array.isArray(variants) && variants.length > 0) {
+    return variants.map(schemaType).join(" | ");
+  }
+  const t = Array.isArray(node.type) ? node.type.join(" | ") : node.type;
+  if (t === "array") return `array<${schemaType(node.items)}>`;
+  return t ?? "object";
+}
+
+// Render a tool's input JSON Schema as a `| param | type | required | description |`
+// table. Returns "" when the schema declares no properties.
+function renderParams(schema: Record<string, unknown> | null | undefined): string {
+  if (!schema || typeof schema !== "object") return "";
+  const props = schema.properties;
+  if (!props || typeof props !== "object") return "";
+  const required = new Set(
+    Array.isArray(schema.required) ? (schema.required as string[]) : [],
+  );
+  const entries = Object.entries(props as Record<string, SchemaNode>);
+  if (entries.length === 0) return "";
+  const lines = ["| param | type | required | description |", "| --- | --- | --- | --- |"];
+  for (const [name, node] of entries) {
+    lines.push(
+      `| \`${cell(name)}\` | ${cell(schemaType(node))} | ${required.has(name) ? "yes" : "no"} | ${cell(node?.description ?? null)} |`,
+    );
+  }
+  return lines.join("\n");
+}
 
 // Escape a cell for a GitHub-flavored markdown table (backslashes + pipes +
 // newlines). Backslashes are escaped first so an input backslash can't combine
@@ -61,6 +111,19 @@ export function renderProviderMarkdown(
       lines.push(`| \`${cell(t.slug)}\` | ${cell(t.name)} | ${cell(t.description)} |`);
     }
     lines.push("");
+
+    // Per-tool parameter tables, for the tools whose schema declared fields.
+    // Lets an author see the exact arguments (names, types, required) instead
+    // of guessing from the description.
+    const withParams = tools
+      .map((t) => ({ tool: t, params: renderParams(t.inputSchema) }))
+      .filter((x) => x.params !== "");
+    if (withParams.length > 0) {
+      lines.push("## Parameters", "");
+      for (const { tool, params } of withParams) {
+        lines.push(`### \`${tool.slug}\``, "", params, "");
+      }
+    }
   }
   return lines.join("\n");
 }

--- a/web/src/lib/mcp-tools.ts
+++ b/web/src/lib/mcp-tools.ts
@@ -28,6 +28,10 @@ export type McpTool = {
   slug: string;
   displayName: string | null;
   description: string | null;
+  /** The tool's input JSON Schema (MCP `tool.inputSchema`), surfaced in the
+   *  /for-agents reference so agent authors can see each tool's parameters.
+   *  Null for rows cached before this was captured (re-sync to populate). */
+  inputSchema: Record<string, unknown> | null;
   refreshedAt: Date;
   createdAt: Date;
 };
@@ -42,6 +46,7 @@ type Row = {
   slug: string;
   display_name: string | null;
   description: string | null;
+  input_schema: Record<string, unknown> | null;
   refreshed_at: Date;
   created_at: Date;
 };
@@ -57,13 +62,14 @@ function rowToTool(r: Row): McpTool {
     slug: r.slug,
     displayName: r.display_name,
     description: r.description,
+    inputSchema: r.input_schema,
     refreshedAt: r.refreshed_at,
     createdAt: r.created_at,
   };
 }
 
 const COLUMNS = `id, workspace_id, user_id, source, provider,
-  connection_name, slug, display_name, description, refreshed_at, created_at`;
+  connection_name, slug, display_name, description, input_schema, refreshed_at, created_at`;
 
 /**
  * Every tool the user has across both substrates, in one query.
@@ -201,6 +207,7 @@ export type NewTool = {
   slug: string;
   displayName?: string | null;
   description?: string | null;
+  inputSchema?: Record<string, unknown> | null;
 };
 
 /**
@@ -244,7 +251,7 @@ export async function replaceToolsForConnection(args: {
       let i = 1;
       for (const t of args.tools) {
         values.push(
-          `($${i}, $${i + 1}, $${i + 2}, $${i + 3}, $${i + 4}, $${i + 5}, $${i + 6}, $${i + 7})`,
+          `($${i}, $${i + 1}, $${i + 2}, $${i + 3}, $${i + 4}, $${i + 5}, $${i + 6}, $${i + 7}, $${i + 8}::jsonb)`,
         );
         params.push(
           args.workspaceId,
@@ -255,17 +262,19 @@ export async function replaceToolsForConnection(args: {
           t.slug,
           t.displayName ?? null,
           t.description ?? null,
+          t.inputSchema ? JSON.stringify(t.inputSchema) : null,
         );
-        i += 8;
+        i += 9;
       }
       await client.query(
         `INSERT INTO workspace_mcp_tool
            (workspace_id, user_id, source, provider, connection_name,
-            slug, display_name, description)
+            slug, display_name, description, input_schema)
            VALUES ${values.join(", ")}
          ON CONFLICT (workspace_id, user_id, source, provider, connection_name, slug)
          DO UPDATE SET display_name = EXCLUDED.display_name,
                        description  = EXCLUDED.description,
+                       input_schema = EXCLUDED.input_schema,
                        refreshed_at = NOW()`,
         params,
       );

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -420,7 +420,10 @@ export function buildMcpServer(
         "and/or structured fields) so the human reviews-and-edits rather than " +
         "starts from scratch; the diff between your guess and what they submit " +
         "trains future autonomy. With a proposal the item is ready for review; " +
-        "without one it sits 'open' for someone to pick up. Returns the item.",
+        "without one it sits 'open' for someone to pick up. To point one item at " +
+        "several things to review (e.g. the top 10 Linear triage tickets as one " +
+        "task), pass `links: [{ label, url }]` — they render as a clickable list, " +
+        "preferable to a Markdown link list in proposedActionText. Returns the item.",
       inputSchema: {
         itemType: z
           .string()

--- a/web/src/lib/native-mcp-tools.ts
+++ b/web/src/lib/native-mcp-tools.ts
@@ -26,6 +26,10 @@ export type FetchedMcpTool = {
   slug: string;
   name: string;
   description: string | undefined;
+  /** The tool's input JSON Schema (MCP `tool.inputSchema`), so the /for-agents
+   *  reference can publish each tool's parameters. Undefined if the server
+   *  omitted it. */
+  inputSchema: Record<string, unknown> | undefined;
 };
 
 export async function fetchNativeMcpTools(
@@ -51,6 +55,10 @@ export async function fetchNativeMcpTools(
       name: typeof t.title === "string" ? t.title : t.name,
       description:
         typeof t.description === "string" ? t.description : undefined,
+      inputSchema:
+        t.inputSchema && typeof t.inputSchema === "object"
+          ? (t.inputSchema as Record<string, unknown>)
+          : undefined,
     }));
   } finally {
     await client.close().catch(() => {


### PR DESCRIPTION
## Why
When Tembo asked whether the agent it generated used the new `links: [{label, url}]` field on `produce_inbox_item`, it said it **couldn't even confirm the field exists**. Root cause: the `/for-agents` tool reference that CAP reads when authoring renders only `| slug | name | description |` — it never publishes a tool's **parameters**. The per-parameter zod `.describe()` (added with `links` in #223) reaches a *running* agent over live MCP, but not the *authoring* CAP. So `links` (and every other TAS tool's params) was undiscoverable at authoring time. A "Refresh" wouldn't help — params simply weren't rendered.

## What

**Cheap fixes (immediate `links` discoverability):**
- `produce_inbox_item`'s tool-level **description** now mentions `links: [{label,url}]` (shows in the for-agents description column).
- `agent-guidance.ts` gains a short *"Surfacing review items to the Tasks Inbox"* note documenting `links` and pointing at the `/for-agents` reference for full schemas.

**Robust fix (parameters for every TAS tool):**
- Capture each tool's input JSON Schema from MCP `list_tools` (was discarded) and cache it — new nullable `input_schema` JSONB on `workspace_mcp_tool` (`migration 0065`), threaded `FetchedMcpTool → replaceToolsForConnection → McpTool → /for-agents route`.
- `renderProviderMarkdown` now emits a per-tool **"## Parameters"** table (param / type / required / description), parsed defensively from the schema (`array<item>`, `enum(...)`, `anyOf`/`oneOf`).

## ⚠️ Requires a Refresh
Existing cached connections show no params until re-synced. After this deploys, **Connections → Native MCP → Refresh** (or reconnect) repopulates `input_schema`. For `tembo-agent-studio` specifically, hit Refresh once and CAP will then see `links` (and all params) in `/for-agents/tembo-agent-studio.md`.

## Test
- New `for-agents-markdown.test.ts` — Parameters rendering incl. `array<object>`, escaped `enum(...)`, and omission when no properties.
- `tsc` clean, `vitest run` 130 passing, eslint clean (pre-existing warnings only), `cargo check` clean (migration embedded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)