### PR TITLE
fix(inbox): accept string context; soften OAuth-token-for-REST guidance

### DIFF
--- a/api/scripts/tas_tools.py
+++ b/api/scripts/tas_tools.py
@@ -25,10 +25,14 @@ so the tool can do deterministic I/O (e.g. with httpx) over it.
 
 Two kinds of credential flow through here:
 
-- `connection(provider)` — a **Native-MCP** connection's OAuth access token,
-  which is a real provider token that also works against the provider's REST
-  API. (Composio brokers auth for LLM tool-calling and doesn't hand out raw
-  downstream tokens, so Composio-only services stay LLM-driven.)
+- `connection(provider)` — a **Native-MCP** connection's OAuth access token. It
+  is a real provider token and CAN double as a REST Bearer token — but only when
+  the MCP grant carries the scopes that REST endpoint needs. Some providers'
+  grants cover identity yet not record reads (you'll get 401/403), so probe with
+  the actual endpoint you need and fall back to a `secret()` API key when the
+  connection token can't do the job. (Composio brokers auth for LLM tool-calling
+  and doesn't hand out raw downstream tokens, so Composio-only services stay
+  LLM-driven.)
 - `secret(name)` — a **Secret**: a free-form, workspace-level API key an admin
   set under Connections → Secrets (e.g. Clay), for services that authenticate
   with a plain key:

--- a/web/src/app/api/v1/inbox/route.ts
+++ b/web/src/app/api/v1/inbox/route.ts
@@ -119,9 +119,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     externalRef: typeof body.externalRef === "string" ? body.externalRef : undefined,
     url: typeof body.url === "string" ? body.url : undefined,
     context:
-      body.context && typeof body.context === "object"
-        ? (body.context as Record<string, unknown>)
-        : undefined,
+      typeof body.context === "string"
+        ? body.context
+        : body.context && typeof body.context === "object"
+          ? (body.context as Record<string, unknown>)
+          : undefined,
     proposedAction,
     options: Array.isArray(body.options)
       ? (body.options as InboxOption[])

--- a/web/src/lib/agent-guidance.ts
+++ b/web/src/lib/agent-guidance.ts
@@ -413,8 +413,9 @@ Rules:
 **Auth flows through Connections — never hardcode a key.** When a tool
 needs to reach an external system, import the bundled \`tas_tools\`
 helper and ask for a connection the agent already declares under
-\`connections:\` (Native MCP only — its OAuth token also works against
-the provider's REST API):
+\`connections:\` (Native MCP only). Its OAuth token can double as a REST
+Bearer token for the provider's API — **when the MCP grant carries the
+scopes that REST endpoint needs** (see the scope caveat below):
 
 \`\`\`python
 # agents/pydantic-agentspec/revenue_tools.py
@@ -437,6 +438,13 @@ def summarize_arr(records: list[dict]) -> dict:
 
 tools = [list_companies, summarize_arr]
 \`\`\`
+
+**Scope caveat:** a provider's MCP OAuth grant doesn't always carry the REST
+scopes a given endpoint needs — the token may authenticate (an identity call
+like \`/self\`) yet 401/403 on record reads. Probe with the ACTUAL endpoint you
+need (not a generic "who am I"), and **fall back to a Secret API key** (below)
+when the connection token can't do the job — a provider API key with the right
+scopes is the reliable credential for heavy REST use.
 
 For a service that authenticates with a **plain API key** (e.g. Clay)
 rather than OAuth — i.e. not a Composio or Native-MCP provider — use a

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -510,7 +510,7 @@ export type ProduceInboxItemInput = {
   externalRef?: string;
   /** Deep link to the source object (issue/ticket/record/task URL). */
   url?: string;
-  context?: Record<string, unknown>;
+  context?: Record<string, unknown> | string;
   proposedAction?: InboxAction;
   /** Action menu rendered as buttons; one may be `recommended`. */
   options?: InboxOption[];
@@ -602,7 +602,12 @@ export async function produceInboxItemFor(
     url: input.url?.trim() || null,
     itemType,
     title,
-    context: input.context ?? {},
+    // Accept a plain-string context (a common model mistake — the field is a
+    // JSON object) by wrapping it as { text } instead of rejecting the call.
+    context:
+      typeof input.context === "string"
+        ? { text: input.context }
+        : (input.context ?? {}),
     proposedAction: input.proposedAction ?? null,
     options: input.options ?? null,
     // Explicit links first (they win de-duping + keep their labels), then every

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -446,7 +446,10 @@ export function buildMcpServer(
             "NEWER value for the same externalRef, the item reopens + refreshes " +
             "(e.g. a reply to an archived thread comes back).",
           ),
-        context: z.record(z.string(), z.unknown()).optional().describe("The raw payload to review (JSON)."),
+        context: z
+          .union([z.record(z.string(), z.unknown()), z.string()])
+          .optional()
+          .describe("The raw payload to review — a JSON object, or a plain string (stored as { text })."),
         proposedActionText: z.string().optional().describe("Your proposed reply / decision."),
         proposedActionFields: z.record(z.string(), z.unknown()).optional().describe("Structured proposal params."),
         options: z


### PR DESCRIPTION
Two small ergonomics fixes from the `attio-duplicate-detector` tools_module refactor.

**1. `produce_inbox_item` accepts a string `context`.** The field is typed as a JSON object, so a model passing a plain string (a natural mistake) hit `Invalid arguments … context expected record` and burned a fail-then-retry every run. Now a string is wrapped as `{ text }`: MCP zod schema → `union(record, string)`, `ProduceInboxItemInput.context` widened, coerced in `produceInboxItemFor` (the single choke point for MCP **and** REST), and the REST route passes strings through.

**2. Soften the "OAuth token works for REST" claim.** The guidance + `tas_tools` docstring asserted a Native-MCP connection's OAuth token "also works against the provider's REST API." For Attio it authenticates identity but **401/403s on record reads** — the MCP grant lacks the REST record scope. Both now say the token *can* double as a REST bearer *when the grant carries the needed scopes*; probe the real endpoint and fall back to a Secret API key for heavy REST use.

`tsc` clean, `vitest` 138 passing, eslint clean, py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)