### PR TITLE
feat(inbox): always offer a first-class Dismiss on the item detail page

### DIFF
--- a/web/src/app/[workspace]/inbox/[id]/review-form.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/review-form.tsx
@@ -137,13 +137,65 @@ export function ReviewForm({
   return (
     <div className="flex flex-col gap-5">
       {section}
-      <SnoozeControl
-        workspaceSlug={workspaceSlug}
-        itemId={itemId}
-        pending={pending}
-        busy={busy}
-        run={run}
-      />
+      {/* "Not acting on it" escapes, always available regardless of the agent's
+          options: dismiss (drop, no learning signal, won't reopen) + snooze. */}
+      <div className="border-border-weak flex flex-col gap-3 border-t pt-4">
+        <DismissControl
+          workspaceSlug={workspaceSlug}
+          itemId={itemId}
+          pending={pending}
+          busy={busy}
+          run={run}
+        />
+        <SnoozeControl
+          workspaceSlug={workspaceSlug}
+          itemId={itemId}
+          pending={pending}
+          busy={busy}
+          run={run}
+        />
+      </div>
+    </div>
+  );
+}
+
+// Always-available Dismiss: drop the item without acting on it (no learning
+// signal, and a re-push won't bring it back). Distinct from the agent's options
+// (Archive/Reply/Ignore), which resolve the item as 'done' + train the agent.
+function DismissControl({
+  workspaceSlug,
+  itemId,
+  pending,
+  busy,
+  run,
+}: {
+  workspaceSlug: string;
+  itemId: string;
+  pending: boolean;
+  busy: string | null;
+  run: (
+    key: string,
+    fn: () => Promise<InboxActionResult>,
+    successMsg?: string,
+  ) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-foreground-weak text-sm">Not relevant?</span>
+      <Button
+        type="button"
+        variant="secondary"
+        disabled={pending}
+        onClick={() =>
+          run(
+            "dismiss",
+            () => dismissInboxItemAction({ workspaceSlug, itemId }),
+            "Dismissed",
+          )
+        }
+      >
+        {busy === "dismiss" ? "Dismissing…" : "Dismiss"}
+      </Button>
     </div>
   );
 }
@@ -170,7 +222,7 @@ function SnoozeControl({
   const [hours, setHours] = useState(72);
   const label = SNOOZE_OPTIONS.find((o) => o.hours === hours)?.label ?? "a while";
   return (
-    <div className="border-border-weak flex flex-wrap items-center gap-2 border-t pt-4">
+    <div className="flex flex-wrap items-center gap-2">
       <span className="text-foreground-weak text-sm">Not now — snooze for</span>
       <select
         value={hours}
@@ -230,12 +282,6 @@ function ActionMenu({
   const replyOpts = options.filter((o) => o.kind === "reply").sort(byRec);
   const clickOpts = options.filter((o) => o.kind === "oneclick").sort(byRec);
   const [draft, setDraft] = useState(replyOpts.find((o) => o.draft)?.draft ?? "");
-  // Offer a built-in Dismiss only when the agent gave NO one-click action at all
-  // (e.g. a reply-only item) — a safety escape so such an item can still be
-  // cleared without acting. When the agent DID provide one-click buttons
-  // (Archive, Complete, Ignore, an explicit Dismiss…), those define how to clear
-  // the item and we don't add our own.
-  const hasOneClick = options.some((o) => o.kind === "oneclick");
 
   return (
     <section className="flex flex-col gap-4">
@@ -308,25 +354,6 @@ function ActionMenu({
         </div>
       )}
 
-      {!hasOneClick && (
-        <div className="flex flex-wrap gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            disabled={pending}
-            onClick={() =>
-              run(
-                "dismiss",
-                () => dismissInboxItemAction({ workspaceSlug, itemId }),
-                "Dismissed",
-              )
-            }
-          >
-            {busy === "dismiss" ? "Dismissing…" : "Dismiss"}
-          </Button>
-        </div>
-      )}
-
       {error && <ErrorBanner error={error} />}
     </section>
   );
@@ -385,20 +412,6 @@ function FreeTextForm({
           }
         >
           {busy === "submit" ? "Submitting…" : "Submit"}
-        </Button>
-        <Button
-          type="button"
-          variant="secondary"
-          disabled={pending}
-          onClick={() =>
-            run(
-              "dismiss",
-              () => dismissInboxItemAction({ workspaceSlug, itemId }),
-              "Dismissed",
-            )
-          }
-        >
-          Dismiss
         </Button>
       </div>
       {error && <ErrorBanner error={error} />}


### PR DESCRIPTION
## Why
You asked whether Dismiss is first-class — it is in the data model (`dismissed` is a terminal status distinct from `done`: it records **no learning signal** and the item **never re-opens**) and it's always available from the index. But the **detail page** hid its Dismiss button whenever the agent supplied a one-click option, so an item with **"Archive"/"Ignore"** could only be cleared via those options — which resolve it to `done` (a learning signal), not dismissed. That's why Archive read like an "unofficial dismiss."

## What
Always render a low-emphasis **"Not relevant? Dismiss"** in the detail footer (grouped with Snooze), in both the action-menu and free-text modes.

- Removes the `hasOneClick` gate in `ActionMenu` and the inline Dismiss in `FreeTextForm` in favor of one shared `DismissControl`.
- Archive/Reply/Ignore stay **`done`** actions (they run real ops + train the agent); Dismiss stays the **drop-without-signal, never-reopen** escape.
- Reuses the existing `dismissInboxItemAction` and the advance-to-next `run` helper (so Dismiss flows to the next item too).
- **UI-only** — no DB/API/serializer change; the dismiss status + paths are untouched.

## Test
`tsc` clean, `vitest` 137 passing, eslint clean. Manual: an item with Archive/Ignore options now shows Dismiss in the footer → sets status `dismissed` + advances to next; reply-only items keep Dismiss (now in the footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)