### PR TITLE
Fix live per-step input tokens under-reporting mid-run

### DIFF
--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -400,22 +400,28 @@ def make_stream_handler():
         if node_counted:
             try:
                 usage = getattr(_ctx, "usage", None)
-                in_cum = _uncached_input(usage)
-                out_cum = _usage_field(usage, "output_tokens", "response_tokens")
-                if in_cum is not None or out_cum is not None:
-                    in_cum = in_cum or 0
-                    out_cum = out_cum or 0
+                # Report TOTAL input per step (the whole context the request
+                # processed) to match the authoritative end-of-run __TAS_STEPS__,
+                # which reads per-ModelResponse usage that carries no cache split
+                # and so reports total input too. Feeding _uncached_input the
+                # CUMULATIVE RunUsage here instead netted out the cached prefix
+                # (re-sent every step), so live In showed ~0 until the run ended.
+                input_so_far = _usage_field(usage, "input_tokens", "request_tokens")
+                output_so_far = _usage_field(usage, "output_tokens", "response_tokens")
+                if input_so_far is not None or output_so_far is not None:
+                    input_so_far = input_so_far or 0
+                    output_so_far = output_so_far or 0
                     _emit_stream_line(
                         PROGRESS_SENTINEL,
                         {
                             "kind": "step_usage",
                             "step": state["step"],
-                            "input_tokens": in_cum - state["prev_in"],
-                            "output_tokens": out_cum - state["prev_out"],
+                            "input_tokens": input_so_far - state["prev_in"],
+                            "output_tokens": output_so_far - state["prev_out"],
                         },
                     )
-                    state["prev_in"] = in_cum
-                    state["prev_out"] = out_cum
+                    state["prev_in"] = input_so_far
+                    state["prev_out"] = output_so_far
             except Exception:
                 pass
 


### PR DESCRIPTION
Reported: during a run the per-step **In** column shows ~0 tokens, then snaps to the real numbers (7.75k, 9.56k, …) the instant the run finishes.

## Cause
Two code paths produce per-step token counts, and they were fed different objects through the same `_uncached_input()`:

- **Live (streaming):** fed the **cumulative `RunUsage`**, whose `cache_read_tokens` covers the prompt prefix re-sent every step. `_uncached_input` subtracts that, so the per-step delta collapsed to the tiny *uncached* remainder → live **In** ≈ 0/2.
- **Final (`__TAS_STEPS__` / `steps_payload`):** fed the **per-`ModelResponse` usage**, which carries no cache split, so `_uncached_input` subtracts nothing and returns the step's **total** input → the real 7.75k/9.56k.

So the live and authoritative values used opposite bases; the final overwrite is what made the numbers "appear correct" at the end.

## Fix
Report **total** input per step in the live handler (`api/scripts/run_pydantic.py`), matching the authoritative end-of-run steps. One-line basis change.

**Display-only / cost-safe:** `persist_run_steps` still DELETE+reinserts the authoritative `__TAS_STEPS__` at run end, and the run-total cost still uses uncached input (#238) — neither is touched. This only changes what the live step rows show *during* the run.

## Known residual (not fixed here)
The live **Out** column lags by one step (each row briefly shows the previous step's output) because `_ctx.usage` at node-end trails the just-emitted response. It fully self-corrects at completion. Same root area; happy to chase it next if we want the live view pixel-accurate.

## Verify
Run any multi-step agent on tembo-tas and watch the step table: **In** should fill in with real per-step totals as each step completes, not jump from ~0 to real only at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)