### PR TITLE
Connection note: which scopes an API key needs (Attio writes)

### DIFF
--- a/web/src/app/[workspace]/connections/[id]/edit/connection-api-key-field.tsx
+++ b/web/src/app/[workspace]/connections/[id]/edit/connection-api-key-field.tsx
@@ -19,12 +19,15 @@ export function ConnectionApiKeyField({
   workspaceSlug,
   connectionId,
   providerLabel,
+  hint,
   isSet,
 }: {
   action: Action;
   workspaceSlug: string;
   connectionId: string;
   providerLabel: string;
+  /** Provider-specific note (why/what scopes); falls back to generic copy. */
+  hint?: string | null;
   isSet: boolean;
 }) {
   const [state, formAction, pending] = useActionState<State, FormData>(
@@ -54,11 +57,18 @@ export function ConnectionApiKeyField({
           disabled={pending}
         />
         <p className="text-foreground-muted text-sm">
-          For privileged operations the {providerLabel} MCP token can&apos;t do
-          — e.g. writes or deletes that need a granular provider access token.
-          Stored encrypted and scoped to your connection (other members
-          can&apos;t use it); agents read it via{" "}
-          <code>tas_tools.connection().api_key</code>.
+          {hint ? (
+            hint
+          ) : (
+            <>
+              For privileged operations the {providerLabel} MCP token can&apos;t
+              do — e.g. writes or deletes that need a granular provider access
+              token. Agents read it via{" "}
+              <code>tas_tools.connection().api_key</code>.
+            </>
+          )}{" "}
+          Stored encrypted and scoped to your connection — other members
+          can&apos;t use it.
         </p>
       </div>
       {state.error && (

--- a/web/src/app/[workspace]/connections/[id]/edit/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/edit/page.tsx
@@ -109,6 +109,7 @@ export default async function EditConnectionPage({
             workspaceSlug={workspace.slug}
             connectionId={loaded.conn.id}
             providerLabel={title}
+            hint={getMcpProvider(loaded.conn.type)?.auxKeyHint ?? null}
             isSet={loaded.conn.hasApiKey}
           />
         </>

--- a/web/src/app/[workspace]/connections/[id]/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/page.tsx
@@ -64,6 +64,8 @@ export default async function ConnectionDetailPage({
   let title: string;
   let logoSlug: string | null;
   let editable = false;
+  // Provider-specific "you need an API key with these scopes" note (Attio etc.).
+  let auxKeyNote: string | null = null;
   const rows: { label: string; value: ReactNode }[] = [];
   const actions: ReactNode[] = [];
 
@@ -98,6 +100,7 @@ export default async function ConnectionDetailPage({
     );
     const isManual = provider?.authMode === "manual";
     editable = isDcrProvider(provider);
+    if (editable) auxKeyNote = provider?.auxKeyHint ?? null;
     title = provider?.displayName ?? c.type;
     logoSlug = c.type;
     const reconnect = `/api/connections/native/${c.type}/authorize?workspace=${encodeURIComponent(
@@ -286,6 +289,20 @@ export default async function ConnectionDetailPage({
           </div>
         ))}
       </dl>
+
+      {auxKeyNote && (
+        <div className="border-sentiment-caution rounded-lg border bg-[var(--color-sentiment-caution-subtle)] px-3 py-2.5 text-sm">
+          <p className="text-foreground-weak leading-5">{auxKeyNote}</p>
+          {editable && !view.viewingOther && (
+            <Link
+              href={editHref}
+              className="text-foreground mt-1 inline-block underline underline-offset-2"
+            >
+              Add API key
+            </Link>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -80,6 +80,13 @@ export type McpProvider = {
    * refresh tokens without the scope or issue short-lived-only access tokens.
    */
   omitOfflineAccess?: boolean;
+  /**
+   * Provider-specific note shown on the connection (detail view + the API-key
+   * edit field) explaining why/when a supplementary API key is needed and which
+   * scopes it requires. Set for providers whose MCP OAuth can't do privileged
+   * ops (Attio: no record/note/delete scopes). Plain text.
+   */
+  auxKeyHint?: string;
 };
 
 export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
@@ -88,6 +95,10 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
     displayName: "Attio",
     mcpServerUrl: "https://mcp.attio.com/mcp",
     oauthAuthorizationServerOrigins: ["https://app.attio.com"],
+    // Attio's MCP OAuth grants only mcp/offline_access/openid — no record/note/
+    // delete scopes — so agents can't write through the connection token alone.
+    auxKeyHint:
+      "Attio's MCP login can't write. To let agents create notes or update/delete records, add an Attio access token (Attio → Settings → Developers) with note_content:read-write, record_permission:read-write, and the delete scopes — agents use it via tas_tools.connection(\"attio\").api_key.",
   },
   pylon: {
     slug: "pylon",


### PR DESCRIPTION
On request: surface, right on the Attio connection, that agents need a supplementary **API key with write scopes** for the MCP server to do write actions — instead of discovering it from a failed run.

- Adds a data-driven `auxKeyHint` to the provider catalog (`mcp-providers.ts`) and sets it for **Attio**: "Attio's MCP login can't write. To let agents create notes or update/delete records, add an Attio access token … with `note_content:read-write`, `record_permission:read-write`, and the delete scopes."
- **Detail view:** renders it as a callout under the connection info, with an **Add API key** link to the edit page (shown for editable connections).
- **Edit field:** uses the hint as the API-key field's helper text (falls back to generic copy for providers with no hint).

Generalizes to any provider whose MCP OAuth can't do privileged ops — just set `auxKeyHint`.

`tsc` / `eslint` clean · `vitest` 148/148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)