### PR TITLE
feat(inbox): advance-to-next on resolve + multi-select mass-dismiss

### DIFF
--- a/web/src/app/[workspace]/inbox/[id]/page.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import { LocalTime } from "@/components/local-time";
 import { McpProviderLogo } from "@/components/mcp-provider-logo";
-import { getInboxItem } from "@/lib/inbox-api";
+import { getInboxItem, listInboxItems, type InboxItem } from "@/lib/inbox-api";
 import { getServerSession } from "@/lib/session";
 import { getWorkspaceBySlug } from "@/lib/workspace";
 
@@ -11,6 +11,15 @@ import { ContextView } from "./context-view";
 import { ReviewForm } from "./review-form";
 
 export const dynamic = "force-dynamic";
+
+// Drop currently-snoozed items (snoozed_until in the future) from the triage
+// queue. Module-scope so `Date.now()` stays out of the server component's render.
+function unsnoozed(items: InboxItem[]): InboxItem[] {
+  const now = Date.now();
+  return items.filter(
+    (i) => !i.snoozedUntil || i.snoozedUntil.getTime() <= now,
+  );
+}
 
 // Inbox item detail: the raw context to review, plus a form pre-filled with the
 // agent's proposed action. The human edits and submits (or dismisses); the diff
@@ -33,6 +42,28 @@ export default async function InboxItemPage({
   if (!item) notFound();
 
   const resolved = item.status === "done" || item.status === "dismissed";
+
+  // For an active item, find the next one to triage so resolving this one
+  // advances the user through their queue (and show how many remain). "Next" is
+  // the item after this one in the active list's default order (created desc),
+  // skipping snoozed items. None left → back to the index.
+  let nextHref = `/${workspace.slug}/inbox`;
+  let remaining = 0;
+  if (!resolved) {
+    const active = await listInboxItems(
+      workspace.id,
+      session.user.id,
+      { statuses: ["open", "claimed", "awaiting_human"] },
+      500,
+    );
+    const queue = unsnoozed(active);
+    const idx = queue.findIndex((i) => i.id === item.id);
+    const after =
+      idx >= 0 ? queue.slice(idx + 1) : queue.filter((i) => i.id !== item.id);
+    const nextId = after[0]?.id ?? null;
+    if (nextId) nextHref = `/${workspace.slug}/inbox/${nextId}`;
+    remaining = Math.max(0, queue.length - 1);
+  }
 
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8">
@@ -62,6 +93,13 @@ export default async function InboxItemPage({
         <p className="text-foreground-weak text-sm">
           Created <LocalTime iso={item.createdAt.toISOString()} style="relative" />
         </p>
+        {!resolved && (
+          <p className="text-foreground-muted text-sm">
+            {remaining > 0
+              ? `${remaining} more in your inbox`
+              : "Last one in your inbox"}
+          </p>
+        )}
       </div>
 
       {item.links && item.links.length > 0 && (
@@ -112,6 +150,7 @@ export default async function InboxItemPage({
           itemId={item.id}
           proposedText={item.proposedAction?.text ?? ""}
           options={item.options}
+          nextHref={nextHref}
         />
       )}
     </div>

--- a/web/src/app/[workspace]/inbox/[id]/review-form.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/review-form.tsx
@@ -64,11 +64,15 @@ export function ReviewForm({
   itemId,
   proposedText,
   options,
+  nextHref,
 }: {
   workspaceSlug: string;
   itemId: string;
   proposedText: string;
   options?: InboxOption[] | null;
+  /** Where to go after resolving this item — the next item to triage, or the
+   *  inbox index when none remain. */
+  nextHref: string;
 }) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -94,11 +98,12 @@ export function ReviewForm({
         return;
       }
       if (r.ok) {
-        // Confirm, then navigate to the inbox. (No router.refresh() — calling it
+        // Confirm, then advance to the next item to triage (or the index when
+        // none remain — nextHref handles both). No router.refresh() — calling it
         // right after push races and re-renders this page instead of landing on
-        // the list. force-dynamic on /inbox gives fresh data on navigation.)
+        // the target. force-dynamic gives fresh data on navigation.
         toast.success(successMsg ?? "Done");
-        router.push(`/${workspaceSlug}/inbox`);
+        router.push(nextHref);
       } else {
         setBusy(null);
         setError(r.error);

--- a/web/src/app/[workspace]/inbox/actions.ts
+++ b/web/src/app/[workspace]/inbox/actions.ts
@@ -9,6 +9,7 @@ import {
   completeInboxItem,
   countActiveInboxItems,
   dismissInboxItem,
+  dismissInboxItems,
   getInboxItem,
   snoozeInboxItem,
 } from "@/lib/inbox-api";
@@ -98,6 +99,46 @@ export async function dismissInboxItemAction(args: {
 
   revalidateInbox(args.workspaceSlug);
   return { ok: true };
+}
+
+export type BulkDismissResult =
+  | { ok: true; dismissed: number }
+  | { ok: false; error: string };
+
+/** Mass-dismiss the selected inbox items (the index multi-select). Operator+;
+ *  owner-scoped (you can only dismiss your own items). Already-resolved ids are
+ *  skipped. Audits each actually-dismissed item. */
+export async function bulkDismissInboxItemsAction(args: {
+  workspaceSlug: string;
+  itemIds: string[];
+}): Promise<BulkDismissResult> {
+  const ids = Array.from(new Set(args.itemIds)).filter(Boolean);
+  if (ids.length === 0) return { ok: true, dismissed: 0 };
+
+  const auth = await authorizeWorkspace(args.workspaceSlug, "operator");
+  if (!auth.ok) {
+    if (auth.reason === "denied") return { ok: false, error: DENIED_MESSAGE };
+    notFound();
+  }
+  const { workspace, userId } = auth;
+
+  const dismissed = await dismissInboxItems(ids, workspace.id, userId);
+  await Promise.all(
+    dismissed.map((id) =>
+      writeAuditEvent({
+        workspaceId: workspace.id,
+        actorUserId: userId,
+        source: "hitl_response",
+        kind: "inbox.dismissed",
+        targetType: "inbox_item",
+        targetId: id,
+        agentName: null,
+      }),
+    ),
+  );
+
+  revalidateInbox(args.workspaceSlug);
+  return { ok: true, dismissed: dismissed.length };
 }
 
 // The human picked an action-menu button. Look up the chosen option ON THE

--- a/web/src/app/[workspace]/inbox/inbox-list.tsx
+++ b/web/src/app/[workspace]/inbox/inbox-list.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 import { LocalTime } from "@/components/local-time";
 import { McpProviderLogo } from "@/components/mcp-provider-logo";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { DataTable, type Column, type SortDir } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+
+import { bulkDismissInboxItemsAction } from "./actions";
 
 // Search / filter / facet for the Tasks Inbox. The table chrome, row hover,
 // whole-row click, and sortable headers all come from the shared DataTable.
@@ -59,6 +64,12 @@ export function InboxList({
   const [typeFilter, setTypeFilter] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("created");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const router = useRouter();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [dismissing, startDismiss] = useTransition();
+  // Terminal facets aren't dismissable, so selection is disabled there.
+  const selectionEnabled = facet !== "done" && facet !== "dismissed";
 
   const counts = useMemo(() => {
     const c = {
@@ -140,6 +151,41 @@ export function InboxList({
       setSortKey(k);
       setSortDir(k === "created" ? "desc" : "asc");
     }
+  }
+
+  // Selection acts on the CURRENT view: derive the visible subset so switching
+  // facet/filter/search naturally drops out-of-view selections (and never
+  // dismisses a row the user can't see).
+  const effectiveSelected = useMemo(() => {
+    const visible = new Set(filtered.map((i) => i.id));
+    return new Set([...selected].filter((id) => visible.has(id)));
+  }, [selected, filtered]);
+  const allSelected =
+    filtered.length > 0 && filtered.every((i) => effectiveSelected.has(i.id));
+  function toggleRow(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function toggleAll() {
+    setSelected(allSelected ? new Set() : new Set(filtered.map((i) => i.id)));
+  }
+  function bulkDismiss() {
+    const itemIds = [...effectiveSelected];
+    if (itemIds.length === 0) return;
+    startDismiss(async () => {
+      const r = await bulkDismissInboxItemsAction({ workspaceSlug, itemIds });
+      if (r.ok) {
+        toast.success(`Dismissed ${r.dismissed} item${r.dismissed === 1 ? "" : "s"}`);
+        setSelected(new Set());
+        router.refresh();
+      } else {
+        toast.error(r.error);
+      }
+    });
   }
 
   const columns: Column<InboxRow>[] = [
@@ -244,6 +290,29 @@ export function InboxList({
         })}
       </div>
 
+      {selectionEnabled && effectiveSelected.size > 0 && (
+        <div className="bg-surface-raised border-border flex items-center gap-3 rounded-lg border px-3 py-2">
+          <span className="text-foreground text-sm font-medium">
+            {effectiveSelected.size} selected
+          </span>
+          <Button
+            size="small"
+            variant="destructive"
+            disabled={dismissing}
+            onClick={bulkDismiss}
+          >
+            {dismissing ? "Dismissing…" : "Dismiss"}
+          </Button>
+          <button
+            type="button"
+            onClick={() => setSelected(new Set())}
+            className="text-foreground-weak hover:text-foreground text-sm"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
       <DataTable
         columns={columns}
         rows={filtered}
@@ -252,6 +321,10 @@ export function InboxList({
         sortKey={sortKey}
         sortDir={sortDir}
         onSort={onSort}
+        selectedKeys={selectionEnabled ? effectiveSelected : undefined}
+        onToggleRow={selectionEnabled ? toggleRow : undefined}
+        allSelected={allSelected}
+        onToggleAll={toggleAll}
         empty={
           <div className="text-foreground-weak rounded-lg border border-dashed border-[var(--color-border)] px-4 py-8 text-center text-sm">
             No items match these filters.

--- a/web/src/components/ui/data-table.tsx
+++ b/web/src/components/ui/data-table.tsx
@@ -52,6 +52,17 @@ export type DataTableProps<T> = {
   rowClassName?: (row: T) => string;
   /** Shown in place of the table body when there are no rows. */
   empty?: ReactNode;
+  // ── Row selection (opt-in: pass both selectedKeys + onToggleRow) ──
+  /** The currently-selected row keys. Presence enables a leading checkbox
+   *  column. Selection state is owned by the caller. */
+  selectedKeys?: Set<string>;
+  /** Toggle one row's selection. The checkbox stops click propagation so it
+   *  never triggers rowHref/onRowClick navigation. */
+  onToggleRow?: (key: string) => void;
+  /** Whether every current row is selected (drives the header checkbox). */
+  allSelected?: boolean;
+  /** Toggle select-all / clear-all over the current rows. */
+  onToggleAll?: () => void;
 };
 
 export function DataTable<T>({
@@ -66,7 +77,12 @@ export function DataTable<T>({
   onSort,
   rowClassName,
   empty,
+  selectedKeys,
+  onToggleRow,
+  allSelected = false,
+  onToggleAll,
 }: DataTableProps<T>) {
+  const selectable = !!selectedKeys && !!onToggleRow;
   const router = useRouter();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
@@ -87,6 +103,17 @@ export function DataTable<T>({
       <table className="w-full text-sm">
         <thead className="bg-surface-secondary text-foreground-weak text-sm uppercase tracking-wide">
           <tr>
+            {selectable && (
+              <th className="w-9 px-3 py-2">
+                <input
+                  type="checkbox"
+                  aria-label="Select all rows"
+                  checked={allSelected}
+                  onChange={() => onToggleAll?.()}
+                  className="cursor-pointer align-middle"
+                />
+              </th>
+            )}
             {columns.map((col) => {
               const isSorted = sortKey === col.key;
               const align = col.align === "right" ? "text-right" : "text-left";
@@ -144,6 +171,20 @@ export function DataTable<T>({
                     rowClassName?.(row),
                   )}
                 >
+                  {selectable && (
+                    <td className="w-9 px-3 py-2 align-top">
+                      <input
+                        type="checkbox"
+                        aria-label="Select row"
+                        checked={selectedKeys!.has(key)}
+                        // Stop propagation so toggling selection never triggers
+                        // the row's navigation/expand handler.
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={() => onToggleRow!(key)}
+                        className="cursor-pointer align-middle"
+                      />
+                    </td>
+                  )}
                   {columns.map((col) => (
                     <td
                       key={col.key}
@@ -159,7 +200,10 @@ export function DataTable<T>({
                 </tr>
                 {canExpand && expanded.has(key) && (
                   <tr className="bg-surface-raised">
-                    <td colSpan={columns.length} className="px-3 pb-3">
+                    <td
+                      colSpan={columns.length + (selectable ? 1 : 0)}
+                      className="px-3 pb-3"
+                    >
                       {renderExpanded!(row)}
                     </td>
                   </tr>

--- a/web/src/lib/inbox-api.ts
+++ b/web/src/lib/inbox-api.ts
@@ -468,6 +468,27 @@ export async function dismissInboxItem(
   return (res.rowCount ?? 0) > 0;
 }
 
+/** Bulk-dismiss several of the owner's items in one statement (the inbox
+ *  multi-select). Owner-scoped and skips already-resolved rows, like the
+ *  single dismiss. Returns the ids actually dismissed (so the caller can audit
+ *  + report an accurate count). */
+export async function dismissInboxItems(
+  ids: string[],
+  workspaceId: string,
+  ownerUserId: string,
+): Promise<string[]> {
+  if (ids.length === 0) return [];
+  const res = await db.query<{ id: string }>(
+    `UPDATE inbox_item
+        SET status = 'dismissed', resolved_at = NOW(), updated_at = NOW()
+      WHERE id = ANY($1::uuid[]) AND workspace_id = $2 AND owner_user_id = $3
+        AND status NOT IN ('done', 'dismissed')
+      RETURNING id`,
+    [ids, workspaceId, ownerUserId],
+  );
+  return res.rows.map((r) => r.id);
+}
+
 // ── Learning-loop signal gathering (scheduler) ────────────────────────
 
 /**


### PR DESCRIPTION
Builds the two saved inbox-triage backlog TODOs.

## 1. Advance to the next item on resolve (+ a counter)
Resolving an item — submit, run an option, dismiss, or snooze — now **advances to the next active item** to triage instead of bouncing back to the index. The detail page shows **"N more in your inbox"** (or "Last one in your inbox"). "Next" is the item after the current one in the active list's default order (created desc), skipping snoozed items; when none remain it returns to the index.

## 2. Multi-select mass-dismiss on the index
The list gains **row checkboxes** + a **"Dismiss" bulk-action bar** ("N selected"). Selection is:
- **owner-scoped** — you can only dismiss your own items (the action + query enforce `owner_user_id`);
- **view-scoped** — switching facet/filter/search drops out-of-view selections, so you can't dismiss a row you can't see (derived `effectiveSelected`, no setState-in-effect);
- **disabled on terminal facets** (Done/Dismissed).

## Implementation
- Shared `DataTable` gains **opt-in selection** (`selectedKeys` + `onToggleRow` + `allSelected`/`onToggleAll`) — a leading checkbox column whose clicks `stopPropagation` so they never trigger row navigation. Backward-compatible (all new props optional).
- New `dismissInboxItems` (bulk, owner-scoped, `RETURNING id`) and `bulkDismissInboxItemsAction` (operator+, audits each actually-dismissed item, reports an accurate count).
- `ReviewForm` takes a server-computed `nextHref`.

## Test
`tsc` clean, `vitest run` 133 passing, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)