### PR TITLE
Expandable tool-call errors in the run step timeline

### DIFF
--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -55,6 +55,13 @@ STEPS_SENTINEL = "__TAS_STEPS__:"
 DELTA_SENTINEL = "__TAS_DELTA__:"
 PROGRESS_SENTINEL = "__TAS_PROGRESS__:"
 
+# Cap on a tool-call error message we persist for the run-step timeline. Long
+# enough to keep a real error useful (API bodies, validation dumps, short
+# tracebacks) now that the UI shows it expandably; bounded so one giant tool
+# error can't bloat the row. Only the stored/displayed copy is capped — the
+# model still sees the full retry-prompt content.
+MAX_TOOL_ERROR_CHARS = 4000
+
 # Sidecar Python tools: the agent's `tools_module:` sibling source, read
 # from the repo by the web layer and handed to us via env. We exec it and
 # expose its `tools = [...]` export to the agent as callable functions —
@@ -188,7 +195,7 @@ def tool_calls_payload(messages) -> list[dict]:
                 calls.append((cid, name))
             elif kind == "retry-prompt":
                 content = getattr(part, "content", "")
-                outcomes[cid] = {"ok": False, "error": str(content)[:200]}
+                outcomes[cid] = {"ok": False, "error": str(content)[:MAX_TOOL_ERROR_CHARS]}
             elif kind.endswith("tool-return"):
                 outcomes.setdefault(cid, {"ok": True, "error": None})
     out: list[dict] = []
@@ -257,7 +264,7 @@ def steps_payload(messages) -> list[dict]:
                 continue
             if kind == "retry-prompt":
                 content = getattr(part, "content", "")
-                outcomes[cid] = {"ok": False, "error": str(content)[:200]}
+                outcomes[cid] = {"ok": False, "error": str(content)[:MAX_TOOL_ERROR_CHARS]}
             elif kind.endswith("tool-return"):
                 outcomes.setdefault(cid, {"ok": True, "error": None})
 
@@ -381,7 +388,7 @@ def make_stream_handler():
                     rkind = getattr(res, "part_kind", "") or ""
                     ok = rkind.endswith("tool-return")
                     err = (
-                        str(getattr(res, "content", ""))[:200]
+                        str(getattr(res, "content", ""))[:MAX_TOOL_ERROR_CHARS]
                         if (not ok and rkind == "retry-prompt")
                         else None
                     )

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/expandable-error.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/expandable-error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+
+// A tool call's error message in the step timeline. Collapsed to two lines by
+// default and click-to-expand — only when the text actually overflows that
+// clamp (short errors show no affordance). Errors can be long (API bodies,
+// validation dumps, short tracebacks); the full stored text is shown when
+// expanded, with newlines preserved.
+export function ExpandableError({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const ref = useRef<HTMLParagraphElement>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Measure against the collapsed clamp: if the content is taller than the
+    // 2-line box, the toggle is meaningful. (Re-measures when collapsed.)
+    if (!expanded) setOverflows(el.scrollHeight > el.clientHeight + 1);
+  }, [text, expanded]);
+
+  return (
+    <div className="pl-[1.375rem]">
+      <p
+        ref={ref}
+        className={`text-sentiment-negative font-mono text-xs leading-4 break-words ${
+          expanded ? "whitespace-pre-wrap" : "line-clamp-2"
+        }`}
+      >
+        {text}
+      </p>
+      {(overflows || expanded) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="text-foreground-muted hover:text-foreground-weak mt-0.5 text-xs"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-steps.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/run-steps.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/pricing";
 import type { RunStep, RunToolCall } from "@/lib/runs-db";
 
+import { ExpandableError } from "./expandable-error";
 import { RevealText } from "./reveal-text";
 import { ToolProviderLogo } from "./tool-provider-logo";
 
@@ -117,9 +118,7 @@ export function RunSteps({
                       )}
                     </div>
                     {c.ok === false && c.errorMessage && (
-                      <p className="text-sentiment-negative line-clamp-2 pl-[1.375rem] font-mono text-xs leading-4">
-                        {c.errorMessage}
-                      </p>
+                      <ExpandableError text={c.errorMessage} />
                     )}
                   </Fragment>
                 );


### PR DESCRIPTION
Reported: tool-call error messages in the Run Steps timeline are truncated and should be expandable.

## Two truncations, both fixed
1. **Runner capped stored error text at 200 chars** — `api/scripts/run_pydantic.py` truncated tool-error content to `[:200]` at all three capture sites (`tool_calls_payload`, `steps_payload`, the streaming `FunctionToolResultEvent`). 200 chars is too short to be worth expanding. Raised to a shared `MAX_TOOL_ERROR_CHARS = 4000` — enough for a real error (API body, validation dump, short traceback), bounded so one giant error can't bloat the row. **Stored/displayed copy only — the model still sees the full retry-prompt content.** (`run_tool_call.error_message` is already `TEXT`, no migration.)
2. **UI hard-clamped to 2 lines** (`line-clamp-2`) with no way to see the rest. Replaced with a new `ExpandableError` client component: 2-line preview + a **Show more/less** toggle that appears only when the text actually overflows; expanded view preserves newlines.

## Files
- `api/scripts/run_pydantic.py` — `MAX_TOOL_ERROR_CHARS` constant + the three cap sites
- `web/src/app/[workspace]/agents/[agent]/runs/[runId]/expandable-error.tsx` — new client component (overflow-detected toggle)
- `…/run-steps.tsx` — render `<ExpandableError>` instead of the clamped `<p>`

## Checks
`py_compile` OK · `tsc` clean · `eslint` clean · `vitest` 140/140

## Verify
Open a run with a failed tool call (e.g. the `encrich-attio-deals-from-amplema` runs): the error shows a 2-line preview with **Show more** when long; expanding reveals the full (≤4000-char) message with formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)