### PR TITLE
CAP prompt: place the agent-file target next to the user's request

### DIFF
--- a/web/src/lib/cap-api.ts
+++ b/web/src/lib/cap-api.ts
@@ -433,9 +433,7 @@ export function buildChatEditPrompt(args: {
   return [
     buildGuidancePointerBlock(framework),
     "",
-    "**Step 2 — Requested change**",
-    "",
-    `Improve the agent defined at @${args.agentPath}.`,
+    "**Step 2 — Delivery**",
     "",
     ...deliveryDirective(
       args.commitMode,
@@ -451,7 +449,13 @@ export function buildChatEditPrompt(args: {
       args.nativeToolsBaseUrl,
       args.nativeToolsKey,
     ),
+    // Keep the file target adjacent to the user's request (TAS fills the path
+    // in from the agent's route, not the user's words) so it stays in front of
+    // CAP right where the instruction is.
     "## Requested change",
+    "",
+    `Improve the agent defined at @${args.agentPath}:`,
+    "",
     args.improvement.trim(),
   ].join("\n");
 }
@@ -480,9 +484,7 @@ export function buildImprovePrompt(args: {
   return [
     buildGuidancePointerBlock(framework),
     "",
-    "**Step 2 — Requested change**",
-    "",
-    `Improve the agent defined at @${args.agentPath}.`,
+    "**Step 2 — Delivery**",
     "",
     ...deliveryDirective(
       args.commitMode,
@@ -490,7 +492,12 @@ export function buildImprovePrompt(args: {
       args.improvementMarker,
     ),
     "",
+    // Keep the file target next to the user's request (TAS fills the path in
+    // from the run's agent, not the user's words).
     "## Improvement requested by the user",
+    "",
+    `Improve the agent defined at @${args.agentPath}:`,
+    "",
     args.improvement.trim(),
     "",
     "## Context: the run that prompted this request",


### PR DESCRIPTION
Per feedback while inspecting a chat-to-edit prompt: the file target (`Improve the agent defined at @<path>.`) sat at the **top** under "Step 2 — Requested change", but the user's actual instruction was at the **bottom**, after the connection-slot reference blocks. Moving the target down next to the request reads better and keeps it in CAP's attention right where the instruction is.

## Change (`web/src/lib/cap-api.ts`, both `buildChatEditPrompt` + `buildImprovePrompt`)
- Move `Improve the agent defined at @<path>` from the top to the bottom, as the lead-in to the user's request: `Improve @<path>:` then the request text.
- Rename the now delivery-only section from "Step 2 — Requested change" → **"Step 2 — Delivery"** (it only carries the commit/PR directive + the `TAS-Feedback-ID` marker).

Before → after (chat-edit):
```
Step 2 — Requested change          Step 2 — Delivery
Improve @<path>.                    <commit to main / open PR + TAS-Feedback-ID>
<commit to main + marker>           <connection slots>
<connection slots>                  ## Requested change
## Requested change                 Improve @<path>:
<user text>                         <user text>
```

No change to the `TAS-Feedback-ID` correlation (the marker line still lives in the delivery directive). `tsc`/`eslint` clean, `vitest` 148/148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)