### PR TITLE
Trigger agents from Clerk webhooks (Svix signature verification)

### DIFF
--- a/api/migrations/0067_workspace_webhook_signing_secret.sql
+++ b/api/migrations/0067_workspace_webhook_signing_secret.sql
@@ -1,0 +1,14 @@
+-- Svix-signed webhook triggers (Clerk, and any Svix-powered sender).
+--
+-- A workspace_webhook normally authenticates inbound requests with its bearer
+-- token. Some senders — notably Clerk — can't attach a custom Authorization
+-- header; instead they SIGN each delivery (Svix scheme: svix-id /
+-- svix-timestamp / svix-signature headers, HMAC-SHA256 over
+-- "{id}.{timestamp}.{body}" keyed by the endpoint signing secret `whsec_...`).
+--
+-- When signing_secret_ciphertext is set, /api/hooks/webhook/<id> verifies that
+-- signature instead of the bearer token. The secret is encrypted at rest with
+-- the shared AES-256-GCM master key (nonce || ciphertext || tag), AAD-bound to
+-- (workspace_id, id) — only the web layer reads it (the Rust runner never does).
+ALTER TABLE workspace_webhook
+    ADD COLUMN IF NOT EXISTS signing_secret_ciphertext BYTEA;

--- a/web/src/app/[workspace]/agents/[agent]/agent-automations-table.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/agent-automations-table.tsx
@@ -39,6 +39,8 @@ export type AgentAutomationRow = {
   triggerType?: string;
   tokenLast4?: string | null;
   webhookUrl?: string;
+  /** Webhook authenticates by Svix signature (Clerk) rather than a bearer token. */
+  signed?: boolean;
 };
 
 type KindFilter = "all" | AgentAutomationKind;
@@ -464,7 +466,9 @@ function TriggerDetail({ row }: { row: AgentAutomationRow }) {
     <div className="flex flex-col gap-0.5">
       <span className="text-foreground-weak text-sm">
         Inbound POST{" "}
-        {row.tokenLast4 ? (
+        {row.signed ? (
+          <span className="text-foreground-muted">signed (Clerk)</span>
+        ) : row.tokenLast4 ? (
           <code className="text-foreground-muted">...{row.tokenLast4}</code>
         ) : null}
       </span>

--- a/web/src/app/[workspace]/agents/[agent]/agent-automations-table.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/agent-automations-table.tsx
@@ -363,18 +363,22 @@ function WebhookActions({
             {row.enabled ? "Disable" : "Enable"}
           </Button>
         </form>
-        <form action={rotateAction}>
-          <input type="hidden" name="workspace" value={workspaceSlug} />
-          <input type="hidden" name="id" value={row.id} />
-          <Button
-            type="submit"
-            variant="ghost"
-            size="small"
-            disabled={rotatePending}
-          >
-            Rotate
-          </Button>
-        </form>
+        {/* Signed (Clerk) webhooks authenticate by signature, not the bearer
+            token, so there's nothing to rotate — hide it. */}
+        {!row.signed && (
+          <form action={rotateAction}>
+            <input type="hidden" name="workspace" value={workspaceSlug} />
+            <input type="hidden" name="id" value={row.id} />
+            <Button
+              type="submit"
+              variant="ghost"
+              size="small"
+              disabled={rotatePending}
+            >
+              Rotate
+            </Button>
+          </form>
+        )}
         <form action={deleteAction}>
           <input type="hidden" name="workspace" value={workspaceSlug} />
           <input type="hidden" name="id" value={row.id} />

--- a/web/src/app/[workspace]/agents/[agent]/automation/page.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/automation/page.tsx
@@ -86,6 +86,7 @@ export default async function AgentAutomationPage({
       href: null,
       tokenLast4: w.tokenLast4,
       webhookUrl: `${baseUrl}/api/hooks/webhook/${w.id}`,
+      signed: w.hasSigningSecret,
     })),
   ];
 

--- a/web/src/app/[workspace]/agents/[agent]/webhooks-actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/webhooks-actions.ts
@@ -22,8 +22,10 @@ import { listWorkspaceMembers } from "@/lib/workspace";
 export type WebhookActionState = {
   message?: string;
   error?: string;
-  /** Present right after create/rotate — the UI reveals it once, then it's gone. */
-  secret?: { id: string; url: string; token: string };
+  /** Present right after create/rotate — the UI reveals it once, then it's gone.
+   *  `signed` webhooks (Clerk/Svix) authenticate by signature, so the bearer
+   *  token is irrelevant and the reveal shows setup for the signing secret. */
+  secret?: { id: string; url: string; token: string; signed: boolean };
 };
 
 function urlFor(id: string): string {
@@ -42,6 +44,7 @@ export async function createWebhookAction(
   const agentName = String(formData.get("agent") ?? "");
   const name = String(formData.get("name") ?? "").trim();
   const ownerRaw = String(formData.get("owner") ?? "").trim();
+  const signingSecret = String(formData.get("signingSecret") ?? "").trim();
 
   const auth = await authorizeWorkspace(slug, "operator");
   if (!auth.ok) {
@@ -52,6 +55,14 @@ export async function createWebhookAction(
 
   if (!name) return { error: "Give the webhook a name." };
   if (name.length > 64) return { error: "Name must be 64 characters or fewer." };
+  // A signing secret is optional (bearer mode if absent). When present it's a
+  // Svix/Clerk endpoint secret — sanity-check the shape so a paste error fails
+  // here rather than silently never verifying.
+  if (signingSecret && !/^whsec_[A-Za-z0-9+/=]{16,}$/.test(signingSecret)) {
+    return {
+      error: "Signing secret should look like `whsec_…` (from Clerk's webhook endpoint).",
+    };
+  }
 
   // Owner defaults to the creating user; an admin may run it as another member.
   let ownerUserId = userId;
@@ -72,6 +83,7 @@ export async function createWebhookAction(
     ownerUserId,
     name,
     createdBy: userId,
+    signingSecret: signingSecret || null,
   });
 
   await writeAuditEvent({
@@ -82,13 +94,18 @@ export async function createWebhookAction(
     targetType: "webhook",
     targetId: webhook.id,
     agentName,
-    payload: { name, ownerUserId },
+    payload: { name, ownerUserId, signed: Boolean(signingSecret) },
   });
 
   revalidateAgent(slug, agentName);
   return {
     message: `Created "${name}".`,
-    secret: { id: webhook.id, url: urlFor(webhook.id), token },
+    secret: {
+      id: webhook.id,
+      url: urlFor(webhook.id),
+      token,
+      signed: Boolean(signingSecret),
+    },
   };
 }
 
@@ -126,7 +143,7 @@ export async function rotateWebhookAction(
   revalidateAgent(slug, existing.agentName);
   return {
     message: `Rotated "${existing.name}". The old token no longer works.`,
-    secret: { id, url: urlFor(id), token },
+    secret: { id, url: urlFor(id), token, signed: false },
   };
 }
 

--- a/web/src/app/[workspace]/agents/[agent]/webhooks-actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/webhooks-actions.ts
@@ -143,7 +143,10 @@ export async function rotateWebhookAction(
   revalidateAgent(slug, existing.agentName);
   return {
     message: `Rotated "${existing.name}". The old token no longer works.`,
-    secret: { id, url: urlFor(id), token, signed: false },
+    // Render the reveal in the webhook's actual mode — a signed (Clerk) webhook
+    // authenticates by signature, so never hand back a rotated bearer token the
+    // receiver won't check. (The UI also hides Rotate for signed webhooks.)
+    secret: { id, url: urlFor(id), token, signed: existing.hasSigningSecret },
   };
 }
 

--- a/web/src/app/[workspace]/agents/[agent]/webhooks-section.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/webhooks-section.tsx
@@ -222,6 +222,7 @@ function WebhookRow({
         <SecretReveal
           url={rotateState.secret.url}
           token={rotateState.secret.token}
+          signed={rotateState.secret.signed}
         />
       )}
     </li>
@@ -289,6 +290,25 @@ export function AddWebhookForm({
           </p>
         </div>
       )}
+      <div className="grid gap-1.5">
+        <Label htmlFor="webhook-signing-secret" className="text-sm">
+          Clerk signing secret{" "}
+          <span className="text-foreground-muted">(optional)</span>
+        </Label>
+        <Input
+          id="webhook-signing-secret"
+          name="signingSecret"
+          autoComplete="off"
+          disabled={pending}
+          placeholder="whsec_…"
+          className="max-w-sm font-mono"
+        />
+        <p className="text-foreground-muted text-sm">
+          Paste this to verify <strong>Clerk</strong> (Svix-signed) webhooks by
+          signature instead of a bearer token — Clerk can&apos;t send a custom
+          auth header. Leave blank for bearer-token senders like Clay.
+        </p>
+      </div>
       {state.error && (
         <p className="text-sentiment-negative text-sm" role="alert">
           {state.error}
@@ -300,24 +320,49 @@ export function AddWebhookForm({
         </Button>
       </div>
       {state.secret && (
-        <SecretReveal url={state.secret.url} token={state.secret.token} />
+        <SecretReveal
+          url={state.secret.url}
+          token={state.secret.token}
+          signed={state.secret.signed}
+        />
       )}
     </form>
   );
 }
 
-function SecretReveal({ url, token }: { url: string; token: string }) {
+function SecretReveal({
+  url,
+  token,
+  signed,
+}: {
+  url: string;
+  token: string;
+  signed: boolean;
+}) {
   return (
     <div className="border-sentiment-caution bg-[var(--color-sentiment-caution-subtle)] flex flex-col gap-2 rounded-lg border p-3">
       <span className="text-foreground text-sm font-medium">
-        Copy these now — the token is shown only once.
+        {signed
+          ? "Point Clerk at this URL."
+          : "Copy these now — the token is shown only once."}
       </span>
       <Field label="Endpoint URL" value={url} />
-      <Field label="Bearer token" value={token} mono />
+      {!signed && <Field label="Bearer token" value={token} mono />}
       <p className="text-foreground-weak text-sm leading-5">
-        In Clay, add an HTTP API column: method <code>POST</code>, URL above, and
-        a header <code>Authorization: Bearer &lt;token&gt;</code>. The agent
-        receives the request body as its input.
+        {signed ? (
+          <>
+            In Clerk, add a webhook endpoint with this URL and subscribe to the
+            events you want. TAS verifies each delivery&apos;s signature against
+            the signing secret you pasted above; the agent receives the Clerk
+            event as its input.
+          </>
+        ) : (
+          <>
+            In Clay, add an HTTP API column: method <code>POST</code>, URL above,
+            and a header <code>Authorization: Bearer &lt;token&gt;</code>. The
+            agent receives the request body as its input.
+          </>
+        )}
       </p>
     </div>
   );

--- a/web/src/app/api/hooks/webhook/[webhookId]/route.ts
+++ b/web/src/app/api/hooks/webhook/[webhookId]/route.ts
@@ -5,6 +5,7 @@ import {
   countRecentEventRuns,
   getWebhookForInbound,
   recordWebhookFire,
+  webhookSvixMatches,
   webhookTokenMatches,
 } from "@/lib/webhooks-db";
 import { resolveAgentForDispatch } from "@/lib/workspace-agents";
@@ -13,12 +14,15 @@ import { resolveAgentForDispatch } from "@/lib/workspace-agents";
 // fire an agent run:
 //
 //   POST /api/hooks/webhook/<id>
-//   Authorization: Bearer <token>
+//   Authorization: Bearer <token>        (bearer mode — Clay)
 //   { ...arbitrary JSON the agent interprets... }
 //
-// Auth is the per-webhook bearer token (constant-time compared in
-// webhookTokenMatches), not a TAS session — the caller has no session. The row
-// id in the URL is the public selector; the token is the secret.
+// Auth is per-webhook, not a TAS session (the caller has no session). The row
+// id in the URL is the public selector. Two modes: a bearer token
+// (constant-time compared in webhookTokenMatches), or — for senders that can't
+// set a custom header, notably Clerk — Svix request signing, verified against
+// the webhook's stored signing secret (webhookSvixMatches) using the
+// svix-id/svix-timestamp/svix-signature headers.
 //
 // Fire-and-forget: we queue the run via /internal/runs (trigger='event') and
 // ack 202 immediately. The agent receives the request body as its input; its
@@ -57,9 +61,23 @@ export async function POST(
     return NextResponse.json({ error: "webhook disabled" }, { status: 403 });
   }
 
-  const presented = bearer(request);
-  if (!presented || !webhookTokenMatches(webhook, presented)) {
-    return NextResponse.json({ error: "invalid token" }, { status: 401 });
+  // Signed webhooks (Clerk) verify the Svix signature; everything else uses the
+  // bearer token. The signing secret's presence picks the mode.
+  if (webhook.signingSecretCiphertext) {
+    const ok = webhookSvixMatches(webhook, {
+      rawBody,
+      svixId: request.headers.get("svix-id"),
+      svixTimestamp: request.headers.get("svix-timestamp"),
+      svixSignature: request.headers.get("svix-signature"),
+    });
+    if (!ok) {
+      return NextResponse.json({ error: "invalid signature" }, { status: 401 });
+    }
+  } else {
+    const presented = bearer(request);
+    if (!presented || !webhookTokenMatches(webhook, presented)) {
+      return NextResponse.json({ error: "invalid token" }, { status: 401 });
+    }
   }
 
   const recent = await countRecentEventRuns(

--- a/web/src/lib/crypto-aad.ts
+++ b/web/src/lib/crypto-aad.ts
@@ -55,6 +55,11 @@ export function aadWebhookToken(workspaceId: string, id: string): string {
   return `webhook${SEP}${workspaceId}${SEP}${id}`;
 }
 
+/** `workspace_webhook` Svix signing secret, keyed by (workspace_id, id). */
+export function aadWebhookSigningSecret(workspaceId: string, id: string): string {
+  return `webhook_signing${SEP}${workspaceId}${SEP}${id}`;
+}
+
 /** `workspace_api_key` token, keyed by (workspace_id, id). */
 export function aadApiKeyToken(workspaceId: string, id: string): string {
   return `api_key${SEP}${workspaceId}${SEP}${id}`;

--- a/web/src/lib/svix-verify.test.ts
+++ b/web/src/lib/svix-verify.test.ts
@@ -1,0 +1,126 @@
+import { createHmac, randomBytes } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { verifySvixRequest } from "./svix-verify";
+
+// A `whsec_`-prefixed secret + a helper that signs exactly like Svix/Clerk.
+const keyBytes = randomBytes(24);
+const secret = "whsec_" + keyBytes.toString("base64");
+
+function sign(id: string, ts: string, body: string): string {
+  const sig = createHmac("sha256", keyBytes)
+    .update(`${id}.${ts}.${body}`)
+    .digest("base64");
+  return `v1,${sig}`;
+}
+
+describe("verifySvixRequest", () => {
+  const id = "msg_2abcDEF";
+  const ts = "1700000000";
+  const body = JSON.stringify({ type: "user.created", data: { id: "u_1" } });
+
+  it("accepts a valid signature within the window", () => {
+    expect(
+      verifySvixRequest({
+        signingSecret: secret,
+        rawBody: body,
+        svixId: id,
+        svixTimestamp: ts,
+        svixSignature: sign(id, ts, body),
+        now: 1700000005,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts when one of several space-separated signatures matches", () => {
+    const sig = `v1,deadbeef ${sign(id, ts, body)} v0,ignored`;
+    expect(
+      verifySvixRequest({
+        signingSecret: secret,
+        rawBody: body,
+        svixId: id,
+        svixTimestamp: ts,
+        svixSignature: sig,
+        now: 1700000005,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("works with a bare (no whsec_ prefix) base64 secret", () => {
+    expect(
+      verifySvixRequest({
+        signingSecret: keyBytes.toString("base64"),
+        rawBody: body,
+        svixId: id,
+        svixTimestamp: ts,
+        svixSignature: sign(id, ts, body),
+        now: 1700000005,
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    expect(
+      verifySvixRequest({
+        signingSecret: secret,
+        rawBody: body + "tamper",
+        svixId: id,
+        svixTimestamp: ts,
+        svixSignature: sign(id, ts, body),
+        now: 1700000005,
+      }),
+    ).toEqual({ ok: false, reason: "bad-signature" });
+  });
+
+  it("rejects a signature bound to a different svix-id", () => {
+    expect(
+      verifySvixRequest({
+        signingSecret: secret,
+        rawBody: body,
+        svixId: "msg_other",
+        svixTimestamp: ts,
+        svixSignature: sign(id, ts, body),
+        now: 1700000005,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects the wrong signing secret", () => {
+    expect(
+      verifySvixRequest({
+        signingSecret: "whsec_" + randomBytes(24).toString("base64"),
+        rawBody: body,
+        svixId: id,
+        svixTimestamp: ts,
+        svixSignature: sign(id, ts, body),
+        now: 1700000005,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects a stale timestamp", () => {
+    expect(
+      verifySvixRequest({
+        signingSecret: secret,
+        rawBody: body,
+        svixId: id,
+        svixTimestamp: ts,
+        svixSignature: sign(id, ts, body),
+        now: 1700000000 + 600,
+      }),
+    ).toEqual({ ok: false, reason: "stale" });
+  });
+
+  it("rejects missing headers", () => {
+    expect(
+      verifySvixRequest({
+        signingSecret: secret,
+        rawBody: body,
+        svixId: null,
+        svixTimestamp: ts,
+        svixSignature: sign(id, ts, body),
+      }),
+    ).toEqual({ ok: false, reason: "missing-headers" });
+  });
+});

--- a/web/src/lib/svix-verify.ts
+++ b/web/src/lib/svix-verify.ts
@@ -1,0 +1,70 @@
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// Svix webhook signature verification — used by Clerk and any other Svix-powered
+// sender. https://docs.svix.com/receiving/verifying-payloads/how-manual
+//
+// The sender includes svix-id, svix-timestamp, and svix-signature headers. The
+// signature is HMAC-SHA256 over "{id}.{timestamp}.{rawBody}", keyed by the
+// endpoint signing secret — the base64 part after the `whsec_` prefix — and
+// itself base64-encoded. svix-signature is a SPACE-separated list of
+// "v1,<sig>" tokens (a secret may be rotated, so several can be present); we
+// accept if any v1 signature matches. We also reject timestamps more than 5
+// minutes off to blunt replay. The raw body must be the exact bytes the sender
+// signed — read request.text() before any parsing.
+
+const MAX_AGE_SECONDS = 60 * 5;
+
+export type SvixVerifyResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "missing-headers" | "stale" | "bad-secret" | "bad-signature";
+    };
+
+export function verifySvixRequest(args: {
+  /** The endpoint signing secret — `whsec_...` or the bare base64 key. */
+  signingSecret: string;
+  rawBody: string;
+  svixId: string | null;
+  svixTimestamp: string | null;
+  svixSignature: string | null;
+  /** Current unix seconds; injectable for tests. */
+  now?: number;
+}): SvixVerifyResult {
+  const { signingSecret, rawBody, svixId, svixTimestamp, svixSignature } = args;
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return { ok: false, reason: "missing-headers" };
+  }
+  const ts = Number(svixTimestamp);
+  if (!Number.isFinite(ts)) return { ok: false, reason: "missing-headers" };
+  const now = args.now ?? Math.floor(Date.now() / 1000);
+  if (Math.abs(now - ts) > MAX_AGE_SECONDS) return { ok: false, reason: "stale" };
+
+  // The signing secret is the base64 key after the `whsec_` prefix.
+  const rawKey = signingSecret.startsWith("whsec_")
+    ? signingSecret.slice("whsec_".length)
+    : signingSecret;
+  const key = Buffer.from(rawKey, "base64");
+  if (key.length === 0) return { ok: false, reason: "bad-secret" };
+
+  const expected = createHmac("sha256", key)
+    .update(`${svixId}.${svixTimestamp}.${rawBody}`)
+    .digest("base64");
+  const expectedBuf = Buffer.from(expected, "utf8");
+
+  // svix-signature: space-separated "v1,<base64sig>" tokens — accept any match.
+  for (const part of svixSignature.split(" ")) {
+    const comma = part.indexOf(",");
+    if (comma === -1 || part.slice(0, comma) !== "v1") continue;
+    const sigBuf = Buffer.from(part.slice(comma + 1), "utf8");
+    if (
+      sigBuf.length === expectedBuf.length &&
+      timingSafeEqual(sigBuf, expectedBuf)
+    ) {
+      return { ok: true };
+    }
+  }
+  return { ok: false, reason: "bad-signature" };
+}

--- a/web/src/lib/webhooks-db.ts
+++ b/web/src/lib/webhooks-db.ts
@@ -3,19 +3,23 @@ import "server-only";
 import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 
 import { decryptSecret, encryptSecret, last4 } from "@/lib/crypto";
-import { aadWebhookToken } from "@/lib/crypto-aad";
+import { aadWebhookSigningSecret, aadWebhookToken } from "@/lib/crypto-aad";
 import { db } from "@/lib/db";
+import { verifySvixRequest } from "@/lib/svix-verify";
 
 // External webhook triggers — an inbound HTTP endpoint that fires an agent run.
-// An outside system (Clay first) POSTs JSON to /api/hooks/webhook/<id> with an
-// `Authorization: Bearer <token>` header; TAS queues a run of the bound agent
-// acting as the webhook's owner. The row `id` is the public URL selector; the
-// bearer token is the secret (encrypted at rest, shown once on creation).
+// An outside system POSTs JSON to /api/hooks/webhook/<id>; TAS queues a run of
+// the bound agent acting as the webhook's owner. The row `id` is the public URL
+// selector. Auth is one of two modes:
+//   - bearer (default): caller sends `Authorization: Bearer <token>` (Clay).
+//   - signed (Svix): caller signs each delivery and we verify it against the
+//     stored signing secret (Clerk, which can't set a custom header).
+// Both secrets are encrypted at rest; the bearer token is shown once on create.
 //
 // Modeled on lib/triggers-db.ts (Composio event triggers), minus the Composio
 // integration — these are TAS-owned endpoints with no third party.
 
-/** Masked, client-safe view — never carries the plaintext token. */
+/** Masked, client-safe view — never carries a plaintext secret. */
 export type WebhookPreview = {
   id: string;
   workspaceId: string;
@@ -23,17 +27,24 @@ export type WebhookPreview = {
   ownerUserId: string;
   name: string;
   tokenLast4: string;
+  /** True when this webhook authenticates by Svix signature (Clerk) rather than
+   *  a bearer token. */
+  hasSigningSecret: boolean;
   enabled: boolean;
   lastFiredAt: Date | null;
   lastFireError: string | null;
   createdAt: Date;
 };
 
-/** Full row including the ciphertext — server-only, for token verification. */
-export type WebhookRow = WebhookPreview & { tokenCiphertext: Buffer };
+/** Full row including the ciphertexts — server-only, for inbound verification. */
+export type WebhookRow = WebhookPreview & {
+  tokenCiphertext: Buffer;
+  signingSecretCiphertext: Buffer | null;
+};
 
 const PREVIEW_COLS = `id, workspace_id, agent_name, owner_user_id, name,
-  token_last4, enabled, last_fired_at, last_fire_error, created_at`;
+  token_last4, (signing_secret_ciphertext IS NOT NULL) AS has_signing_secret,
+  enabled, last_fired_at, last_fire_error, created_at`;
 
 type PreviewDbRow = {
   id: string;
@@ -42,6 +53,7 @@ type PreviewDbRow = {
   owner_user_id: string;
   name: string;
   token_last4: string;
+  has_signing_secret: boolean;
   enabled: boolean;
   last_fired_at: Date | null;
   last_fire_error: string | null;
@@ -56,6 +68,7 @@ function toPreview(r: PreviewDbRow): WebhookPreview {
     ownerUserId: r.owner_user_id,
     name: r.name,
     tokenLast4: r.token_last4,
+    hasSigningSecret: r.has_signing_secret,
     enabled: r.enabled,
     lastFiredAt: r.last_fired_at,
     lastFireError: r.last_fire_error,
@@ -116,14 +129,24 @@ export async function getWebhookPreview(
 export async function getWebhookForInbound(
   id: string,
 ): Promise<WebhookRow | null> {
-  const { rows } = await db.query<PreviewDbRow & { token_ciphertext: Buffer }>(
-    `SELECT ${PREVIEW_COLS}, token_ciphertext FROM workspace_webhook
+  const { rows } = await db.query<
+    PreviewDbRow & {
+      token_ciphertext: Buffer;
+      signing_secret_ciphertext: Buffer | null;
+    }
+  >(
+    `SELECT ${PREVIEW_COLS}, token_ciphertext, signing_secret_ciphertext
+       FROM workspace_webhook
       WHERE id = $1`,
     [id],
   );
   const r = rows[0];
   if (!r) return null;
-  return { ...toPreview(r), tokenCiphertext: r.token_ciphertext };
+  return {
+    ...toPreview(r),
+    tokenCiphertext: r.token_ciphertext,
+    signingSecretCiphertext: r.signing_secret_ciphertext,
+  };
 }
 
 /** Constant-time check that a presented token matches the stored one. */
@@ -148,21 +171,52 @@ export function webhookTokenMatches(
   return timingSafeEqual(a, b);
 }
 
+/**
+ * Verify a Svix-signed inbound (Clerk) against the webhook's stored signing
+ * secret. Returns false if this webhook isn't a signed one or the signature
+ * doesn't verify. The raw body must be the exact bytes the sender signed.
+ */
+export function webhookSvixMatches(
+  row: WebhookRow,
+  args: {
+    rawBody: string;
+    svixId: string | null;
+    svixTimestamp: string | null;
+    svixSignature: string | null;
+  },
+): boolean {
+  if (!row.signingSecretCiphertext) return false;
+  let secret: string;
+  try {
+    secret = decryptSecret(
+      row.signingSecretCiphertext,
+      aadWebhookSigningSecret(row.workspaceId, row.id),
+    );
+  } catch {
+    return false;
+  }
+  return verifySvixRequest({ signingSecret: secret, ...args }).ok;
+}
+
 export async function createWebhook(args: {
   workspaceId: string;
   agentName: string;
   ownerUserId: string;
   name: string;
   createdBy: string;
+  /** Optional Svix signing secret (`whsec_...`). When set, the webhook
+   *  authenticates by signature (Clerk) instead of the bearer token. */
+  signingSecret?: string | null;
 }): Promise<{ webhook: WebhookPreview; token: string }> {
   const token = generateToken();
-  // Generate the id up front so the token AAD can bind to it at encrypt time.
+  // Generate the id up front so the secret AADs can bind to it at encrypt time.
   const id = randomUUID();
+  const signing = args.signingSecret?.trim() || null;
   const { rows } = await db.query<PreviewDbRow>(
     `INSERT INTO workspace_webhook
        (id, workspace_id, agent_name, owner_user_id, name, token_ciphertext,
-        token_last4, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        token_last4, signing_secret_ciphertext, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        RETURNING ${PREVIEW_COLS}`,
     [
       id,
@@ -172,6 +226,9 @@ export async function createWebhook(args: {
       args.name,
       encryptSecret(token, aadWebhookToken(args.workspaceId, id)),
       last4(token),
+      signing
+        ? encryptSecret(signing, aadWebhookSigningSecret(args.workspaceId, id))
+        : null,
       args.createdBy,
     ],
   );


### PR DESCRIPTION
Lets you trigger an agent from inbound **Clerk** webhooks (e.g. `user.created`, `organization.created`).

## Why a change was needed
TAS already fires agents from inbound webhooks — but only with a per-webhook **bearer token**. Clerk authenticates differently: it's **Svix-powered** and signs each delivery (`svix-id` / `svix-timestamp` / `svix-signature`, HMAC-SHA256 over `{id}.{timestamp}.{body}` with a `whsec_…` secret), and Clerk's dashboard gives you no way to add a custom `Authorization` header. So today Clerk would hit the endpoint with no bearer token → 401.

## What this adds
An optional per-webhook **signing secret**. When set, the webhook authenticates by **signature** instead of a bearer token; everything else (delivery → run, the event payload as the agent's input) is unchanged.

- **`migration 0067`** — nullable `signing_secret_ciphertext` on `workspace_webhook` (encrypted at rest, AAD-bound to `(workspace, id)`; only the web layer reads it).
- **`svix-verify.ts`** — manual Svix HMAC-SHA256 verification (handles multiple space-separated `v1,` signatures; ±5-min replay window), mirroring the existing `slack-verify.ts`. Unit tests included (valid, tampered body, wrong id, wrong secret, stale, missing headers, bare/`whsec_` secret).
- **`webhooks-db`** — encrypt/store the signing secret; expose `hasSigningSecret`; `webhookSvixMatches()` for the receiver.
- **`route`** — verify the Svix signature when the webhook is signed; otherwise the bearer path (unchanged).
- **UI** — the create form gets an optional **"Clerk signing secret (`whsec_…`)"** field with Clerk-specific setup copy; the automations table shows **"signed (Clerk)"** instead of the token last4.

## Setup (end to end)
1. Create a webhook on the agent, paste Clerk's endpoint **signing secret**.
2. In Clerk, add a webhook endpoint pointing at the TAS URL and subscribe to events.
3. Each subscribed Clerk event fires the agent with the event payload as its input. Generalizes to any Svix-powered sender.

## Checks
`tsc` clean · `eslint` clean · `vitest` **148/148** (8 new svix-verify tests). No Rust change (the runner never reads this column). Migration applies on api boot via `sqlx::migrate!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)