### PR TITLE
security: fix ReDoS in inbox link extraction (CodeQL #74)

### DIFF
--- a/web/src/lib/api-v1/actions.test.ts
+++ b/web/src/lib/api-v1/actions.test.ts
@@ -169,6 +169,20 @@ describe("extractInboxLinks", () => {
     expect(links).toContainEqual({ url: "https://example.com/b" });
   });
 
+  it("trims only TRAILING sentence punctuation, fast (no ReDoS) on a long run", () => {
+    // A long internal run of punctuation chars not at end-of-string was the
+    // quadratic-backtracking case for the old /[.,;:!?]+$/ regex (alert #74).
+    const url = `https://example.com/${"!".repeat(50_000)}x`;
+    const started = performance.now();
+    const links = extractInboxLinks({
+      ...base,
+      proposedAction: { text: `${url}... trailing` },
+    });
+    // Trailing dots stripped; the internal "!!!…x" is left intact.
+    expect(links).toContainEqual({ url });
+    expect(performance.now() - started).toBeLessThan(500);
+  });
+
   it("pulls bare urls out of the context payload", () => {
     const links = extractInboxLinks({
       ...base,

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -560,6 +560,16 @@ export function sanitizeInboxLinks(
 // happens in sanitizeInboxLinks once these are merged with any explicit links.
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
 const BARE_URL_RE = /https?:\/\/[^\s)"'<>\]]+/g;
+// Sentence punctuation to strip off the tail of a bare URL (e.g. "see
+// https://x/foo."). Done with a linear scan rather than an anchored
+// `/[.,;:!?]+$/` regex, whose greedy `+` backtracks quadratically on a long run
+// of these chars not at end-of-string — a ReDoS on agent-supplied content.
+const TRAILING_PUNCT = new Set([".", ",", ";", ":", "!", "?"]);
+function trimTrailingPunct(s: string): string {
+  let end = s.length;
+  while (end > 0 && TRAILING_PUNCT.has(s[end - 1])) end--;
+  return s.slice(0, end);
+}
 export function extractInboxLinks(input: ProduceInboxItemInput): InboxLink[] {
   const out: InboxLink[] = [];
   const text = input.proposedAction?.text ?? "";
@@ -570,7 +580,7 @@ export function extractInboxLinks(input: ProduceInboxItemInput): InboxLink[] {
   // Bare urls across the proposed text + the raw context payload.
   const haystack = `${text} ${JSON.stringify(input.context ?? {})}`;
   for (const m of haystack.matchAll(BARE_URL_RE)) {
-    out.push({ url: m[0].replace(/[.,;:!?]+$/, "") }); // trim trailing punctuation
+    out.push({ url: trimTrailingPunct(m[0]) });
   }
   return out;
 }


### PR DESCRIPTION
Addresses code-scanning alert **#74** — `js/polynomial-redos` (high) at `web/src/lib/api-v1/actions.ts:573`, introduced by the auto-extract feature (#230).

## Cause
`extractInboxLinks` trimmed trailing sentence punctuation off each bare URL with `m[0].replace(/[.,;:!?]+$/, "")`. The greedy `+` + end-anchor backtracks **quadratically** when the matched URL contains a long run of `.,;:!?` not at end-of-string — and the URL comes from **agent-supplied** content via `produce_inbox_item`, so it's attacker-influenced.

## Fix
Replace the anchored regex with a **linear trailing-punctuation scan** (`trimTrailingPunct`) — identical trimming, no backtracking. (`BARE_URL_RE` / `MARKDOWN_LINK_RE` are single char-class repetitions → already linear, untouched.)

## Test
New regression test: a 50,000-char internal `!` run is trimmed correctly **and** returns in <500ms. `vitest` 138 passing, `tsc` clean, eslint clean. CodeQL re-scans on merge and should auto-close #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)