### PR TITLE
Optional API key on native-MCP connections (bundled + per-user)

### DIFF
--- a/api/migrations/0068_workspace_connection_aux_secret.sql
+++ b/api/migrations/0068_workspace_connection_aux_secret.sql
@@ -1,0 +1,16 @@
+-- Optional supplementary API key on a native-MCP connection.
+--
+-- Some providers' MCP OAuth grants only coarse scopes (Attio: mcp /
+-- offline_access / openid — no record/note/delete granularity), so privileged
+-- operations need the provider's own API key (an Attio access token with
+-- granular scopes). Rather than a separate, workspace-shared secret wired by a
+-- magic slug, the key rides the connection it belongs to — bundled, and per-user
+-- by construction (workspace_connection is keyed by user_id).
+--
+-- Encrypted at rest with the shared AES-256-GCM master key, AAD-bound to the
+-- same (workspace_id, user_id, type, name) identity as `credentials` (so the
+-- existing aadNativeConnection / crypto::aad::native_connection works for it).
+-- Independent of the OAuth token in `credentials`: the refresh sweep rewrites
+-- `credentials` only and never touches this column.
+ALTER TABLE workspace_connection
+    ADD COLUMN IF NOT EXISTS aux_secret_ciphertext BYTEA;

--- a/api/scripts/tas_tools.py
+++ b/api/scripts/tas_tools.py
@@ -80,6 +80,10 @@ class Connection:
     access_token: str
     #: The provider's MCP endpoint URL (for talking MCP directly).
     mcp_url: str
+    #: Optional supplementary API key the user attached to this connection, for
+    #: privileged REST ops the OAuth token can't do (e.g. an Attio access token
+    #: with note/delete scope). `None` when unset.
+    api_key: str | None = None
 
 
 def _load() -> dict:
@@ -122,8 +126,13 @@ def connection(provider: str, name: str = "default") -> Connection:
             f'the "{provider}"/"{name}" connection is missing credentials '
             f"for this run"
         )
+    api_key = entry.get("api_key") or None
     return Connection(
-        provider=provider, name=name, access_token=token, mcp_url=url
+        provider=provider,
+        name=name,
+        access_token=token,
+        mcp_url=url,
+        api_key=api_key,
     )
 
 

--- a/api/src/runs/runner.rs
+++ b/api/src/runs/runner.rs
@@ -453,6 +453,9 @@ async fn run_pydantic(
                     "access_token".to_string(),
                     serde_json::Value::String(row.access_token),
                 );
+                if let Some(api_key) = row.api_key {
+                    entry.insert("api_key".to_string(), serde_json::Value::String(api_key));
+                }
                 by_provider
                     .entry(row.provider)
                     .or_default()

--- a/api/src/workspace.rs
+++ b/api/src/workspace.rs
@@ -59,6 +59,10 @@ pub struct NativeMcpRow {
     pub name: String,
     pub mcp_url: String,
     pub access_token: String,
+    /// Optional supplementary API key the user attached to this connection (for
+    /// privileged REST ops the MCP OAuth token can't do, e.g. Attio note/delete).
+    /// `None` when unset; surfaced to the runtime as `tas_tools.connection().api_key`.
+    pub api_key: Option<String>,
 }
 
 /// Decrypted native-MCP connections owned by a specific user in a
@@ -79,8 +83,8 @@ pub async fn list_active_native_connections(
     workspace_id: uuid::Uuid,
     user_id: &str,
 ) -> anyhow::Result<Vec<NativeMcpRow>> {
-    let rows: Vec<(String, String, Option<String>, Vec<u8>)> = sqlx::query_as(
-        "SELECT type, name, mcp_server_url, credentials \
+    let rows: Vec<(String, String, Option<String>, Vec<u8>, Option<Vec<u8>>)> = sqlx::query_as(
+        "SELECT type, name, mcp_server_url, credentials, aux_secret_ciphertext \
            FROM workspace_connection \
           WHERE workspace_id = $1 AND user_id = $2 AND status = 'active'",
     )
@@ -91,7 +95,7 @@ pub async fn list_active_native_connections(
     .context("failed to list workspace_connection")?;
 
     let mut out = Vec::with_capacity(rows.len());
-    for (provider, name, mcp_url, ciphertext) in rows {
+    for (provider, name, mcp_url, ciphertext, aux_ciphertext) in rows {
         let mcp_url = match mcp_url {
             Some(u) if !u.is_empty() => u,
             _ => {
@@ -121,11 +125,25 @@ pub async fn list_active_native_connections(
                 continue;
             }
         };
+        // Optional supplementary API key, encrypted under the SAME AAD as
+        // credentials. A decrypt failure is non-fatal: drop just the aux key (the
+        // connection still works for everything the OAuth token covers).
+        let api_key = aux_ciphertext.and_then(|ct| {
+            match key.decrypt_aad(&ct, aad.as_bytes()) {
+                Ok(s) if !s.is_empty() => Some(s),
+                Ok(_) => None,
+                Err(e) => {
+                    tracing::warn!(?e, %provider, %name, "native connection aux key failed to decrypt; ignoring");
+                    None
+                }
+            }
+        });
         out.push(NativeMcpRow {
             provider,
             name,
             mcp_url,
             access_token,
+            api_key,
         });
     }
     Ok(out)

--- a/web/src/app/[workspace]/connections/[id]/edit/connection-api-key-field.tsx
+++ b/web/src/app/[workspace]/connections/[id]/edit/connection-api-key-field.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type State = { message?: string; error?: string };
+type Action = (state: State, formData: FormData) => Promise<State>;
+
+// Optional supplementary API key on a native-MCP connection. Some providers'
+// MCP OAuth grants only coarse scopes (Attio: no record/note/delete), so a
+// privileged provider access token is needed for those ops. The key rides the
+// connection (per-user, bundled) instead of a separate shared secret. The value
+// is write-only here — never read back; we only know whether one is set.
+export function ConnectionApiKeyField({
+  action,
+  workspaceSlug,
+  connectionId,
+  providerLabel,
+  isSet,
+}: {
+  action: Action;
+  workspaceSlug: string;
+  connectionId: string;
+  providerLabel: string;
+  isSet: boolean;
+}) {
+  const [state, formAction, pending] = useActionState<State, FormData>(
+    action,
+    {},
+  );
+  return (
+    <form action={formAction} className="flex flex-col gap-3">
+      <input type="hidden" name="workspace" value={workspaceSlug} />
+      <input type="hidden" name="connectionId" value={connectionId} />
+      <div className="grid gap-1.5">
+        <Label htmlFor="api-key" className="text-sm">
+          API key{" "}
+          <span className="text-foreground-muted">
+            (optional{isSet ? " — set" : ""})
+          </span>
+        </Label>
+        <Input
+          id="api-key"
+          name="apiKey"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={
+            isSet ? "•••••••• — paste to replace" : "Paste a provider API key"
+          }
+          disabled={pending}
+        />
+        <p className="text-foreground-muted text-sm">
+          For privileged operations the {providerLabel} MCP token can&apos;t do
+          — e.g. writes or deletes that need a granular provider access token.
+          Stored encrypted and scoped to your connection (other members
+          can&apos;t use it); agents read it via{" "}
+          <code>tas_tools.connection().api_key</code>.
+        </p>
+      </div>
+      {state.error && (
+        <p className="text-sentiment-negative text-sm" role="alert">
+          {state.error}
+        </p>
+      )}
+      {state.message && (
+        <p className="text-sentiment-positive text-sm">{state.message}</p>
+      )}
+      <div className="flex gap-2">
+        <Button type="submit" variant="primary" disabled={pending}>
+          {pending ? "Saving…" : "Save API key"}
+        </Button>
+        {isSet && (
+          <Button
+            type="submit"
+            name="clear"
+            value="true"
+            variant="secondary"
+            disabled={pending}
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/web/src/app/[workspace]/connections/[id]/edit/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/edit/page.tsx
@@ -9,7 +9,11 @@ import { getWorkspaceBySlug } from "@/lib/workspace";
 
 import { renameComposioConnectionAction } from "../../../settings/actions";
 import { loadConnection, parseConnectionRef } from "../../connection-ref";
-import { renameNativeMcpConnectionAction } from "../../native-mcp-actions";
+import {
+  renameNativeMcpConnectionAction,
+  setNativeMcpApiKeyAction,
+} from "../../native-mcp-actions";
+import { ConnectionApiKeyField } from "./connection-api-key-field";
 import { ConnectionRenameField } from "./connection-rename-field";
 import { SecretEditForm } from "./secret-edit-form";
 
@@ -91,12 +95,22 @@ export default async function EditConnectionPage({
           currentName={loaded.conn.name}
         />
       ) : (
-        <ConnectionRenameField
-          action={renameNativeMcpConnectionAction}
-          workspaceSlug={workspace.slug}
-          connectionId={loaded.conn.id}
-          currentName={loaded.conn.name}
-        />
+        <>
+          <ConnectionRenameField
+            action={renameNativeMcpConnectionAction}
+            workspaceSlug={workspace.slug}
+            connectionId={loaded.conn.id}
+            currentName={loaded.conn.name}
+          />
+          <hr className="border-[var(--color-border-weak)]" />
+          <ConnectionApiKeyField
+            action={setNativeMcpApiKeyAction}
+            workspaceSlug={workspace.slug}
+            connectionId={loaded.conn.id}
+            providerLabel={title}
+            isSet={loaded.conn.hasApiKey}
+          />
+        </>
       )}
     </div>
   );

--- a/web/src/app/[workspace]/connections/[id]/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/page.tsx
@@ -108,6 +108,22 @@ export default async function ConnectionDetailPage({
       { label: "Connection", value: <code className="text-foreground">{c.name}</code> },
       { label: "Status", value: <Badge variant={nativeVariant(c.status)} size="small">{c.status}</Badge> },
       { label: "Auth", value: c.authType === "pat" ? "API key" : "OAuth" },
+      // The optional supplementary API key (set via Edit) — only meaningful for
+      // editable (DCR) connections, where the aux-key field lives.
+      ...(editable
+        ? [
+            {
+              label: "API key",
+              value: c.hasApiKey ? (
+                <Badge variant="green" size="small">
+                  Set
+                </Badge>
+              ) : (
+                <span className="text-foreground-muted">Not set</span>
+              ),
+            },
+          ]
+        : []),
       { label: "Connected", value: <LocalTime iso={c.createdAt.toISOString()} /> },
       ...(c.tokenExpiresAt
         ? [{ label: "Token expires", value: <LocalTime iso={c.tokenExpiresAt.toISOString()} /> }]

--- a/web/src/app/[workspace]/connections/native-mcp-actions.ts
+++ b/web/src/app/[workspace]/connections/native-mcp-actions.ts
@@ -12,6 +12,7 @@ import {
   getNativeConnectionCredentials,
   listNativeConnectionsForUser,
   renameNativeConnection,
+  setNativeConnectionAuxSecret,
 } from "@/lib/connections";
 import {
   deleteToolsForConnection,
@@ -98,6 +99,61 @@ export async function disconnectNativeMcpConnectionAction(
   revalidatePath(`/${slug}/connections`, "layout");
   // The detail page this was triggered from no longer resolves — go to the list.
   redirect(`/${slug}/connections`);
+}
+
+/**
+ * Set (or, with `clear=true`, remove) the optional supplementary API key on a
+ * native-MCP connection — a granular provider access token for privileged REST
+ * ops the MCP OAuth token can't do (e.g. Attio note/delete). Same owner/admin
+ * mutate model as disconnect. The value is encrypted at rest and never read
+ * back to the UI; we never log it.
+ */
+export async function setNativeMcpApiKeyAction(
+  _prev: SimpleConnectionActionState,
+  formData: FormData,
+): Promise<SimpleConnectionActionState> {
+  const slug = String(formData.get("workspace") ?? "");
+  const connectionId = String(formData.get("connectionId") ?? "");
+  const clear = formData.get("clear") === "true";
+  const apiKey = String(formData.get("apiKey") ?? "");
+  if (!connectionId) return { error: "Missing connection id." };
+
+  const auth = await authorizeWorkspace(slug, "operator");
+  if (!auth.ok) {
+    if (auth.reason === "denied") return { error: DENIED_MESSAGE };
+    notFound();
+  }
+  const { workspace, userId, role } = auth;
+
+  const row = await getNativeConnectionById(workspace.id, connectionId);
+  if (!row) return { error: "Connection not found." };
+  if (role !== "workspace_admin" && row.userId !== userId) {
+    return { error: DENIED_MESSAGE };
+  }
+  if (!clear && !apiKey.trim()) {
+    return { error: "Paste an API key, or use Remove to clear it." };
+  }
+
+  const ok = await setNativeConnectionAuxSecret(
+    workspace.id,
+    connectionId,
+    clear ? null : apiKey,
+  );
+  if (!ok) return { error: "Connection no longer exists." };
+
+  await writeAuditEvent({
+    workspaceId: workspace.id,
+    actorUserId: userId,
+    source: "human_action",
+    kind: clear ? "connection.api_key_cleared" : "connection.api_key_set",
+    targetType: "connection",
+    targetId: connectionId,
+    agentName: null,
+    payload: { provider: row.type, name: row.name },
+  });
+
+  revalidatePath(`/${slug}/connections`, "layout");
+  return { message: clear ? "API key removed." : "API key saved." };
 }
 
 /**

--- a/web/src/lib/agent-guidance.ts
+++ b/web/src/lib/agent-guidance.ts
@@ -441,10 +441,29 @@ tools = [list_companies, summarize_arr]
 
 **Scope caveat:** a provider's MCP OAuth grant doesn't always carry the REST
 scopes a given endpoint needs — the token may authenticate (an identity call
-like \`/self\`) yet 401/403 on record reads. Probe with the ACTUAL endpoint you
-need (not a generic "who am I"), and **fall back to a Secret API key** (below)
-when the connection token can't do the job — a provider API key with the right
-scopes is the reliable credential for heavy REST use.
+like \`/self\`) yet 401/403 on record reads/writes. Some providers (e.g. Attio)
+only expose coarse MCP scopes with no record/note/delete granularity at all.
+Probe with the ACTUAL endpoint you need (not a generic "who am I").
+
+When the OAuth token can't do the job, use the connection's **optional
+supplementary API key** — a granular provider access token the user attaches to
+the connection (Connections → the connection → Edit → API key). It's read off
+the same connection object and is the reliable credential for privileged REST:
+
+\`\`\`python
+c = tas_tools.connection("attio")
+key = c.api_key or c.access_token        # prefer the attached API key when set
+r = httpx.post(
+    "https://api.attio.com/v2/notes",
+    headers={"Authorization": f"Bearer {key}"},
+    json=note_payload,
+)
+\`\`\`
+
+Prefer this over a workspace **Secret** (below): the key is bundled with the
+connection it belongs to and **per-user** (other members can't use it), whereas
+a Secret is workspace-shared. Fall back to a Secret only for a service with no
+connection to attach to.
 
 For a service that authenticates with a **plain API key** (e.g. Clay)
 rather than OAuth — i.e. not a Composio or Native-MCP provider — use a

--- a/web/src/lib/connections.ts
+++ b/web/src/lib/connections.ts
@@ -44,6 +44,9 @@ export type WorkspaceConnection = {
   status: NativeConnectionStatus;
   tokenExpiresAt: Date | null;
   metadata: Record<string, unknown>;
+  /** Whether a supplementary API key is attached (never the value — that's
+   *  decrypted only in the runtime, never exposed to the UI). */
+  hasApiKey: boolean;
   createdBy: string;
   createdAt: Date;
   updatedAt: Date;
@@ -60,6 +63,7 @@ type ConnectionRow = {
   status: string;
   token_expires_at: Date | null;
   metadata: Record<string, unknown> | null;
+  has_api_key: boolean;
   created_by: string;
   created_at: Date;
   updated_at: Date;
@@ -67,6 +71,7 @@ type ConnectionRow = {
 
 const COLUMNS = `id, workspace_id, user_id, type, name, mcp_server_url,
   auth_type, status, token_expires_at, metadata,
+  (aux_secret_ciphertext IS NOT NULL) AS has_api_key,
   created_by, created_at, updated_at`;
 
 function rowToConnection(r: ConnectionRow): WorkspaceConnection {
@@ -81,6 +86,7 @@ function rowToConnection(r: ConnectionRow): WorkspaceConnection {
     status: (r.status as NativeConnectionStatus) ?? "active",
     tokenExpiresAt: r.token_expires_at,
     metadata: r.metadata ?? {},
+    hasApiKey: r.has_api_key ?? false,
     createdBy: r.created_by,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
@@ -321,5 +327,34 @@ export async function setNativeConnectionStatus(
       WHERE id = $1`,
     [connectionId, status],
   );
+}
+
+/**
+ * Set (or clear, when `apiKey` is null/blank) the supplementary API key on a
+ * native-MCP connection. Encrypted under the SAME AAD as the credentials blob,
+ * stored in `aux_secret_ciphertext` — independent of the OAuth token, so a token
+ * refresh never disturbs it. Returns false when the row isn't in the workspace.
+ */
+export async function setNativeConnectionAuxSecret(
+  workspaceId: string,
+  connectionId: string,
+  apiKey: string | null,
+): Promise<boolean> {
+  const conn = await getNativeConnectionById(workspaceId, connectionId);
+  if (!conn) return false;
+  const trimmed = apiKey?.trim() || null;
+  const ciphertext = trimmed
+    ? encryptSecret(
+        trimmed,
+        aadNativeConnection(workspaceId, conn.userId, conn.type, conn.name),
+      )
+    : null;
+  const { rowCount } = await db.query(
+    `UPDATE workspace_connection
+        SET aux_secret_ciphertext = $3, updated_at = NOW()
+      WHERE id = $1 AND workspace_id = $2`,
+    [connectionId, workspaceId, ciphertext],
+  );
+  return (rowCount ?? 0) > 0;
 }
 


### PR DESCRIPTION
Implements #259. Lets a native-MCP connection carry an **optional supplementary API key**, set right on the connection, exposed at runtime as `tas_tools.connection("attio").api_key`.

## Why
Some providers' MCP OAuth grants only coarse scopes — **Attio's is `mcp` / `offline_access` / `openid`, with no record/note/delete granularity** — so privileged REST ops need the provider's own granular access token. That key previously lived as a separate, **workspace-shared** `workspace_secret_connection` wired by a magic slug. This lets the key ride the connection it belongs to: **bundled** (no orphan secret), and **per-user by construction** (native connections are keyed by `user_id`), so other members' agents can't use your key. Resolves the Attio driver behind #258.

## Data path (web writes → Rust decrypts → Python reads)
- **migration 0068** — nullable `aux_secret_ciphertext` on `workspace_connection`, AAD-bound to the same `(workspace, user, type, name)` identity as `credentials`; the OAuth refresh sweep rewrites `credentials` only, so it never disturbs this column.
- **Rust** — `workspace.rs` decrypts the aux key into `NativeMcpRow.api_key` (decrypt failure is non-fatal — drops just the aux key); `runner.rs` serializes it into `TAS_NATIVE_MCP_CONNECTIONS` only when set.
- **Python** — `tas_tools.Connection` gains `.api_key` (`None` when unset); `connection()` threads it through.
- **web** — `setNativeConnectionAuxSecret` + `setNativeMcpApiKeyAction` (owner/admin mutate, value **write-only** — never read back to the UI, never logged); an **API key** set/clear field on the connection **Edit** page and a **Set / Not set** row on the detail page (`hasApiKey` derived as `aux_secret_ciphertext IS NOT NULL` — the value is never decrypted for display).
- **guidance** — `agent-guidance.ts` now tells CAP to prefer the connection's `.api_key` over a workspace Secret for privileged REST (bundled + per-user).

## Checks
`cargo` fmt/clippy/test (43) clean · `tsc` clean · `eslint` 0 errors · `vitest` 148/148 · `py_compile` OK. Migration applies on api boot.

## Verify
Connect Attio → its connection Edit page → paste a granular Attio access token under **API key** → detail shows **Set**. A run's `tas_tools.connection("attio").api_key` returns it (decrypted in the runner), usable for `POST /v2/notes` etc.

## Next
Migrate the `encrich-attio-deals-from-amplema` agent to `tas_tools.connection("attio").api_key` and drop the shared `attio_api_key` Secret. Relates #258 (still covers API-key-only providers with no connection).

Closes #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)