### PR TITLE
Graceful shutdown: drain in-flight runs before the api exits

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use axum::{middleware, routing::get, routing::post, Router};
@@ -30,6 +32,10 @@ pub struct AppState {
     pub http: reqwest::Client,
     pub encryption_key: Arc<crypto::MasterKey>,
     pub run_cancels: RunCancels,
+    /// Set once a shutdown signal (SIGTERM from a deploy/restart) arrives, so the
+    /// run endpoint refuses new work while in-flight runs drain. See main()'s
+    /// graceful-shutdown path.
+    pub draining: Arc<AtomicBool>,
 }
 
 #[tokio::main]
@@ -103,6 +109,7 @@ async fn main() -> anyhow::Result<()> {
         http,
         encryption_key,
         run_cancels: Arc::new(Mutex::new(HashMap::new())),
+        draining: Arc::new(AtomicBool::new(false)),
     };
 
     let internal_routes = Router::new()
@@ -111,6 +118,11 @@ async fn main() -> anyhow::Result<()> {
         .route("/runs/{id}/cancel", post(runs::handlers::cancel_run))
         .layer(middleware::from_fn(auth::require_internal_token))
         .layer(axum::Extension(internal_token));
+
+    // Handles for the graceful-shutdown path, cloned before `state` moves into
+    // the router.
+    let draining = state.draining.clone();
+    let run_cancels = state.run_cancels.clone();
 
     let app = Router::new()
         .route("/health", get(routes::health::health))
@@ -124,7 +136,87 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("tas-api listening on {bind_addr}");
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal(draining))
+        .await?;
+
+    // The HTTP server has stopped accepting connections. Runs execute as detached
+    // tokio tasks owning a Python subprocess, so wait for the in-flight ones to
+    // finish before exiting — a deploy/restart no longer guillotines a run
+    // mid-flight (which the boot reconciler would otherwise mark 'failed'). Bounded
+    // by API_DRAIN_TIMEOUT_SECS: the platform SIGKILLs after its own grace window
+    // regardless, and runs that outlast the window fall back to the reconciler,
+    // exactly as before this change.
+    drain_runs(&run_cancels, drain_timeout()).await;
 
     Ok(())
+}
+
+/// Seconds to wait for in-flight runs to drain on shutdown. Keep at/under the
+/// platform's pre-SIGKILL grace window (raise both together to protect longer
+/// runs). Overridable via `API_DRAIN_TIMEOUT_SECS`.
+const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 25;
+
+fn drain_timeout() -> Duration {
+    let secs = std::env::var("API_DRAIN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_DRAIN_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Resolves when the process is asked to stop — SIGTERM (a deploy/restart) or
+/// Ctrl-C locally. Flips `draining` so `create_run` starts refusing new work,
+/// then returns, which tells axum to stop accepting connections.
+async fn shutdown_signal(draining: Arc<AtomicBool>) {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => {
+                tracing::error!(?e, "failed to install SIGTERM handler");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+    draining.store(true, Ordering::SeqCst);
+    tracing::info!("shutdown signal received — refusing new runs, draining in-flight ones");
+}
+
+/// Wait for in-flight runs (tracked in `run_cancels`) to finish, up to `timeout`.
+/// Runs still executing when the timeout hits are left to the boot reconciler on
+/// the next start (same as an unclean stop), so shutdown never blocks forever.
+async fn drain_runs(run_cancels: &RunCancels, timeout: Duration) {
+    let start = Instant::now();
+    loop {
+        let remaining = run_cancels.lock().map(|m| m.len()).unwrap_or(0);
+        if remaining == 0 {
+            tracing::info!("all in-flight runs drained; exiting");
+            return;
+        }
+        if start.elapsed() >= timeout {
+            tracing::warn!(
+                remaining,
+                "drain timeout reached; remaining runs will be reconciled as interrupted on next boot"
+            );
+            return;
+        }
+        tracing::info!(
+            remaining,
+            "waiting for in-flight runs to finish before exit…"
+        );
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
 }

--- a/api/src/runs/handlers.rs
+++ b/api/src/runs/handlers.rs
@@ -89,6 +89,17 @@ pub async fn create_run(
     State(state): State<AppState>,
     Json(req): Json<CreateRunRequest>,
 ) -> Result<Json<CreateRunResponse>, (StatusCode, String)> {
+    // Refuse new work once we've started draining for shutdown — the run would be
+    // guillotined by the imminent SIGKILL, then reconciled as failed on boot. The
+    // web layer surfaces this as a failed dispatch; during a deploy new traffic is
+    // routed to the fresh instance anyway.
+    if state.draining.load(std::sync::atomic::Ordering::SeqCst) {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "api is shutting down".to_string(),
+        ));
+    }
+
     let run_id = Uuid::new_v4();
 
     let user_message = req.user_message.unwrap_or_default();


### PR DESCRIPTION
Implements the graceful-drain idea from earlier: stop deploys/restarts from killing in-flight runs.

## Problem
`main.rs` ran `axum::serve(...).await` with **no signal handling**. On SIGTERM (a Railway redeploy) the process died instantly, taking any in-flight run with it; the boot reconciler then marked those runs `failed` ("Interrupted — the server restarted while this run was in progress."). Run `754894ca` (a 12s run) was a recent casualty of a deploy landing on top of it.

## Fix — bounded graceful drain
The hard part already existed: `run_cancels` (`Arc<Mutex<HashMap<run_id, CancellationToken>>>`) tracks exactly the in-flight runs. So:

1. **Catch SIGTERM / Ctrl-C** (`shutdown_signal`) → flip an `AppState.draining` flag.
2. **`create_run` refuses new work** with `503` while draining (during a deploy, new traffic is routed to the fresh instance anyway).
3. **`axum::serve(...).with_graceful_shutdown(...)`** stops accepting connections.
4. **Wait for in-flight runs to drain** (`drain_runs` polls `run_cancels` until empty), bounded by **`API_DRAIN_TIMEOUT_SECS`** (default **25s**), then exit.

## Why bounded (and no regression)
The platform SIGKILLs after its own grace window regardless, so a run that outlasts the timeout falls back to the **existing boot reconciler** — exactly today's behavior. Nothing gets worse; **short runs (the common casualty) are now protected**. Multi-minute runs need durable/resumable execution (#170) — out of scope here.

## Operating note
To protect longer runs, raise `API_DRAIN_TIMEOUT_SECS` **and** the platform's pre-SIGKILL grace window together (on Railway, the deploy stop timeout). The default 25s targets the typical short-run case without holding deploys open.

## Checks
`cargo check` / `clippy` clean (only pre-existing dead-code warnings) · `cargo fmt --check` clean · `cargo test` 43/43.

## Manual verification
Locally: start the api, kick off a run, send SIGTERM → the process should log "draining in-flight runs", wait for the run to finish (or the 25s cap), then exit; the run lands `succeeded` instead of `failed`. A second SIGTERM-during-idle exits immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)