### PR TITLE
Fix Amplemarket connect: don't request offline_access

### DIFF
--- a/web/src/app/api/connections/native/[provider]/authorize/route.ts
+++ b/web/src/app/api/connections/native/[provider]/authorize/route.ts
@@ -353,6 +353,7 @@ export async function GET(
   // their connect. Gate on the advertised grant, and never duplicate it.
   if (
     !isManual &&
+    !provider.omitOfflineAccess &&
     (asMeta.grant_types_supported ?? []).includes("refresh_token") &&
     !scopes.includes("offline_access")
   ) {

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -68,6 +68,17 @@ export type McpProvider = {
    * readonly + compose.
    */
   scopeOverride?: string[];
+  /**
+   * Suppress the OIDC `offline_access` scope that TAS otherwise appends for DCR
+   * providers whose auth server advertises the `refresh_token` grant. Most
+   * servers accept the unknown scope leniently (Attio/Dialed even REQUIRE it to
+   * mint a refresh token and don't advertise it), but some STRICTLY validate the
+   * request against their `scopes_supported` and reject `offline_access` with
+   * "invalid scope", which is fatal to the whole authorize. Amplemarket is the
+   * first of these (advertises only mcp:read/mcp:write). Such servers either mint
+   * refresh tokens without the scope or issue short-lived-only access tokens.
+   */
+  omitOfflineAccess?: boolean;
 };
 
 export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
@@ -150,6 +161,9 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
     // client (token auth method "none") — TAS-managed, no per-customer setup, like Attio.
     mcpServerUrl: "https://mcp.amplemarket.com/mcp",
     oauthAuthorizationServerOrigins: ["https://app.amplemarket.com"],
+    // Strictly validates scope against scopes_supported (mcp:read/mcp:write) and
+    // rejects the auto-appended offline_access with "invalid scope" — suppress it.
+    omitOfflineAccess: true,
   },
   gmail: {
     slug: "gmail",


### PR DESCRIPTION
Follow-up to #248. Connecting Amplemarket failed at the consent screen with:

> Authorization Error — The requested scope is invalid, unknown, or malformed.

## Cause
For DCR providers whose auth server advertises the `refresh_token` grant, TAS appends the OIDC `offline_access` scope at authorize time (to obtain a refresh token). Most servers accept it leniently — Attio/Dialed even **require** it and don't advertise it. **Amplemarket strictly validates the request against its `scopes_supported` (`mcp:read`/`mcp:write`) and rejects the unknown `offline_access`**, failing the whole authorize.

## Fix
Add an `omitOfflineAccess` provider flag that gates the `offline_access` append, and set it for Amplemarket. Attio/Dialed/etc. are unaffected — they keep the append. Surgical, matching the existing `scopeOverride`/`authorizeParams` per-provider override style.

Amplemarket's server lists `refresh_token` in `grant_types_supported`, so it may still issue a refresh token on the code exchange without the scope; if not, the access token is short-lived-only and reconnect is occasionally needed. Either way, requesting the unknown scope was fatal, so this unblocks connect.

## Checks
`tsc` clean, `eslint` clean. (No allowlist change — `native_oauth.rs` already covers Amplemarket from #248.)

## Verify
Re-run the Amplemarket connect on tembo-tas → consent screen loads (scope `mcp:read mcp:write`), callback + token exchange complete, tools load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)