### PR TITLE
Fix: default (unset) authMode connections are editable — surfaces the API key field

### DIFF
--- a/web/src/app/[workspace]/connections/[id]/edit/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/edit/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { BackLink } from "@/components/back-link";
 import { toolkitLabel } from "@/lib/composio-label";
 import { resolveConnectionsView } from "@/lib/connections-view";
-import { getMcpProvider } from "@/lib/mcp-providers";
+import { getMcpProvider, isDcrProvider } from "@/lib/mcp-providers";
 import { getServerSession } from "@/lib/session";
 import { getWorkspaceBySlug } from "@/lib/workspace";
 
@@ -48,9 +48,10 @@ export default async function EditConnectionPage({
 
   // Native manual / self-key connections have nothing to edit (name is fixed) —
   // the detail view hides their Edit button, so reaching here is a stray URL.
+  // DCR providers (incl. the unset default — Attio etc.) are editable.
   if (
     loaded.kind === "native" &&
-    getMcpProvider(loaded.conn.type)?.authMode !== "dcr"
+    !isDcrProvider(getMcpProvider(loaded.conn.type))
   ) {
     notFound();
   }

--- a/web/src/app/[workspace]/connections/[id]/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/page.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { toolkitLabel } from "@/lib/composio-label";
 import { resolveConnectionsView } from "@/lib/connections-view";
-import { getMcpProvider } from "@/lib/mcp-providers";
+import { getMcpProvider, isDcrProvider } from "@/lib/mcp-providers";
 import { listToolsForConnection } from "@/lib/mcp-tools";
 import { getServerSession } from "@/lib/session";
 import { getWorkspaceBySlug } from "@/lib/workspace";
@@ -97,7 +97,7 @@ export default async function ConnectionDetailPage({
       c.name,
     );
     const isManual = provider?.authMode === "manual";
-    editable = provider?.authMode === "dcr";
+    editable = isDcrProvider(provider);
     title = provider?.displayName ?? c.type;
     logoSlug = c.type;
     const reconnect = `/api/connections/native/${c.type}/authorize?workspace=${encodeURIComponent(

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -232,6 +232,22 @@ export function getMcpProvider(slug: string): McpProvider | null {
 }
 
 /**
+ * Whether a provider uses the TAS-managed DCR path — `authMode` "dcr" OR unset,
+ * since "dcr" is the documented default and most catalog entries omit it.
+ * Excludes "manual" (BYO confidential app) and "self-key" (Tembo). This is the
+ * "is this connection editable / can it hold a supplementary API key" predicate;
+ * checking `authMode === "dcr"` literally is a bug — it misses every default-DCR
+ * provider (Attio, Pylon, Fathom, Dialed, Linear, Amplemarket).
+ */
+export function isDcrProvider(provider: McpProvider | null | undefined): boolean {
+  return (
+    !!provider &&
+    provider.authMode !== "manual" &&
+    provider.authMode !== "self-key"
+  );
+}
+
+/**
  * The MCP server URL for the "self-key" Tembo provider — TAS's own /mcp
  * endpoint. Computed from the request/env-derived public origin rather than
  * baked into the catalog, then stored per-row in workspace_connection so it


### PR DESCRIPTION
Follow-up to #260. The supplementary API key field is on the connection **Edit** page — but for **Attio** (and Pylon/Fathom/Dialed/Linear/Amplemarket) there was no way to reach it: the detail page's **Edit** button and the edit page itself gated on `authMode === "dcr"` **literally**, and those providers' catalog entries **omit** `authMode` (relying on "dcr" being the default). So `undefined === "dcr"` → false → no Edit button, edit page 404s. Net effect reported live: *"I don't see where to paste."*

## Fix
Add `isDcrProvider(provider)` — true when `authMode` is neither `"manual"` nor `"self-key"` (i.e. DCR incl. the unset default) — and use it for both gates (detail-page `editable`, edit-page guard). This also restores rename for those providers, which was silently broken by the same literal check (the edit-page comment already states the intent: only manual/self-key "have nothing to edit").

## Checks
`tsc` clean · `eslint` clean · `vitest` 148/148.

## Verify
Attio connection → detail page now shows **Edit** + the **API key: Not set** row → Edit → the **API key** field is there to paste a granular Attio access token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)