### PR TITLE
fix(api): register runs before spawning

### DIFF
--- a/api/src/runs/handlers.rs
+++ b/api/src/runs/handlers.rs
@@ -12,6 +12,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::runs::runner;
@@ -162,6 +163,13 @@ pub async fn create_run(
         }
     };
 
+    let cancel = CancellationToken::new();
+    state
+        .run_cancels
+        .lock()
+        .expect("run_cancels mutex poisoned")
+        .insert(run_id, cancel.clone());
+
     tokio::spawn(async move {
         runner::execute_run(
             &task_state,
@@ -177,6 +185,7 @@ pub async fn create_run(
                 tools_module_content,
                 skills_content,
             },
+            cancel,
         )
         .await;
     });

--- a/api/src/runs/runner.rs
+++ b/api/src/runs/runner.rs
@@ -90,19 +90,12 @@ struct Usage {
 /// Drive a single run from queued through to terminal state. Always
 /// updates the run row even on error so the UI never sees a row stuck
 /// in `running` forever.
-pub async fn execute_run(state: &AppState, ctx: RunContext) {
-    // Register a cancellation token so the kill-run endpoint can SIGKILL this
-    // run's subprocess. Always removed on exit, so the registry only ever holds
-    // genuinely in-flight runs.
+pub async fn execute_run(state: &AppState, ctx: RunContext, cancel: CancellationToken) {
+    // The handler registered this token synchronously before spawning so
+    // shutdown draining cannot miss a queued-but-not-yet-polled run. Always
+    // remove it on exit, so the registry only ever holds genuinely in-flight
+    // runs.
     let run_id = ctx.run_id;
-    let cancel = CancellationToken::new();
-    {
-        let mut cancels = state
-            .run_cancels
-            .lock()
-            .expect("run_cancels mutex poisoned");
-        cancels.insert(run_id, cancel.clone());
-    }
 
     execute_run_inner(state, ctx, &cancel).await;
 


### PR DESCRIPTION
## summary

- register a run cancellation token synchronously in `create_run` before spawning the detached runner task
- pass that token into `execute_run`, keeping runner-side cleanup on task completion
- removes the scheduler race where graceful shutdown could see an empty in-flight map for a just-accepted run

## verification

- `git apply --check` of this diff against freshly fetched `origin/main`
- `cargo fmt`
- `nix-shell -p gcc pkg-config openssl --run "cargo check"`
- `nix-shell -p gcc pkg-config openssl --run "cargo test"`
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/98552ea9-2b04-4f5f-8f65-567444c6ce37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-8?theme=light&v=11" height="28"></picture></a> 