### PR TITLE
feat(runner): wire WebSearch capability into the pydantic runtime

### DIFF
--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -908,6 +908,67 @@ def _make_scaledown_processor(rate: str, min_chars: int):
     return process
 
 
+def _build_capabilities(spec: dict) -> list:
+    """Translate the AgentSpec `capabilities:` list into pydantic-ai capability
+    objects, passed to `Agent(capabilities=[...])`.
+
+    Today this wires `WebSearch` -> pydantic-ai's provider-adaptive WebSearch
+    capability: it uses the provider's native web search where available (e.g.
+    Anthropic's `web_search` on Claude, OpenAI's), with a local fallback
+    otherwise. Each entry is either a bare name (`WebSearch`) or a single-key map
+    (`WebSearch: { ...config }`) — the map's config is forwarded to the
+    capability when it accepts those kwargs. Unknown/uninwired capabilities
+    (e.g. `Thinking`, handled via model_settings) are logged and skipped — a typo
+    or an unsupported capability must never break agent construction.
+    """
+    caps = spec.get("capabilities")
+    if not isinstance(caps, list) or not caps:
+        return []
+    out: list = []
+    for entry in caps:
+        if isinstance(entry, str):
+            name, cfg = entry, {}
+        elif isinstance(entry, dict) and len(entry) == 1:
+            name, cfg = next(iter(entry.items()))
+            if not isinstance(cfg, dict):
+                cfg = {}
+        else:
+            print(
+                f"[capabilities] skipping unrecognized entry: {entry!r}",
+                file=sys.stderr,
+            )
+            continue
+        key = name.strip().lower() if isinstance(name, str) else ""
+        if key in ("websearch", "web_search"):
+            try:
+                from pydantic_ai.capabilities import WebSearch
+            except Exception as e:  # noqa: BLE001 — version skew must not be fatal
+                print(
+                    f"[capabilities] WebSearch unavailable in this pydantic-ai "
+                    f"build: {e}",
+                    file=sys.stderr,
+                )
+                continue
+            try:
+                out.append(WebSearch(**cfg) if cfg else WebSearch())
+            except TypeError as e:
+                # A config key the capability doesn't accept — fall back to the
+                # default rather than failing the whole run.
+                print(
+                    f"[capabilities] WebSearch config {cfg!r} rejected ({e}); "
+                    f"using defaults",
+                    file=sys.stderr,
+                )
+                out.append(WebSearch())
+            print("[capabilities] enabled WebSearch", file=sys.stderr)
+        else:
+            print(
+                f"[capabilities] '{name}' is not wired as a capability; ignoring",
+                file=sys.stderr,
+            )
+    return out
+
+
 def build_agent(
     spec: dict,
     toolsets: list | None = None,
@@ -940,10 +1001,14 @@ def build_agent(
     instructions reference services in natural language and the
     model can't connect them to the tool surface.
 
+    `capabilities:` is translated to pydantic-ai capabilities by
+    `_build_capabilities` — currently `WebSearch` -> the provider-adaptive
+    WebSearch capability. Other capabilities (e.g. `Thinking`) aren't wired here
+    yet.
+
     Out of scope for this MVP path:
       - output_schema (would need to dynamically build a Pydantic
         model from the JSON schema; defaulting to str output)
-      - capabilities (no general translation to builtin_tools yet)
       - deps_schema (deps come from the caller; runtime supplies none)
     """
     model = spec.get("model")
@@ -1027,6 +1092,13 @@ def build_agent(
     # docstring, so well-documented functions get good tool schemas.
     if tools:
         kwargs["tools"] = tools
+
+    # Provider-adaptive capabilities from `capabilities:` (e.g. WebSearch).
+    # These are model-side abilities (not MCP/sidecar) — pydantic-ai uses the
+    # provider's native implementation where available, with a local fallback.
+    capabilities = _build_capabilities(spec)
+    if capabilities:
+        kwargs["capabilities"] = capabilities
 
     # ScaleDown prompt compression — opt-in per agent via `scaledown:`, and only
     # when the workspace set a key. Any non-`off` mode attaches a history

--- a/api/tests/test_run_pydantic_build_agent.py
+++ b/api/tests/test_run_pydantic_build_agent.py
@@ -67,3 +67,34 @@ tools = [echo]
     )
 
     assert isinstance(agent, Agent)
+
+
+def test_build_capabilities_maps_websearch() -> None:
+    from pydantic_ai.capabilities import WebSearch
+
+    # Bare-name form and single-key-map form both map to the WebSearch capability.
+    for caps in (["WebSearch"], [{"WebSearch": {}}], ["web_search"]):
+        built = run_pydantic._build_capabilities({"capabilities": caps})
+        assert len(built) == 1
+        assert isinstance(built[0], WebSearch)
+
+
+def test_build_capabilities_ignores_unknown_and_empty() -> None:
+    # Unwired capabilities (handled elsewhere) and absent/empty lists yield none,
+    # and never raise — a typo must not break agent construction.
+    assert run_pydantic._build_capabilities({}) == []
+    assert run_pydantic._build_capabilities({"capabilities": []}) == []
+    assert run_pydantic._build_capabilities({"capabilities": ["Thinking"]}) == []
+    assert run_pydantic._build_capabilities({"capabilities": "WebSearch"}) == []
+
+
+def test_build_agent_attaches_websearch_capability() -> None:
+    agent = run_pydantic.build_agent(
+        {
+            "name": "searcher",
+            "model": "anthropic:claude-sonnet-4-5",
+            "instructions": "Search the web when current info is needed.",
+            "capabilities": ["WebSearch"],
+        }
+    )
+    assert isinstance(agent, Agent)


### PR DESCRIPTION
## Why
An agent reported it "doesn't have access to a web search tool." Tracing it: `capabilities: [WebSearch]` is **documented** in the agent guidance but was **never wired** — `build_agent` in the pydantic runner explicitly listed capabilities as *"out of scope (no translation to builtin_tools yet)"*, so the field was silently dropped and the agent ran with no web search.

## What
Translate the AgentSpec `capabilities:` list into pydantic-ai capability objects and pass them to `Agent(capabilities=[...])`:

- **`WebSearch`** → pydantic-ai's **provider-adaptive** WebSearch capability: native web search where the provider supports it (Anthropic `web_search` on Claude, OpenAI), local fallback otherwise.
- Accepts both spec shapes the guidance uses — bare name (`WebSearch`) and single-key map (`WebSearch: { ...config }`); the map's config is forwarded when the capability accepts it, else falls back to defaults.
- Unknown capabilities (e.g. `Thinking`, which is handled via `model_settings`) and typos are logged to stderr and skipped — **never fatal** to agent construction.

## Verified against the bundled runtime (pydantic-ai 1.102.0)
I installed `pydantic-ai[mcp]==1.102.0` and confirmed:
- `WebSearch` lives in `pydantic_ai.capabilities`; `Agent(capabilities=[WebSearch()])` is the **current, non-deprecated** API.
- The older `builtin_tools=[WebSearchTool()]` path is deprecated — so this PR uses the capabilities API directly.
- `Agent(capabilities=[WebSearch()])` constructs cleanly for both Anthropic and OpenAI models.

## Test
Added cases to `tests/test_run_pydantic_build_agent.py` (the pytest CI's "Pydantic runner smoke test" runs): WebSearch maps from both spec shapes, unknown/empty are ignored, and `build_agent` attaches it. All 7 pass against real pydantic-ai 1.102.0.

## Usage
An agent now gets web search by declaring:
```yaml
capabilities: [WebSearch]
```
(The guidance in `agent-guidance.ts` already recommends exactly this — it's now functional.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)