### PR TITLE
Add Clay as a native MCP provider

### DIFF
--- a/api/src/native_oauth.rs
+++ b/api/src/native_oauth.rs
@@ -67,6 +67,11 @@ const LINEAR_OAUTH_ORIGINS: &[&str] = &["https://mcp.linear.app"];
 // public client, PKCE S256, scopes mcp:read/mcp:write) — TAS-managed, like Attio.
 const AMPLEMARKET_MCP_ORIGIN: &str = "https://mcp.amplemarket.com";
 const AMPLEMARKET_OAUTH_ORIGINS: &[&str] = &["https://app.amplemarket.com"];
+// Clay advertises api.clay.com as its auth server (DCR, public client, PKCE S256,
+// scope "mcp"), but its authorize endpoint lives on app.clay.com while
+// token/registration sit on api.clay.com — both origins allowed (like Fathom).
+const CLAY_MCP_ORIGIN: &str = "https://api.clay.com";
+const CLAY_OAUTH_ORIGINS: &[&str] = &["https://api.clay.com", "https://app.clay.com"];
 // Gmail (Google Workspace MCP) is a confidential/manual client on standard
 // Google OAuth: the auth server is accounts.google.com but its TOKEN endpoint
 // lives on a separate origin (oauth2.googleapis.com) — both must be trusted so
@@ -85,6 +90,7 @@ const NATIVE_MCP_OAUTH_ALLOWLIST: &[(&str, &[&str])] = &[
     (DIALED_MCP_ORIGIN, DIALED_OAUTH_ORIGINS),
     (LINEAR_MCP_ORIGIN, LINEAR_OAUTH_ORIGINS),
     (AMPLEMARKET_MCP_ORIGIN, AMPLEMARKET_OAUTH_ORIGINS),
+    (CLAY_MCP_ORIGIN, CLAY_OAUTH_ORIGINS),
     (GMAIL_MCP_ORIGIN, GMAIL_OAUTH_ORIGINS),
 ];
 

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -24,6 +24,7 @@ export type McpProviderSlug =
   | "dialed"
   | "linear"
   | "amplemarket"
+  | "clay"
   | "gmail"
   | "tembo-agent-studio";
 
@@ -164,6 +165,25 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
     // Strictly validates scope against scopes_supported (mcp:read/mcp:write) and
     // rejects the auto-appended offline_access with "invalid scope" — suppress it.
     omitOfflineAccess: true,
+  },
+  clay: {
+    slug: "clay",
+    displayName: "Clay",
+    // Verified (probe): POST https://api.clay.com/v3/mcp → 401; protected-resource
+    // metadata is served PATH-SUFFIXED (/.well-known/oauth-protected-resource/v3/mcp;
+    // the bare origin 404s — handled by the suffixed-discovery fallback) and advertises
+    // the auth server as https://api.clay.com (scope "mcp"). Auth-server metadata exposes
+    // a registration_endpoint (/oauth/register → DCR), PKCE S256, and a public client
+    // (token auth method "none") — TAS-managed, no per-customer setup, like Attio. The
+    // authorize endpoint lives on a SEPARATE origin (app.clay.com) from token/registration
+    // (api.clay.com) — both origins are allowed, like Fathom. offline_access kept (default):
+    // the authorize endpoint is a client-rendered app that doesn't reject unknown scopes at
+    // the GET, unlike Amplemarket.
+    mcpServerUrl: "https://api.clay.com/v3/mcp",
+    oauthAuthorizationServerOrigins: [
+      "https://api.clay.com",
+      "https://app.clay.com",
+    ],
   },
   gmail: {
     slug: "gmail",


### PR DESCRIPTION
Adds **Clay** (`https://api.clay.com/v3/mcp`) as a native MCP provider. Directory: https://claude.ai/directory/a8159026-14b4-403a-933b-bd897a5b36ca

## What it is
A **DCR** provider (TAS-managed OAuth, zero per-customer setup), confirmed by probing its discovery endpoints:

- protected-resource metadata is **path-suffixed** (`/.well-known/oauth-protected-resource/v3/mcp`; the bare origin 404s — the route's suffixed-discovery fallback derives this from the MCP URL pathname), advertising auth server **`https://api.clay.com`**, scope **`mcp`**
- auth-server metadata → `registration_endpoint` (`/oauth/register` → DCR), PKCE **S256**, public client (`"none"`), grants `authorization_code` + `refresh_token`

## Two wrinkles handled
1. **Split origins** — `authorization_endpoint` is on **`app.clay.com`** while token/registration are on **`api.clay.com`**, so both origins are allowlisted (same pattern as Fathom).
2. **`offline_access`** — Clay advertises only scope `mcp` (the shape that made Amplemarket reject the auto-appended `offline_access`). But I verified via a throwaway DCR client that Clay's authorize endpoint is a **client-rendered app that returns an identical page with or without `offline_access`** — it doesn't server-reject unknown scopes at the GET like Amplemarket did. So I kept the **default** (offline_access on, to get refresh tokens). If it turns out Clay rejects it deeper in the flow, the fix is the same one-liner as #249 (`omitOfflineAccess: true`).

## Changes
- `web/src/lib/mcp-providers.ts` — `clay` slug + catalog entry (two OAuth origins)
- `api/src/native_oauth.rs` — `clay` MCP + both OAuth origins added to `NATIVE_MCP_OAUTH_ALLOWLIST`
- No logo change — Composio's CDN serves `clay`; no migration; authorize/callback routes unchanged

## Checks
`tsc` clean · `eslint` clean · `mcp-providers.allowlist-sync.test.ts` **9/9** · `cargo check` clean

## Verify post-merge
Connect Clay from the Connections page on tembo-tas → consent loads (scope `mcp`), callback + token exchange complete, tools load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)