### PR TITLE
Make webhook signing-secret UI provider-agnostic

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/agent-automations-table.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/agent-automations-table.tsx
@@ -471,7 +471,7 @@ function TriggerDetail({ row }: { row: AgentAutomationRow }) {
       <span className="text-foreground-weak text-sm">
         Inbound POST{" "}
         {row.signed ? (
-          <span className="text-foreground-muted">signed (Clerk)</span>
+          <span className="text-foreground-muted">signed (Svix)</span>
         ) : row.tokenLast4 ? (
           <code className="text-foreground-muted">...{row.tokenLast4}</code>
         ) : null}

--- a/web/src/app/[workspace]/agents/[agent]/webhooks-actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/webhooks-actions.ts
@@ -60,7 +60,7 @@ export async function createWebhookAction(
   // here rather than silently never verifying.
   if (signingSecret && !/^whsec_[A-Za-z0-9+/=]{16,}$/.test(signingSecret)) {
     return {
-      error: "Signing secret should look like `whsec_…` (from Clerk's webhook endpoint).",
+      error: "Signing secret should look like `whsec_…` (the Svix signing secret from your webhook provider).",
     };
   }
 

--- a/web/src/app/[workspace]/agents/[agent]/webhooks-section.tsx
+++ b/web/src/app/[workspace]/agents/[agent]/webhooks-section.tsx
@@ -292,7 +292,7 @@ export function AddWebhookForm({
       )}
       <div className="grid gap-1.5">
         <Label htmlFor="webhook-signing-secret" className="text-sm">
-          Clerk signing secret{" "}
+          Signing secret{" "}
           <span className="text-foreground-muted">(optional)</span>
         </Label>
         <Input
@@ -304,9 +304,10 @@ export function AddWebhookForm({
           className="max-w-sm font-mono"
         />
         <p className="text-foreground-muted text-sm">
-          Paste this to verify <strong>Clerk</strong> (Svix-signed) webhooks by
-          signature instead of a bearer token — Clerk can&apos;t send a custom
-          auth header. Leave blank for bearer-token senders like Clay.
+          Paste this to verify <strong>Svix-signed</strong> webhooks (e.g. Clerk)
+          by signature instead of a bearer token — useful when the sender
+          can&apos;t add a custom auth header. Leave blank for bearer-token
+          senders like Clay.
         </p>
       </div>
       {state.error && (
@@ -343,7 +344,7 @@ function SecretReveal({
     <div className="border-sentiment-caution bg-[var(--color-sentiment-caution-subtle)] flex flex-col gap-2 rounded-lg border p-3">
       <span className="text-foreground text-sm font-medium">
         {signed
-          ? "Point Clerk at this URL."
+          ? "Point your provider at this URL."
           : "Copy these now — the token is shown only once."}
       </span>
       <Field label="Endpoint URL" value={url} />
@@ -351,10 +352,10 @@ function SecretReveal({
       <p className="text-foreground-weak text-sm leading-5">
         {signed ? (
           <>
-            In Clerk, add a webhook endpoint with this URL and subscribe to the
-            events you want. TAS verifies each delivery&apos;s signature against
-            the signing secret you pasted above; the agent receives the Clerk
-            event as its input.
+            In your provider (e.g. Clerk), add a webhook endpoint with this URL
+            and subscribe to the events you want. TAS verifies each
+            delivery&apos;s signature against the signing secret you pasted
+            above; the agent receives the event as its input.
           </>
         ) : (
           <>


### PR DESCRIPTION
Follow-up to #253. The signing-secret field was branded **"Clerk signing secret"**, but Svix signing isn't Clerk-specific (any Svix-powered sender uses it). Per feedback, make it generic with Clerk/Clay as examples rather than the framing:

- Field label: "Clerk signing secret" → **"Signing secret"**
- Helper copy: reframed around "**Svix-signed** webhooks (e.g. Clerk)" — useful when the sender can't add a custom auth header
- Reveal copy: "Point your provider at this URL" / "In your provider (e.g. Clerk)…"
- Validation error: "the Svix signing secret from your webhook provider"
- Automations table mode label: "signed (Clerk)" → **"signed (Svix)"**

Copy-only; `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)