### PR TITLE
fix(runner): record uncached input tokens — stop double-charging prompt cache

### DIFF
--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -216,6 +216,26 @@ def _usage_field(usage_obj, *names):
     return None
 
 
+def _uncached_input(usage_obj):
+    """Genuinely-new (uncached) input tokens.
+
+    pydantic-ai's `input_tokens` is the TOTAL input — it INCLUDES the prompt-cache
+    halves (cache reads + cache writes). The cost estimate prices cache reads at
+    0.1x and writes at 1.25x SEPARATELY, so the recorded `input_tokens` must
+    EXCLUDE them; otherwise every cached token is billed twice — once at the full
+    input rate (inside input_tokens) and once at the cache rate. (For a long
+    agentic run the cached prefix is re-sent every step, so this otherwise
+    inflates the cost several-fold.) Returns None when no input is reported;
+    clamps at 0.
+    """
+    total = _usage_field(usage_obj, "input_tokens", "request_tokens")
+    if total is None:
+        return None
+    cr = _usage_field(usage_obj, "cache_read_tokens") or 0
+    cw = _usage_field(usage_obj, "cache_write_tokens") or 0
+    return max(0, total - cr - cw)
+
+
 def steps_payload(messages) -> list[dict]:
     """Per model-request usage + the tool calls that request emitted.
 
@@ -281,7 +301,7 @@ def steps_payload(messages) -> list[dict]:
             {
                 "step": idx,
                 "summary": summary,
-                "input_tokens": _usage_field(usage_obj, "input_tokens", "request_tokens"),
+                "input_tokens": _uncached_input(usage_obj),
                 "output_tokens": _usage_field(usage_obj, "output_tokens", "response_tokens"),
                 "cache_read_tokens": _usage_field(usage_obj, "cache_read_tokens"),
                 "cache_write_tokens": _usage_field(usage_obj, "cache_write_tokens"),
@@ -380,7 +400,7 @@ def make_stream_handler():
         if node_counted:
             try:
                 usage = getattr(_ctx, "usage", None)
-                in_cum = _usage_field(usage, "input_tokens", "request_tokens")
+                in_cum = _uncached_input(usage)
                 out_cum = _usage_field(usage, "output_tokens", "response_tokens")
                 if in_cum is not None or out_cum is not None:
                     in_cum = in_cum or 0
@@ -432,16 +452,22 @@ def usage_payload(usage_obj) -> dict:
         "response_tokens",
         "total_tokens",
         "requests",
-        # Anthropic prompt-cache counters — uncached input is in input_tokens;
-        # these are the cache write (creation) and read halves, priced
-        # separately (~1.25x / ~0.1x of input). The Rust side uses them for the
-        # run's cost estimate.
+        # Anthropic/OpenAI prompt-cache counters — the cache write (creation) and
+        # read halves, priced separately (~1.25x / ~0.1x of input). The Rust side
+        # uses them for the run's cost estimate.
         "cache_read_tokens",
         "cache_write_tokens",
     ):
         val = getattr(usage_obj, attr, None)
         if val is not None:
             out[attr] = val
+    # pydantic-ai's input_tokens is the TOTAL input (incl. the cache halves above).
+    # Record the UNCACHED input so the cost estimate, which prices cache reads/
+    # writes separately, doesn't double-charge cached tokens. See _uncached_input.
+    uncached = _uncached_input(usage_obj)
+    if uncached is not None:
+        out["input_tokens"] = uncached
+        out.pop("request_tokens", None)  # old-name fallback is also cache-inclusive
     return out
 
 

--- a/api/tests/test_run_pydantic_build_agent.py
+++ b/api/tests/test_run_pydantic_build_agent.py
@@ -98,3 +98,24 @@ def test_build_agent_attaches_websearch_capability() -> None:
         }
     )
     assert isinstance(agent, Agent)
+
+
+def test_uncached_input_excludes_cache_halves() -> None:
+    from types import SimpleNamespace
+
+    # The real run that overstated cost ~6x: input_tokens is the TOTAL incl. cache.
+    u = SimpleNamespace(
+        input_tokens=940477, cache_read_tokens=938547, cache_write_tokens=1929
+    )
+    assert run_pydantic._uncached_input(u) == 940477 - 938547 - 1929  # == 1
+
+    # No caching reported → uncached == input.
+    assert run_pydantic._uncached_input(
+        SimpleNamespace(input_tokens=5000)
+    ) == 5000
+
+    # Clamp at 0; None input → None.
+    assert run_pydantic._uncached_input(
+        SimpleNamespace(input_tokens=100, cache_read_tokens=200)
+    ) == 0
+    assert run_pydantic._uncached_input(SimpleNamespace()) is None


### PR DESCRIPTION
## The bug
A run's `tokens_input` was pydantic-ai's cumulative **total** input, which **includes the prompt-cache halves** (cache reads + writes). The Rust cost estimate then priced that full number at the input rate **and** added `cache_read×0.1 + cache_write×1.25` on top — so every cached token is billed **twice** (full rate inside `tokens_input`, plus the cache rate). In a long agentic run the cached prefix is re-sent each step, so this overstates cost several-fold.

**Real example** (`attio-duplicate-detector`): `tokens_input = 12.4M`, cost shown **$44.58** — but ~11.5M of that "input" was cache reads. Correctly accounted, the run cost **~$7** (~6× overstatement).

## The fix
Record genuinely-new (uncached) input = `input_tokens − cache_read − cache_write` (clamp ≥0), via a new `_uncached_input` helper, applied to:
- the run-total usage (`usage_payload` → drives `cost_usd`),
- the per-step `__TAS_STEPS__` usage, and
- the live streaming per-step diff.

The Rust formula (`(tokens_input + cache_read×0.1 + cache_write×1.25) × rate`) is now correct because `tokens_input` is finally the uncached figure it always assumed. The headline token count stops showing the scary cache-inflated number; cache read/write still display separately. General across Anthropic + OpenAI (both report cache-inclusive input). Historical rows keep their old numbers; new runs are correct.

## Test
New `_uncached_input` unit test (the exact 940k-input/938k-cache-read step → 1 uncached; no-cache passthrough; clamp; None). `py_compile` clean; full `build_agent` pytest **8 passed** against real pydantic-ai 1.102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)