### PR TITLE
feat(agents): copy button on the Definition tab

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/definition/page.tsx
@@ -71,6 +71,7 @@ export default async function AgentDefinitionPage({
       id: "draft",
       label: draftDiffers ? "Draft (current file)" : "Draft",
       block: <HighlightedCodeBlock source={raw} language={specLanguage} />,
+      source: raw,
     },
     ...versions.map((v) => ({
       id: `v${v.versionNumber}`,
@@ -81,6 +82,7 @@ export default async function AgentDefinitionPage({
       block: (
         <HighlightedCodeBlock source={v.specContent} language={specLanguage} />
       ),
+      source: v.specContent,
     })),
   ];
 

--- a/web/src/app/[workspace]/agents/[agent]/definition/spec-version-viewer.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/definition/spec-version-viewer.tsx
@@ -2,14 +2,21 @@
 
 import { useState, type ReactNode } from "react";
 
+import { CopyButton } from "@/components/copy-button";
 import { Select } from "@/components/ui/select";
 
 // Lets the Definition tab switch between the live draft and each stable
 // version's snapshotted spec. The blocks are rendered server-side (syntax
 // highlighting stays on the server) and passed in as ReactNodes; this just
-// picks which one to show. Defaults to the first item (the draft).
+// picks which one to show. Defaults to the first item (the draft). `source` is
+// the raw spec text of that item, for the copy button.
 
-export type SpecVersionItem = { id: string; label: string; block: ReactNode };
+export type SpecVersionItem = {
+  id: string;
+  label: string;
+  block: ReactNode;
+  source: string;
+};
 
 export function SpecVersionViewer({ items }: { items: SpecVersionItem[] }) {
   const [active, setActive] = useState(items[0]?.id ?? "");
@@ -17,18 +24,26 @@ export function SpecVersionViewer({ items }: { items: SpecVersionItem[] }) {
 
   return (
     <div className="flex flex-col gap-3">
-      {items.length > 1 && (
-        <label className="text-foreground-weak flex items-center gap-2 text-sm">
-          <span>Showing</span>
-          <Select
-            value={active}
-            onValueChange={setActive}
-            options={items.map((i) => ({ value: i.id, label: i.label }))}
-            ariaLabel="Spec version"
-            className="min-w-[180px]"
-          />
-        </label>
-      )}
+      <div className="flex items-center justify-between gap-3">
+        {items.length > 1 ? (
+          <label className="text-foreground-weak flex items-center gap-2 text-sm">
+            <span>Showing</span>
+            <Select
+              value={active}
+              onValueChange={setActive}
+              options={items.map((i) => ({ value: i.id, label: i.label }))}
+              ariaLabel="Spec version"
+              className="min-w-[180px]"
+            />
+          </label>
+        ) : (
+          <span />
+        )}
+        <CopyButton
+          text={current?.source ?? ""}
+          ariaLabel="Copy agent definition"
+        />
+      </div>
       {current?.block}
     </div>
   );


### PR DESCRIPTION
Adds a top-right **Copy** button to the agent Definition spec viewer, so the spec can be lifted elsewhere in one click (same affordance as the run-output / Slack-manifest copy buttons).

It copies the **currently-selected** version — draft or a stable snapshot — by carrying each item's raw `source` text into the viewer and copying the active one via the shared `CopyButton`. When multiple versions exist, the button sits to the right of the version selector; with just the draft, it's right-aligned on its own.

`tsc` clean, `vitest` passing, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)