### PR TITLE
feat(inbox): auto-extract links from item content into the links list

### DIFF
--- a/web/src/lib/api-v1/actions.test.ts
+++ b/web/src/lib/api-v1/actions.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/audit-db", () => ({ writeAuditEvent: vi.fn() }));
 
 import {
   createAutomationFor,
+  extractInboxLinks,
   sanitizeInboxLinks,
 } from "@/lib/api-v1/actions";
 import { createAutomation } from "@/lib/automations-api";
@@ -137,5 +138,53 @@ describe("sanitizeInboxLinks", () => {
       url: `https://example.com/${i}`,
     }));
     expect(sanitizeInboxLinks(many)).toHaveLength(50);
+  });
+
+  it("de-dupes by url, keeping the first (labelled) occurrence", () => {
+    expect(
+      sanitizeInboxLinks([
+        { label: "First", url: "https://x.com/a" },
+        { url: "https://x.com/a" },
+        { label: "Other", url: "https://x.com/b" },
+      ]),
+    ).toEqual([
+      { label: "First", url: "https://x.com/a" },
+      { label: "Other", url: "https://x.com/b" },
+    ]);
+  });
+});
+
+describe("extractInboxLinks", () => {
+  const base = { itemType: "t", title: "t" };
+
+  it("pulls Markdown links (with labels) and bare urls from the proposed text", () => {
+    const links = extractInboxLinks({
+      ...base,
+      proposedAction: {
+        text: "See [ENG-1](https://linear.app/a) and https://example.com/b.",
+      },
+    });
+    expect(links).toContainEqual({ label: "ENG-1", url: "https://linear.app/a" });
+    // Bare url with trailing sentence punctuation trimmed.
+    expect(links).toContainEqual({ url: "https://example.com/b" });
+  });
+
+  it("pulls bare urls out of the context payload", () => {
+    const links = extractInboxLinks({
+      ...base,
+      context: { stories: [{ url: "https://news.site/x" }] },
+    });
+    expect(links).toContainEqual({ url: "https://news.site/x" });
+  });
+
+  it("merges + de-dupes through sanitizeInboxLinks (Markdown label wins over a bare dupe)", () => {
+    const input = {
+      ...base,
+      proposedAction: { text: "[ENG-1](https://linear.app/a)" },
+      context: { ref: "https://linear.app/a" },
+    };
+    expect(sanitizeInboxLinks(extractInboxLinks(input))).toEqual([
+      { label: "ENG-1", url: "https://linear.app/a" },
+    ]);
   });
 });

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -523,7 +523,8 @@ export type ProduceInboxItemInput = {
   parentRunId?: string;
 };
 
-// Keep only well-formed http(s) links, drop the rest, and cap the count. The
+// Keep only well-formed http(s) links, de-dupe by url (first occurrence wins, so
+// an explicit or labelled link beats a later bare one), and cap the count. The
 // url reaches an <a href> directly, so a non-http(s) scheme (javascript:,
 // data:) must never be stored. Returns null when nothing survives so the column
 // stays clean.
@@ -533,6 +534,7 @@ export function sanitizeInboxLinks(
 ): InboxLink[] | null {
   if (!Array.isArray(links) || links.length === 0) return null;
   const clean: InboxLink[] = [];
+  const seen = new Set<string>();
   for (const l of links) {
     const url = typeof l?.url === "string" ? l.url.trim() : "";
     let parsed: URL;
@@ -542,11 +544,35 @@ export function sanitizeInboxLinks(
       continue;
     }
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") continue;
+    if (seen.has(url)) continue;
+    seen.add(url);
     const label = typeof l?.label === "string" ? l.label.trim() : "";
     clean.push(label ? { label, url } : { url });
     if (clean.length >= MAX_INBOX_LINKS) break;
   }
   return clean.length > 0 ? clean : null;
+}
+
+// Pull every link out of an item's content so the human gets a clickable Links
+// list even when the agent didn't populate `links` explicitly. Sources: the
+// proposed-action text (Markdown `[label](url)` keeps its label; bare urls too)
+// and the raw context payload (bare urls). De-duping + http(s)-only filtering
+// happens in sanitizeInboxLinks once these are merged with any explicit links.
+const MARKDOWN_LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+const BARE_URL_RE = /https?:\/\/[^\s)"'<>\]]+/g;
+export function extractInboxLinks(input: ProduceInboxItemInput): InboxLink[] {
+  const out: InboxLink[] = [];
+  const text = input.proposedAction?.text ?? "";
+  // Markdown links first so their label is what survives de-duping.
+  for (const m of text.matchAll(MARKDOWN_LINK_RE)) {
+    out.push({ label: m[1].trim(), url: m[2] });
+  }
+  // Bare urls across the proposed text + the raw context payload.
+  const haystack = `${text} ${JSON.stringify(input.context ?? {})}`;
+  for (const m of haystack.matchAll(BARE_URL_RE)) {
+    out.push({ url: m[0].replace(/[.,;:!?]+$/, "") }); // trim trailing punctuation
+  }
+  return out;
 }
 
 export async function produceInboxItemFor(
@@ -569,7 +595,12 @@ export async function produceInboxItemFor(
     context: input.context ?? {},
     proposedAction: input.proposedAction ?? null,
     options: input.options ?? null,
-    links: sanitizeInboxLinks(input.links),
+    // Explicit links first (they win de-duping + keep their labels), then every
+    // link auto-extracted from the item's text + context.
+    links: sanitizeInboxLinks([
+      ...(input.links ?? []),
+      ...extractInboxLinks(input),
+    ]),
     externalTs: input.externalTs ?? null,
     // A proposal (or an action menu) ready for review is awaiting_human;
     // otherwise it's open for a human or agent to pick up and propose against.


### PR DESCRIPTION
## Why
The `links` Links list (#223) only populated when an agent set the `links` field explicitly. But agents often put links in their **proposed text** (a Markdown link list) or the **context payload** — like the `link-list-test` agent did — so the nice clickable Links section stayed empty. You asked: auto-extract any links in an item into the `links` collection, de-duped.

## What
At produce time (`produceInboxItemFor` — the single choke point for both MCP `produce_inbox_item` and the REST endpoint), `extractInboxLinks` pulls:
- **Markdown `[label](url)`** from the proposed-action text — keeping the label;
- **bare `http(s)` urls** from the proposed text **and** the raw context payload (trailing sentence punctuation trimmed).

These merge with any explicit `links` (explicit first) and run through `sanitizeInboxLinks`, which now **de-dupes by url** (first/labelled occurrence wins) on top of the existing http(s)-only filter + 50 cap. So:
- a url in both an explicit link and the text → explicit wins (keeps its label);
- a url as both a Markdown link and a bare dupe → the labelled Markdown one wins;
- `javascript:`/`data:`/malformed are still dropped.

## Test
New `extractInboxLinks` cases + a dedupe case; `vitest` 137 passing, `tsc` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)