### PR TITLE
feat(api): POST /api/v1/runs/[id]/cancel — scriptable run kill

### DIFF
--- a/web/src/app/api/v1/runs/[id]/cancel/route.ts
+++ b/web/src/app/api/v1/runs/[id]/cancel/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { authorizeApiRequest } from "@/lib/api-auth";
+import { apiError, authErrorResponse } from "@/lib/api-v1/http";
+import { cancelRun, getRun } from "@/lib/runs-api";
+
+// POST /api/v1/runs/[id]/cancel — kill an in-flight run, the scriptable
+// equivalent of the run page's Stop button: it transitions the run to
+// 'cancelled' and SIGKILLs the agent's subprocess. Min role operator (a
+// mutation), scoped to the key's workspace so one workspace can't cancel
+// another's run. Returns { cancelled } — true if this call stopped a running
+// run, false if it was already terminal (idempotent / nothing to do).
+
+export const dynamic = "force-dynamic";
+
+type RouteParams = Promise<{ id: string }>;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: RouteParams },
+): Promise<NextResponse> {
+  const auth = await authorizeApiRequest(request, "operator");
+  if (!auth.ok) return authErrorResponse(auth);
+
+  const { id } = await params;
+  let run;
+  try {
+    run = await getRun(id, auth.workspace.id);
+  } catch {
+    return apiError(502, "could not reach the run service");
+  }
+  if (!run || run.workspaceId !== auth.workspace.id) {
+    return apiError(404, "run not found");
+  }
+
+  let cancelled: boolean;
+  try {
+    cancelled = await cancelRun(id, auth.workspace.id);
+  } catch {
+    return apiError(502, "could not reach the run service");
+  }
+  return NextResponse.json({ cancelled });
+}


### PR DESCRIPTION
Until now the only way to stop an in-flight run was the run page's **Stop** button (#216), which posts to the **internal-only** `/internal/runs/[id]/cancel` — not reachable from the public API. So a run could be *triggered* via `POST /api/v1/runs` but not *killed* programmatically.

Adds **`POST /api/v1/runs/[id]/cancel`**:
- **operator** role, workspace-scoped (can't cancel another workspace's run; 404 if not found).
- Returns `{ cancelled }` — `true` if it stopped a running run, `false` if already terminal (idempotent).
- Reuses the same `cancelRun` helper the Stop button uses → flips the row to `cancelled` **and** SIGKILLs the agent subprocess.

(Surfaced while debugging a slow `attio-duplicate-detector` run — there was no scriptable kill. MCP `cancel_run` parity is a trivial follow-up if wanted.)

`tsc` clean, `vitest` passing, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)