### PR TITLE
feat: auto-refresh all connection tool caches on deploy + daily

### DIFF
--- a/api/migrations/0066_instance_tool_reconcile.sql
+++ b/api/migrations/0066_instance_tool_reconcile.sql
@@ -1,0 +1,5 @@
+-- Track when the tool-cache reconcile last ran, so the boot/scheduled reconcile
+-- can throttle itself (skip if it ran very recently — a crash-loop guard) while
+-- still refreshing every native-MCP + Composio connection's cached tool catalog
+-- on each deploy and daily. Single-row instance_settings table (migration 0031).
+ALTER TABLE instance_settings ADD COLUMN IF NOT EXISTS last_tool_reconcile_at TIMESTAMPTZ;

--- a/web/src/lib/composio-connections.ts
+++ b/web/src/lib/composio-connections.ts
@@ -86,6 +86,20 @@ export async function listConnectionsForUser(
   return rows.map(rowToConnection);
 }
 
+/** Every ACTIVE Composio connection across all workspaces/users — for the
+ *  deploy/scheduled tool-cache reconcile (not a per-user view). */
+export async function listAllActiveComposioConnections(): Promise<
+  WorkspaceComposioConnection[]
+> {
+  const { rows } = await db.query<Row>(
+    `SELECT ${COLUMNS}
+       FROM workspace_composio_connection
+      WHERE status = 'ACTIVE'
+      ORDER BY workspace_id ASC, user_id ASC, toolkit_slug ASC, name ASC`,
+  );
+  return rows.map(rowToConnection);
+}
+
 /**
  * Lookup a specific (user, toolkit, name) tuple. Used by the
  * runner to resolve which Composio connection an agent's declared

--- a/web/src/lib/connections.ts
+++ b/web/src/lib/connections.ts
@@ -106,6 +106,20 @@ export async function listNativeConnectionsForUser(
   return rows.map(rowToConnection);
 }
 
+/** Every active native-MCP connection across all workspaces/users — for the
+ *  deploy/scheduled tool-cache reconcile (not a per-user view). */
+export async function listAllActiveNativeConnections(): Promise<
+  WorkspaceConnection[]
+> {
+  const { rows } = await db.query<ConnectionRow>(
+    `SELECT ${COLUMNS}
+       FROM workspace_connection
+      WHERE status = 'active'
+      ORDER BY workspace_id ASC, user_id ASC, type ASC, name ASC`,
+  );
+  return rows.map(rowToConnection);
+}
+
 export async function getNativeConnection(
   workspaceId: string,
   userId: string,

--- a/web/src/lib/instance-settings.ts
+++ b/web/src/lib/instance-settings.ts
@@ -47,6 +47,32 @@ export async function getStoredInstanceName(): Promise<string | null> {
 }
 
 /**
+ * When the tool-cache reconcile last completed (null if never / table missing).
+ * Used to throttle the boot + scheduled reconcile so restarts don't re-run it
+ * within a short window.
+ */
+export async function getLastToolReconcileAt(): Promise<Date | null> {
+  try {
+    const { rows } = await db.query<{ last_tool_reconcile_at: Date | null }>(
+      "SELECT last_tool_reconcile_at FROM instance_settings WHERE id = TRUE LIMIT 1",
+    );
+    return rows[0]?.last_tool_reconcile_at ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Stamp the tool-cache reconcile time (upserts the singleton row). */
+export async function markToolReconcile(at: Date): Promise<void> {
+  await db.query(
+    `INSERT INTO instance_settings (id, last_tool_reconcile_at)
+          VALUES (TRUE, $1)
+     ON CONFLICT (id) DO UPDATE SET last_tool_reconcile_at = $1`,
+    [at],
+  );
+}
+
+/**
  * First run = no user accounts exist yet. While true, the pre-sign-in
  * setup screen may set the instance name (no admin to gate on yet). On a
  * DB error we return false — fail closed, don't open anonymous setup.

--- a/web/src/lib/scheduler.ts
+++ b/web/src/lib/scheduler.ts
@@ -42,8 +42,16 @@ import {
   type InboxItem,
 } from "@/lib/inbox-api";
 import { resolveAgentForDispatch } from "@/lib/workspace-agents";
+import { maybeReconcileToolCaches } from "@/lib/tool-reconcile";
 
 const TICK_MS = 30_000;
+// Boot reconcile floor — a fresh process re-syncs tool caches unless one ran in
+// the last 10 min. Deploys (minutes+ apart) always run; a crash-looping restart
+// within 10 min doesn't re-storm provider APIs.
+const RECONCILE_BOOT_FLOOR_MS = 10 * 60_000;
+// Daily reconcile for long-running instances with no deploys — catches external
+// (Composio / native provider) tools that change server-side.
+const RECONCILE_DAILY_MS = 24 * 60 * 60_000;
 // How many corrected cases to include in one batched learning prompt. Bounds
 // the CAP prompt size; older signals beyond this still get consumed so they
 // don't pile up, they just don't each get spelled out.
@@ -61,10 +69,20 @@ export function startScheduler() {
   void learningTick().catch((e) =>
     console.error("[scheduler] initial learning tick threw", e),
   );
+  // Refresh every connection's cached tool catalog on boot (i.e. each deploy),
+  // throttled so restarts don't re-storm provider APIs. Background — must not
+  // block the scheduler from starting.
+  void maybeReconcileToolCaches(RECONCILE_BOOT_FLOOR_MS).catch((e) =>
+    console.error("[scheduler] initial tool reconcile threw", e),
+  );
   timer = setInterval(() => {
     void tick().catch((e) => console.error("[scheduler] tick threw", e));
     void learningTick().catch((e) =>
       console.error("[scheduler] learning tick threw", e),
+    );
+    // Daily drift catch-up; the throttle makes this a cheap no-op most ticks.
+    void maybeReconcileToolCaches(RECONCILE_DAILY_MS).catch((e) =>
+      console.error("[scheduler] tool reconcile threw", e),
     );
   }, TICK_MS);
   console.log(`[scheduler] started, tick=${TICK_MS}ms`);

--- a/web/src/lib/tool-reconcile.test.ts
+++ b/web/src/lib/tool-reconcile.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { isReconcileThrottled } from "@/lib/tool-reconcile";
+
+describe("isReconcileThrottled", () => {
+  const now = 1_000_000_000_000;
+  const tenMin = 10 * 60_000;
+
+  it("never throttles when there's no prior run", () => {
+    expect(isReconcileThrottled(null, now, tenMin)).toBe(false);
+  });
+
+  it("throttles a run within the window", () => {
+    expect(isReconcileThrottled(new Date(now - 60_000), now, tenMin)).toBe(true);
+  });
+
+  it("does not throttle once the window has elapsed (a real deploy/day later)", () => {
+    expect(isReconcileThrottled(new Date(now - tenMin - 1), now, tenMin)).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/lib/tool-reconcile.ts
+++ b/web/src/lib/tool-reconcile.ts
@@ -1,0 +1,148 @@
+import "server-only";
+
+// Refresh every connection's cached tool catalog (the workspace_mcp_tool table
+// that powers the Tools tab + the /for-agents reference) without anyone clicking
+// "Refresh". Two triggers, one throttled path:
+//   - on boot (every deploy starts a fresh process) — picks up tembo-agent-studio
+//     tool/schema changes shipped in the release, and re-syncs everything;
+//   - daily via the scheduler — catches external/Composio tools that change
+//     server-side between deploys.
+// A short DB-stamped throttle stops crash-loop restarts from re-running it every
+// few seconds, while still letting any real deploy (minutes+ apart) refresh.
+//
+// Best-effort: a single connection that fails (expired token, provider down,
+// missing key) is logged and skipped — it never blocks boot or the other
+// connections. Reuses the exact internals the per-connection Refresh buttons use.
+
+import {
+  getNativeConnectionCredentials,
+  listAllActiveNativeConnections,
+} from "@/lib/connections";
+import { listAllActiveComposioConnections } from "@/lib/composio-connections";
+import { fetchNativeMcpTools } from "@/lib/native-mcp-tools";
+import { fetchComposioToolkitTools } from "@/lib/composio-tools";
+import { replaceToolsForConnection } from "@/lib/mcp-tools";
+import { getWorkspaceSecretPlaintext } from "@/lib/workspace";
+import {
+  getLastToolReconcileAt,
+  markToolReconcile,
+} from "@/lib/instance-settings";
+
+type Tally = { ok: number; failed: number };
+
+// In-process guard so two triggers (boot + a scheduler tick) can't run the
+// batch concurrently.
+let inFlight = false;
+
+/** True when a reconcile stamped `last` is recent enough to skip given `maxAgeMs`.
+ *  Pure for testability. */
+export function isReconcileThrottled(
+  last: Date | null,
+  now: number,
+  maxAgeMs: number,
+): boolean {
+  return last !== null && now - last.getTime() < maxAgeMs;
+}
+
+/** Re-introspect + re-cache every active native-MCP and Composio connection.
+ *  Returns per-substrate ok/failed tallies. Never throws on a single
+ *  connection's failure. */
+export async function reconcileAllToolCaches(): Promise<{
+  native: Tally;
+  composio: Tally;
+}> {
+  const native: Tally = { ok: 0, failed: 0 };
+  const composio: Tally = { ok: 0, failed: 0 };
+
+  for (const c of await listAllActiveNativeConnections()) {
+    try {
+      const creds = await getNativeConnectionCredentials(c.id);
+      const tools = await fetchNativeMcpTools(c.mcpServerUrl, creds.access_token);
+      await replaceToolsForConnection({
+        workspaceId: c.workspaceId,
+        userId: c.userId,
+        source: "native-mcp",
+        provider: c.type,
+        connectionName: c.name,
+        tools: tools.map((t) => ({
+          slug: t.slug,
+          displayName: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+      });
+      native.ok++;
+    } catch (e) {
+      native.failed++;
+      console.warn(
+        `[tool-reconcile] native ${c.type}/${c.name} (ws ${c.workspaceId}) failed:`,
+        e instanceof Error ? e.message : e,
+      );
+    }
+  }
+
+  // One Composio API key per workspace — fetch it once and reuse across that
+  // workspace's connections.
+  const keyByWorkspace = new Map<string, string | null>();
+  for (const c of await listAllActiveComposioConnections()) {
+    try {
+      let apiKey = keyByWorkspace.get(c.workspaceId);
+      if (apiKey === undefined) {
+        apiKey = await getWorkspaceSecretPlaintext(
+          c.workspaceId,
+          "composio_api_key",
+        );
+        keyByWorkspace.set(c.workspaceId, apiKey);
+      }
+      if (!apiKey) {
+        // No workspace Composio key — can't introspect; leave the cache as-is.
+        composio.failed++;
+        continue;
+      }
+      const tools = await fetchComposioToolkitTools(apiKey, c.toolkit);
+      await replaceToolsForConnection({
+        workspaceId: c.workspaceId,
+        userId: c.userId,
+        source: "composio",
+        provider: c.toolkit,
+        connectionName: c.name,
+        tools: tools.map((t) => ({
+          slug: t.slug,
+          displayName: t.name,
+          description: t.description,
+        })),
+      });
+      composio.ok++;
+    } catch (e) {
+      composio.failed++;
+      console.warn(
+        `[tool-reconcile] composio ${c.toolkit}/${c.name} (ws ${c.workspaceId}) failed:`,
+        e instanceof Error ? e.message : e,
+      );
+    }
+  }
+
+  return { native, composio };
+}
+
+/** Run a reconcile unless one ran within `maxAgeMs` (or one is in flight).
+ *  Stamps the completion time so the next trigger throttles off it. */
+export async function maybeReconcileToolCaches(maxAgeMs: number): Promise<void> {
+  if (inFlight) return;
+  if (isReconcileThrottled(await getLastToolReconcileAt(), Date.now(), maxAgeMs)) {
+    return;
+  }
+  inFlight = true;
+  try {
+    const { native, composio } = await reconcileAllToolCaches();
+    await markToolReconcile(new Date());
+    console.log(
+      `[tool-reconcile] done — native ${native.ok} ok / ${native.failed} failed, ` +
+        `composio ${composio.ok} ok / ${composio.failed} failed`,
+    );
+  } catch (e) {
+    console.error("[tool-reconcile] batch threw", e);
+  } finally {
+    inFlight = false;
+  }
+}


### PR DESCRIPTION
## Why
Cached tool catalogs (`workspace_mcp_tool` — powers the Tools tab + the `/for-agents` reference) only refreshed when someone clicked **Refresh** per connection. So `tembo-agent-studio`'s tools (which change every release) and Composio/native provider tools (which drift server-side) went stale until a manual refresh — e.g. the new `produce_inbox_item` `links` param from #224 wouldn't appear without a manual Refresh. You asked to force a refresh on deploys, for **all** connections (Composio included).

## What
A best-effort batch reconcile that re-introspects every active **native-MCP and Composio** connection and re-caches its tools — reusing the exact internals the per-connection Refresh buttons use (`fetchNativeMcpTools` / `fetchComposioToolkitTools` → `replaceToolsForConnection`):

- **On boot** (each deploy is a fresh process) — a release's tool/schema changes land immediately, and everything re-syncs.
- **Daily** via the existing in-process scheduler — catches external tools that change between deploys (your Composio point).

**Throttle:** a DB-stamped `instance_settings.last_tool_reconcile_at` (`migration 0066`) stops crash-loop restarts from re-storming provider APIs — **10-min floor** on boot, **24h** for the daily tick — while any real deploy (minutes+ apart) still refreshes. Plus an in-process in-flight guard so boot + a tick can't overlap.

**Resilient:** each connection runs in its own try/catch — an expired token, a provider being down, or a missing Composio key is logged and skipped; it never blocks boot or the other connections.

## Notes
- Runs only in the Node runtime (the scheduler is already gated to `NEXT_RUNTIME === "nodejs"` and single-process per the single-tenant model).
- New surface: `listAllActiveNativeConnections` / `listAllActiveComposioConnections`, `src/lib/tool-reconcile.ts`, two `instance-settings` throttle helpers, scheduler wiring.

## Test
- Unit test for the pure throttle decision (`isReconcileThrottled`).
- `tsc` clean, `vitest run` 133 passing, eslint clean, `cargo check` clean (migration embedded).

After this deploys, no more manual "Refresh" needed — `/for-agents/tembo-agent-studio.md` will show `links` (and every tool's params) on the next boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)