### PR TITLE
feat(for-agents): tokenless reference for self-key + opt-in public instances

### DIFF
--- a/web/src/app/for-agents/[provider]/route.ts
+++ b/web/src/app/for-agents/[provider]/route.ts
@@ -8,15 +8,19 @@ import {
   renderProviderMarkdown,
   type ForAgentsTool,
 } from "@/lib/for-agents-markdown";
+import { isForAgentsPublic } from "@/lib/config";
 import { getMcpProvider } from "@/lib/mcp-providers";
-import { listToolsForUser } from "@/lib/mcp-tools";
+import { listProviderToolCatalog, listToolsForUser } from "@/lib/mcp-tools";
 
-// Agent-facing native-MCP tool reference: GET /for-agents/<provider>.md?key=…
+// Agent-facing native-MCP tool reference: GET /for-agents/<provider>.md
 //
 // The create-agent prompt links CAP here so it can read a native MCP's exact
-// tool slugs (it can't introspect the provider's server). Auth is a signed,
-// expiring, workspace+user-scoped token in `?key=` (see lib/for-agents-token);
-// it unlocks only the cached tool catalog, nothing else. Served as text/markdown.
+// tool slugs + parameters (it can't introspect the provider's server). For
+// third-party providers, auth is a signed, expiring, workspace+user-scoped
+// bearer token (see lib/for-agents-token) that unlocks only that workspace's
+// cached tool catalog. The self-key provider (tembo-agent-studio) is TAS's own
+// MCP — its tools are identical for everyone and already public API, so its
+// reference is served WITHOUT a token. Served as text/markdown.
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -35,23 +39,36 @@ export async function GET(
   const { provider: raw } = await params;
   const slug = raw.replace(/\.md$/, "");
 
+  const provider = getMcpProvider(slug);
+  if (!provider) {
+    return text(`# Unknown provider\n\nNo native MCP provider \`${slug}\`.`, 404);
+  }
+
+  // Tokenless access is allowed when either:
+  //   - the provider is TAS's own self-key MCP (tembo-agent-studio) — its tools
+  //     are identical for everyone and already public API; or
+  //   - the instance opted into a public reference (isForAgentsPublic, e.g. our
+  //     dogfood box) — then every provider's reference is viewable.
+  // Otherwise a third-party reference stays gated (its tool list reveals which
+  // integrations a workspace connected).
+  const tokenlessOk = provider.authMode === "self-key" || isForAgentsPublic();
+
   const token = bearerFromHeader(request.headers.get("authorization"));
   const payload = token
     ? verifyForAgentsToken(token, Math.floor(Date.now() / 1000))
     : null;
-  if (!payload) {
+  if (!payload && !tokenlessOk) {
     return text(
       "# Unauthorized\n\nSend `Authorization: Bearer <token>`.",
       401,
     );
   }
 
-  const provider = getMcpProvider(slug);
-  if (!provider) {
-    return text(`# Unknown provider\n\nNo native MCP provider \`${slug}\`.`, 404);
-  }
-
-  const all = await listToolsForUser(payload.w, payload.u);
+  // With a token: the caller's own workspace catalog. Tokenless: the
+  // workspace-agnostic canonical catalog for the provider.
+  const all = payload
+    ? await listToolsForUser(payload.w, payload.u)
+    : await listProviderToolCatalog(slug);
   const seen = new Set<string>();
   const tools: ForAgentsTool[] = [];
   for (const t of all) {

--- a/web/src/app/for-agents/route.ts
+++ b/web/src/app/for-agents/route.ts
@@ -1,16 +1,17 @@
 import { type NextRequest } from "next/server";
 
-import { getPublicOrigin } from "@/lib/config";
+import { getPublicOrigin, isForAgentsPublic } from "@/lib/config";
 import { renderIndexMarkdown } from "@/lib/for-agents-markdown";
 import {
   bearerFromHeader,
   verifyForAgentsToken,
 } from "@/lib/for-agents-token";
 import { listMcpProviders } from "@/lib/mcp-providers";
-import { listToolsForUser } from "@/lib/mcp-tools";
+import { listCachedNativeProviders, listToolsForUser } from "@/lib/mcp-tools";
 
-// Agent-facing index: GET /for-agents?key=… → a linked list of the per-provider
-// tool-reference pages. Same signed-token auth as the provider pages.
+// Agent-facing index: GET /for-agents → a linked list of the per-provider
+// tool-reference pages. Token-gated by default; an instance can opt into a
+// public reference (isForAgentsPublic) — same rule as the provider pages.
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -20,16 +21,21 @@ export async function GET(request: NextRequest): Promise<Response> {
   const payload = token
     ? verifyForAgentsToken(token, Math.floor(Date.now() / 1000))
     : null;
-  if (!payload) {
+  if (!payload && !isForAgentsPublic()) {
     return new Response("# Unauthorized\n\nSend `Authorization: Bearer <token>`.", {
       status: 401,
       headers: { "content-type": "text/markdown; charset=utf-8" },
     });
   }
 
-  const all = await listToolsForUser(payload.w, payload.u);
+  // With a token: providers the caller's workspace has connected. Tokenless
+  // (public instance): every provider with cached tools.
   const connected = new Set(
-    all.filter((t) => t.source === "native-mcp").map((t) => t.provider),
+    payload
+      ? (await listToolsForUser(payload.w, payload.u))
+          .filter((t) => t.source === "native-mcp")
+          .map((t) => t.provider)
+      : await listCachedNativeProviders(),
   );
   const md = renderIndexMarkdown(
     `${getPublicOrigin()}/for-agents`,

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -12,6 +12,16 @@ export function isGoogleConfigured(): boolean {
   return Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
 }
 
+// When set, the /for-agents tool reference is served WITHOUT a token for every
+// provider (not just TAS's own self-key MCP), rendering the instance's
+// workspace-agnostic tool catalog. Off by default so customer instances keep
+// the reference token-gated (it reveals which integrations are connected); we
+// enable it on the internal dogfood instance for easy inspection.
+export function isForAgentsPublic(): boolean {
+  const v = process.env.TAS_FOR_AGENTS_PUBLIC?.trim().toLowerCase();
+  return v === "1" || v === "true";
+}
+
 // Instance admins, by env allowlist. Pure (no DB/session) so the auth
 // account-creation gate can import it without a cycle through
 // lib/session → lib/auth. lib/instance re-exports these alongside the

--- a/web/src/lib/mcp-tools.ts
+++ b/web/src/lib/mcp-tools.ts
@@ -153,6 +153,39 @@ export async function listToolsForWorkspace(
 }
 
 /**
+ * Workspace-agnostic tool catalog for a native-MCP provider — newest-refreshed
+ * cached row per slug, across all workspaces. Used by the tokenless /for-agents
+ * reference: always for the self-key (TAS-own) provider, and for any provider
+ * when the instance opts into a public reference (isForAgentsPublic). Not
+ * scoped to a workspace/user, so don't use it where per-workspace isolation
+ * matters.
+ */
+export async function listProviderToolCatalog(
+  provider: string,
+): Promise<McpTool[]> {
+  const { rows } = await db.query<Row>(
+    `SELECT DISTINCT ON (slug) ${COLUMNS}
+       FROM workspace_mcp_tool
+      WHERE source = 'native-mcp' AND provider = $1
+      ORDER BY slug ASC, refreshed_at DESC`,
+    [provider],
+  );
+  return rows.map(rowToTool);
+}
+
+/** Every native-MCP provider that has any cached tools across the instance —
+ *  the workspace-agnostic "which providers are connected" set for the tokenless
+ *  /for-agents index. */
+export async function listCachedNativeProviders(): Promise<string[]> {
+  const { rows } = await db.query<{ provider: string }>(
+    `SELECT DISTINCT provider
+       FROM workspace_mcp_tool
+      WHERE source = 'native-mcp'`,
+  );
+  return rows.map((r) => r.provider);
+}
+
+/**
  * Distinct tool-slug → (source, provider) across the whole workspace's tool
  * cache, for resolving a run's recorded tool_name to the provider whose logo
  * to show. Workspace-wide (not per-user) because a tool slug maps to the same


### PR DESCRIPTION
## Why
You wanted to view the `/for-agents` tool reference on the dogfood instance without minting/passing a token. It was token-gated for every provider.

## What
- **Self-key provider always tokenless** — `tembo-agent-studio` is TAS's own MCP; its tools are identical for everyone and already public API, so its reference no longer needs a token.
- **`TAS_FOR_AGENTS_PUBLIC` instance flag** — when set, the **whole** reference (index + every provider page) is tokenless, rendering the instance's workspace-agnostic tool catalog. **Off by default** so customer instances stay gated (a third-party tool list reveals which integrations a workspace connected). We enable it on tembo-tas.

Tokenless reads use workspace-agnostic helpers (`listProviderToolCatalog` / `listCachedNativeProviders` — newest-refreshed row per slug across all workspaces). A valid token still works everywhere and still scopes third-party refs to the caller's workspace.

## Follow-up (ops)
After merge + deploy, set `TAS_FOR_AGENTS_PUBLIC=1` on the tembo-tas **web** service so the dogfood reference is fully public.

## Test
`tsc` clean, `vitest run` 133 passing, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)