### PR TITLE
docs(inbox): clarify options resolve the item — use url/links to open

### DIFF
--- a/web/src/lib/agent-guidance.ts
+++ b/web/src/lib/agent-guidance.ts
@@ -761,6 +761,16 @@ Markdown link list in \`proposedActionText\`. The exact parameter list for any
 \`tembo-agent-studio\` tool is in its \`/for-agents\` reference — fetch it when
 you need a tool's full schema.
 
+**Links vs. options — don't confuse them.** \`options\` are action BUTTONS and
+every one RESOLVES (completes) the item when clicked — they're for acting on it
+(reply / archive / complete / ignore), never for navigation. To let the human
+**open a record or link without closing the task**, use \`url\` (the "Open in …"
+link) or \`links\` — NOT an option. An "Open in X" option will just mark the item
+done and navigate nowhere. Build deep links from the provider's own record
+permalink where one is returned, rather than hand-templating an ID into a URL
+path (a wrong slug/id form silently resolves to the provider's default list
+view).
+
 ### retries
 
 Integer or struct. Default behavior is provider-determined. Set

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -464,13 +464,21 @@ export function buildMcpServer(
                   params: z.record(z.string(), z.unknown()).optional().describe("e.g. { convId }."),
                 })
                 .optional()
-                .describe("How to perform this action on click. Omit for a no-op (e.g. 'Ignore')."),
+                .describe(
+                  "How to perform this action on click. Omit ONLY when clicking " +
+                  "should just resolve the item with no side effect (e.g. 'Ignore') " +
+                  "— an option with no execute still COMPLETES the item.",
+                ),
             }),
           )
           .optional()
           .describe(
-            "Action menu rendered as buttons for the human — the set of things they might do. " +
-            "Pick one recommended; reply options carry a draft.",
+            "Action menu rendered as buttons. EVERY option RESOLVES (completes) " +
+            "the item when clicked — options are for acting on the item (reply, " +
+            "archive, complete, ignore), NOT for navigation. To let the human " +
+            "OPEN a record/link without closing the task, use `url` (the 'Open " +
+            "in …' link) or `links` — never an option. Pick one recommended; " +
+            "reply options carry a draft.",
           ),
         links: z
           .array(


### PR DESCRIPTION
## Why
Investigating two reported inbox bugs on `attio-duplicate-detector`, both traced to the same footgun: agents reach for **`options`** to make an "Open record" button, not realizing **every option RESOLVES (completes) the item** on click — so the button closes the task and navigates nowhere. (Confirmed: that agent ships a `oneclick` `open_company` option with no `execute`.)

## What (guidance/docs only)
- **`produce_inbox_item` schema describes:** the `options` field now states plainly that every option completes the item and that navigation must use `url`/`links`, never an option. The `execute` "omit for a no-op" wording now clarifies a no-execute option **still completes** the item.
- **`agent-guidance.ts`:** a *"Links vs. options — don't confuse them"* note, plus a reminder to build deep links from the **provider's own record permalink** rather than hand-templating an id into a path (a wrong slug/id form silently resolves to the provider's default list view — exactly the Attio `companies/record/{id}` vs `company/{id}` case).

No behavior change.

## Test
`tsc` clean, eslint clean, MCP `server.test.ts` (tool-name snapshot) unaffected — 15 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)