### PR TITLE
release: bump compose.release.yaml default to 2026.6.28

### DIFF
--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -43,7 +43,7 @@ services:
       retries: 10
 
   api:
-    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-api:${TAS_VERSION:-2026.6.27}
+    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-api:${TAS_VERSION:-2026.6.28}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -63,7 +63,7 @@ services:
       start_period: 30s
 
   web:
-    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-web:${TAS_VERSION:-2026.6.27}
+    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-web:${TAS_VERSION:-2026.6.28}
     restart: unless-stopped
     depends_on:
       api:


### PR DESCRIPTION
Point the self-host `compose.release.yaml` default image tag at the published `2026.6.28` images ([release](https://github.com/tembo/agent-studio/releases/tag/v2026.6.28)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)