### PR TITLE
Confidential Dynamic Client Registration (unblocks Avoma connect)

### DIFF
--- a/api/src/native_oauth.rs
+++ b/api/src/native_oauth.rs
@@ -210,12 +210,15 @@ async fn refresh_one(
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .ok_or_else(|| anyhow!("no refresh_token stored — reconnect required"))?;
-    // The client identity the refresh exchange presents. DCR (public) providers
-    // stored a `dcr_client_id` and send no secret; manual (confidential)
-    // providers (HubSpot) present the BYO client_id + client_secret an admin
-    // stored in workspace_native_oauth_client.
-    let (client_id, client_secret): (String, Option<String>) =
-        if metadata.get("auth_mode").and_then(|v| v.as_str()) == Some("manual") {
+    // The client identity the refresh exchange presents:
+    //  - manual (HubSpot): BYO client_id + client_secret from
+    //    workspace_native_oauth_client → client_secret_post.
+    //  - dcr_confidential (Avoma): client_id + client_secret stored IN the
+    //    credentials blob (no per-workspace app) → HTTP Basic.
+    //  - dcr (public): a `dcr_client_id`, no secret.
+    let auth_mode = metadata.get("auth_mode").and_then(|v| v.as_str());
+    let (client_id, client_secret, use_basic): (String, Option<String>, bool) = match auth_mode {
+        Some("manual") => {
             // Which BYO app instance this connection authorized against. Older
             // rows (pre multi-instance) have no `instance` → fall back to
             // "default", which is where their single app was migrated.
@@ -226,16 +229,33 @@ async fn refresh_one(
                 .unwrap_or("default");
             let (cid, secret) =
                 native_oauth_client_secret(pool, key, workspace_id, provider, instance).await?;
-            (cid, Some(secret))
-        } else {
+            (cid, Some(secret), false)
+        }
+        Some("dcr_confidential") => {
+            let cid = creds
+                .get("client_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow!("dcr_confidential connection has no client_id stored"))?
+                .to_string();
+            let secret = creds
+                .get("client_secret")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow!("dcr_confidential connection has no client_secret stored"))?
+                .to_string();
+            (cid, Some(secret), true)
+        }
+        _ => {
             let cid = metadata
                 .get("dcr_client_id")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
                 .ok_or_else(|| anyhow!("no dcr_client_id in connection metadata"))?
                 .to_string();
-            (cid, None)
-        };
+            (cid, None, false)
+        }
+    };
 
     let token_endpoint = discover_token_endpoint(http, mcp_url).await?;
 
@@ -244,12 +264,19 @@ async fn refresh_one(
         ("refresh_token", refresh_token),
         ("client_id", client_id.as_str()),
     ];
-    if let Some(ref secret) = client_secret {
-        form.push(("client_secret", secret.as_str()));
-    }
-    let res = http
+    let mut req = http
         .post(token_endpoint)
-        .header("Accept", "application/json")
+        .header("Accept", "application/json");
+    // Confidential client auth: dcr_confidential uses HTTP Basic (Avoma's default);
+    // manual uses client_secret_post (in the body). Public sends neither.
+    if let Some(ref secret) = client_secret {
+        if use_basic {
+            req = req.basic_auth(client_id.as_str(), Some(secret.as_str()));
+        } else {
+            form.push(("client_secret", secret.as_str()));
+        }
+    }
+    let res = req
         .form(&form)
         .send()
         .await
@@ -296,13 +323,21 @@ async fn refresh_one(
     // Same JSON shape as the web `ConnectionCredentials` / what
     // saveNativeConnection persists, so a blob written here round-trips
     // through the web layer unchanged.
-    let new_creds = serde_json::json!({
+    let mut new_creds = serde_json::json!({
         "access_token": access_token,
         "refresh_token": new_refresh,
         "expires_at": expires_at.map(|t| t.to_rfc3339()),
         "scope": token.scope,
         "token_type": token.token_type,
     });
+    // dcr_confidential stores its client_id/secret in the blob — this rewrite
+    // would drop them, so carry them forward for the next refresh.
+    if auth_mode == Some("dcr_confidential") {
+        if let Some(ref secret) = client_secret {
+            new_creds["client_id"] = serde_json::Value::String(client_id.clone());
+            new_creds["client_secret"] = serde_json::Value::String(secret.clone());
+        }
+    }
     let blob = key
         .encrypt_aad(&new_creds.to_string(), conn_aad.as_bytes())
         .context("encrypt refreshed credentials")?;

--- a/web/src/app/api/connections/native/[provider]/authorize/route.ts
+++ b/web/src/app/api/connections/native/[provider]/authorize/route.ts
@@ -4,6 +4,8 @@ import { NextResponse, type NextRequest } from "next/server";
 import { authorizeWorkspace } from "@/lib/auth-server";
 import { getPublicOrigin } from "@/lib/config";
 import { createApiKey, deleteApiKey } from "@/lib/api-keys-db";
+import { encryptSecret } from "@/lib/crypto";
+import { aadNativeConnection } from "@/lib/crypto-aad";
 import {
   getNativeConnection,
   saveNativeConnection,
@@ -171,6 +173,9 @@ type AuthServerMetadata = {
 
 type DcrResponse = {
   client_id?: string;
+  /** Present when the server registers a CONFIDENTIAL client (Avoma). We capture
+   *  it and present it (HTTP Basic) at token exchange + refresh. */
+  client_secret?: string;
 };
 
 export async function GET(
@@ -394,6 +399,8 @@ export async function GET(
 
   // ── Step 3: obtain a client_id ──────────────────────────────────
   let clientId: string;
+  // Set when DCR registers a CONFIDENTIAL client (Avoma) — the secret to present.
+  let dcrClientSecret: string | null = null;
   if (isManual) {
     // Confidential client: require client_secret_post and use the admin-stored
     // OAuth app. The secret is added at the callback's token exchange.
@@ -418,14 +425,9 @@ export async function GET(
     }
     clientId = byo.clientId;
   } else {
-    // Public client → Dynamic Client Registration.
-    if (!authMethods.some((m) => m === "none")) {
-      return back(
-        workspace.slug,
-        provider.slug,
-        `${provider.displayName} auth server requires a confidential client; configure an OAuth app instead.`,
-      );
-    }
+    // Dynamic Client Registration. The server decides public vs confidential:
+    // a public client gets no secret (we use PKCE only); a confidential one
+    // (Avoma) returns a client_secret we capture for token exchange + refresh.
     let registrationEndpoint: URL;
     try {
       registrationEndpoint = await trustedOAuthUrl(
@@ -475,6 +477,18 @@ export async function GET(
         );
       }
       clientId = dcrJson.client_id;
+      // Confidential DCR: the server issued a client_secret. We'll present it via
+      // HTTP Basic. If there's NO secret and the server doesn't support public
+      // ("none"), we can't authenticate the client at all.
+      if (dcrJson.client_secret) {
+        dcrClientSecret = dcrJson.client_secret;
+      } else if (!authMethods.some((m) => m === "none")) {
+        return back(
+          workspace.slug,
+          provider.slug,
+          `${provider.displayName} auth server requires a confidential client but DCR returned no client_secret.`,
+        );
+      }
     } catch (e) {
       return back(
         workspace.slug,
@@ -492,6 +506,7 @@ export async function GET(
     .digest("base64url");
 
   // ── Step 5: sign state + redirect ───────────────────────────────
+  const confidentialDcr = !isManual && dcrClientSecret !== null;
   const state = signNativeMcpState({
     workspaceId: workspace.id,
     workspaceSlug: workspace.slug,
@@ -501,8 +516,24 @@ export async function GET(
     pkceVerifier,
     clientId,
     tokenEndpoint: tokenEndpoint.toString(),
-    authMode: isManual ? "manual" : "dcr",
+    authMode: isManual ? "manual" : confidentialDcr ? "dcr_confidential" : "dcr",
     ...(isManual ? { instance } : {}),
+    // Carry the DCR-issued client_secret to the callback ENCRYPTED (state is
+    // signed but readable, and round-trips through the provider). AAD-bound to
+    // this connection so the ciphertext is useless elsewhere.
+    ...(confidentialDcr
+      ? {
+          clientSecretCiphertext: encryptSecret(
+            dcrClientSecret as string,
+            aadNativeConnection(
+              workspace.id,
+              userId,
+              provider.slug,
+              connectionName,
+            ),
+          ).toString("base64"),
+        }
+      : {}),
   });
 
   const authorizeUrl = new URL(authorizationEndpoint);

--- a/web/src/app/api/connections/native/[provider]/callback/route.ts
+++ b/web/src/app/api/connections/native/[provider]/callback/route.ts
@@ -3,6 +3,8 @@ import { NextResponse, type NextRequest } from "next/server";
 import { writeAuditEvent } from "@/lib/audit-db";
 import { saveNativeConnection } from "@/lib/connections";
 import { getPublicOrigin } from "@/lib/config";
+import { decryptSecret } from "@/lib/crypto";
+import { aadNativeConnection } from "@/lib/crypto-aad";
 import {
   getMcpProvider,
   redirectUriFor,
@@ -134,8 +136,11 @@ export async function GET(
       `Token endpoint is not trusted: ${(e as Error).message}`,
     );
   }
-  // Confidential (manual / BYO-app) providers add the stored client_secret at
-  // the token exchange (client_secret_post). Public DCR providers send none.
+  // Client authentication at the token exchange:
+  //  - manual (BYO confidential app): stored client_secret via client_secret_post.
+  //  - dcr_confidential (Avoma): the DCR-issued secret (decrypted from state) via
+  //    HTTP Basic — the spec default when the server omits the auth-method field.
+  //  - dcr (public): PKCE only, no secret.
   const tokenParams: Record<string, string> = {
     grant_type: "authorization_code",
     code,
@@ -143,6 +148,13 @@ export async function GET(
     client_id: state.clientId,
     code_verifier: state.pkceVerifier,
   };
+  const tokenHeaders: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+  };
+  // dcr_confidential: recover the DCR client_secret for both the token exchange
+  // and persistence (so refresh can present it). Decrypted under the connection AAD.
+  let confidentialSecret: string | null = null;
   if (state.authMode === "manual") {
     const byo = await getNativeOAuthClientSecret(
       state.workspaceId,
@@ -158,14 +170,36 @@ export async function GET(
       );
     }
     tokenParams.client_secret = byo.clientSecret;
+  } else if (
+    state.authMode === "dcr_confidential" &&
+    state.clientSecretCiphertext
+  ) {
+    try {
+      confidentialSecret = decryptSecret(
+        Buffer.from(state.clientSecretCiphertext, "base64"),
+        aadNativeConnection(
+          state.workspaceId,
+          state.userId,
+          provider.slug,
+          state.connectionName,
+        ),
+      );
+    } catch {
+      return back(
+        state.workspaceSlug,
+        provider.slug,
+        "error",
+        "Could not recover the OAuth client secret — please reconnect.",
+      );
+    }
+    tokenHeaders.Authorization =
+      "Basic " +
+      Buffer.from(`${state.clientId}:${confidentialSecret}`).toString("base64");
   }
   try {
     const tokenRes = await fetch(tokenEndpoint, noRedirectFetchInit({
       method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-      },
+      headers: tokenHeaders,
       body: new URLSearchParams(tokenParams).toString(),
     }));
     if (!tokenRes.ok) {
@@ -212,11 +246,19 @@ export async function GET(
       expires_at: expiresAt,
       scope: tokenJson.scope,
       token_type: tokenJson.token_type,
+      // dcr_confidential: stash the DCR client_id + secret WITH the connection
+      // (encrypted with the credentials blob) so the Rust refresh can present
+      // them via Basic — there's no per-workspace BYO app to read them from.
+      ...(state.authMode === "dcr_confidential" && confidentialSecret
+        ? { client_id: state.clientId, client_secret: confidentialSecret }
+        : {}),
     },
-    // The client identity the refresh exchange must present. For DCR
-    // (public) providers that's the registered client_id; for manual
-    // (confidential) providers it's the BYO client_id, plus auth_mode so the
-    // Rust refresh knows to add the stored client_secret.
+    // The client identity the refresh exchange must present:
+    //  - manual: BYO client_id + auth_mode → refresh reads the secret from
+    //    workspace_native_oauth_client.
+    //  - dcr_confidential: auth_mode → refresh reads client_id/secret from the
+    //    credentials blob (above) and uses Basic.
+    //  - dcr (public): just the registered client_id, no secret.
     metadata:
       state.authMode === "manual"
         ? {
@@ -224,7 +266,9 @@ export async function GET(
             client_id: state.clientId,
             instance: state.instance ?? "default",
           }
-        : { dcr_client_id: state.clientId },
+        : state.authMode === "dcr_confidential"
+          ? { auth_mode: "dcr_confidential", dcr_client_id: state.clientId }
+          : { dcr_client_id: state.clientId },
   });
 
   await writeAuditEvent({

--- a/web/src/lib/connections.ts
+++ b/web/src/lib/connections.ts
@@ -31,6 +31,11 @@ export type ConnectionCredentials = {
   expires_at?: string; // ISO timestamp
   scope?: string;
   token_type?: string;
+  /** dcr_confidential only: the DCR-issued confidential client the refresh
+   *  exchange must present (HTTP Basic). Stored inside the encrypted blob and
+   *  carried forward by the Rust refresh. */
+  client_id?: string;
+  client_secret?: string;
 };
 
 export type WorkspaceConnection = {

--- a/web/src/lib/oauth-state.ts
+++ b/web/src/lib/oauth-state.ts
@@ -64,15 +64,25 @@ export type NativeMcpStatePayload = {
   /** Authorization server token endpoint, captured during
    *  discovery so the callback doesn't need to re-discover. */
   tokenEndpoint: string;
-  /** OAuth client mode. "manual" (confidential, BYO app) tells the
-   *  callback to add the stored client_secret at token exchange.
-   *  Absent/"dcr" = public client (no secret). */
-  authMode?: "dcr" | "manual";
+  /** OAuth client mode.
+   *   - absent/"dcr": public client (PKCE only, no secret).
+   *   - "manual": confidential BYO app — callback adds the admin-stored
+   *     client_secret (client_secret_post) read by `instance`.
+   *   - "dcr_confidential": the server's DCR issued a confidential client
+   *     (it returned a client_secret); callback presents it via HTTP Basic.
+   *     The secret rides in `clientSecretCiphertext` (encrypted), NOT plaintext —
+   *     state is signed but readable, and the provider echoes it back. */
+  authMode?: "dcr" | "manual" | "dcr_confidential";
   /** For manual providers: which BYO OAuth-app instance this flow used
    *  (slug in workspace_native_oauth_client). The callback re-reads the
    *  secret by this instance, and it's stored on the connection so refresh
    *  presents the right client_secret. Absent for DCR. */
   instance?: string;
+  /** dcr_confidential only: the DCR-issued client_secret, AES-256-GCM encrypted
+   *  (master key, AAD = the connection's native_connection AAD), base64. The
+   *  callback decrypts it for the token exchange and persists it (encrypted) on
+   *  the connection so refresh can present it. Never plaintext in the URL. */
+  clientSecretCiphertext?: string;
   /** Short random nonce — defends against state replay across users. */
   nonce: string;
   /** Issued-at (epoch ms); states older than STATE_TTL_MS are rejected (#46). */


### PR DESCRIPTION
Fixes the Avoma connect failure: *"Avoma auth server requires a confidential client; configure an OAuth app instead."*

## Why
TAS's DCR path only supported **public** clients (PKCE, no secret). Avoma's DCR issues a **confidential** client — it returns a `client_secret` and its auth server omits `token_endpoint_auth_methods_supported` (RFC default: `client_secret_basic`). And Avoma has no BYO-app dashboard, so the manual path isn't an option either (and it also assumed `client_secret_post`). So neither existing path worked.

## What this adds — confidential DCR, end to end
- **authorize** (`authorize/route.ts`): register as before, but **capture the DCR-issued `client_secret`**; only error if there's no secret *and* no public (`none`) support. The secret is carried to the callback **encrypted** in the signed state (`clientSecretCiphertext`, AAD-bound to the connection) — the state is signed-but-readable and the provider echoes it, so it must never be plaintext.
- **callback** (`callback/route.ts`): decrypt it, authenticate the token exchange via **HTTP Basic**, and persist `client_id`+`client_secret` *inside the encrypted credentials blob* + `metadata.auth_mode="dcr_confidential"`.
- **Rust refresh** (`native_oauth.rs`): read `client_id`/`client_secret` from the credentials blob, present them via **Basic**, and **carry them forward** (the refresh rewrites the whole blob, so they'd otherwise be dropped).
- `ConnectionCredentials` gains optional `client_id`/`client_secret`; `NativeMcpStatePayload` gains the new mode + ciphertext.

**Security notes:** the secret is never in the URL/state in plaintext (encrypted with the master key, AAD-bound); stored only inside the AES-256-GCM credentials blob; never logged. Public DCR (Attio/Clay/etc.) and manual (HubSpot/Gmail) paths are untouched.

## Checks
web `tsc`/`eslint` clean · `vitest` 149/149 · Rust `cargo check`/`clippy`/`fmt` clean · `cargo test` 43/43.

## Verify
After deploy: **Connect Avoma** on tembo-tas → should pass discovery → confidential DCR → Basic token exchange → connection lands active, tools cached. (If Avoma actually wants `client_secret_post` rather than Basic at the token endpoint, the exchange would 401 — that'd be a one-line follow-up to switch the method; Basic is the spec default for its omitted auth-method field.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)