### PR TITLE
Instance-based native MCP providers (adds Metabase)

### DIFF
--- a/api/src/native_oauth.rs
+++ b/api/src/native_oauth.rs
@@ -257,7 +257,11 @@ async fn refresh_one(
         }
     };
 
-    let token_endpoint = discover_token_endpoint(http, mcp_url).await?;
+    let instance_based = metadata
+        .get("instance_based")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let token_endpoint = discover_token_endpoint(http, mcp_url, instance_based).await?;
 
     let mut form: Vec<(&str, &str)> = vec![
         ("grant_type", "refresh_token"),
@@ -399,13 +403,22 @@ async fn native_oauth_client_secret(
 async fn discover_token_endpoint(
     http: &reqwest::Client,
     mcp_url: &str,
+    instance_based: bool,
 ) -> anyhow::Result<reqwest::Url> {
     let mcp_url = parse_trusted_https_url(mcp_url, "mcp_server_url")?;
     assert_public_endpoint_host(&mcp_url, "mcp_server_url").await?;
     let origin = mcp_url.origin().ascii_serialization();
-    let allowed_oauth_origins = allowed_oauth_origins_for_mcp_origin(&origin).ok_or_else(|| {
-        anyhow!("mcp_server_url origin is not in the native-MCP provider allowlist")
-    })?;
+    // Fixed providers: compile-time allowlist. Instance-based (self-hosted, e.g.
+    // Metabase): same-origin — OAuth endpoints must live on the connection's own
+    // origin (validated at Connect time; still SSRF-guarded above + below).
+    let instance_origins = [origin.as_str()];
+    let allowed_oauth_origins: &[&str] = if instance_based {
+        &instance_origins
+    } else {
+        allowed_oauth_origins_for_mcp_origin(&origin).ok_or_else(|| {
+            anyhow!("mcp_server_url origin is not in the native-MCP provider allowlist")
+        })?
+    };
 
     // RFC 9728: protected-resource metadata lives at the origin — but some
     // servers (Gmail) serve it only PATH-SUFFIXED with the resource path and

--- a/web/src/app/[workspace]/connections/new/native-connect-form.tsx
+++ b/web/src/app/[workspace]/connections/new/native-connect-form.tsx
@@ -13,23 +13,54 @@ export function NativeConnectForm({
   workspaceSlug,
   providerSlug,
   selfKey = false,
+  instanceUrlLabel,
 }: {
   workspaceSlug: string;
   providerSlug: string;
   selfKey?: boolean;
+  /** Set for instance-based (self-hosted) providers — shows a required URL
+   *  field and passes it as `?base=` to the authorize flow. */
+  instanceUrlLabel?: string;
 }) {
   const [name, setName] = useState("default");
+  const [base, setBase] = useState("");
 
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const params = new URLSearchParams({ workspace: workspaceSlug });
     const trimmed = name.trim().toLowerCase();
     if (trimmed && trimmed !== "default") params.set("name", trimmed);
+    if (instanceUrlLabel) {
+      const b = base.trim();
+      if (!b) return;
+      params.set("base", b);
+    }
     window.location.href = `/api/connections/native/${providerSlug}/authorize?${params.toString()}`;
   }
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      {instanceUrlLabel && (
+        <div className="grid gap-1.5">
+          <Label htmlFor="native-base" className="text-sm">
+            {instanceUrlLabel}
+          </Label>
+          <Input
+            id="native-base"
+            name="base"
+            type="url"
+            required
+            autoComplete="off"
+            spellCheck={false}
+            value={base}
+            onChange={(e) => setBase(e.target.value)}
+            placeholder="https://metabase.your-company.com"
+          />
+          <p className="text-foreground-muted text-sm">
+            Your self-hosted instance. You&apos;ll authenticate against it next.
+          </p>
+        </div>
+      )}
       {!selfKey && (
         <div className="grid gap-1.5">
           <Label htmlFor="native-name" className="text-sm">

--- a/web/src/app/[workspace]/connections/new/page.tsx
+++ b/web/src/app/[workspace]/connections/new/page.tsx
@@ -145,6 +145,11 @@ export default async function NewConnectionPage({
             workspaceSlug={workspace.slug}
             providerSlug={provider.slug}
             selfKey={provider.authMode === "self-key"}
+            instanceUrlLabel={
+              provider.instanceUrlTemplate
+                ? (provider.instanceUrlLabel ?? "Instance URL")
+                : undefined
+            }
           />
         )}
       </FormShell>

--- a/web/src/app/api/connections/native/[provider]/authorize/route.ts
+++ b/web/src/app/api/connections/native/[provider]/authorize/route.ts
@@ -12,7 +12,9 @@ import {
 } from "@/lib/connections";
 import {
   getMcpProvider,
+  isInstanceProvider,
   redirectUriFor,
+  resolveInstanceMcpUrl,
   tasMcpServerUrl,
   type McpProvider,
   type McpProviderSlug,
@@ -21,8 +23,8 @@ import { fetchNativeMcpTools } from "@/lib/native-mcp-tools";
 import { replaceToolsForConnection } from "@/lib/mcp-tools";
 import {
   noRedirectFetchInit,
+  trustedMcpOrigin,
   trustedOAuthUrl,
-  trustedProviderMcpOrigin,
 } from "@/lib/native-oauth-security";
 import {
   DEFAULT_INSTANCE,
@@ -238,10 +240,29 @@ export async function GET(
     return connectSelfKey(provider, workspace, userId, connectionName);
   }
 
+  // Resolve the MCP server URL. Fixed providers use the catalog constant;
+  // instance-based (self-hosted, e.g. Metabase) take the host the operator
+  // entered (?base=…) and apply the template — so the URL is per-connection.
+  let mcpServerUrl: string;
+  if (isInstanceProvider(provider)) {
+    const baseRaw = request.nextUrl.searchParams.get("base") ?? "";
+    const resolved = resolveInstanceMcpUrl(provider, baseRaw);
+    if (!resolved) {
+      return back(
+        workspace.slug,
+        provider.slug,
+        `Enter your ${provider.displayName} URL (e.g. https://metabase.example.com).`,
+      );
+    }
+    mcpServerUrl = resolved;
+  } else {
+    mcpServerUrl = provider.mcpServerUrl;
+  }
+
   // ── Step 1: protected-resource discovery ────────────────────────
   let mcpOrigin: string;
   try {
-    mcpOrigin = await trustedProviderMcpOrigin(provider);
+    mcpOrigin = await trustedMcpOrigin(mcpServerUrl);
   } catch (e) {
     return back(
       workspace.slug,
@@ -249,11 +270,18 @@ export async function GET(
       `Provider MCP URL is not trusted: ${(e as Error).message}`,
     );
   }
+  // OAuth endpoint trust: fixed providers use the catalog allowlist; instance-
+  // based providers trust the user's own origin (same-origin — every discovered
+  // endpoint must live on the host they typed). SSRF guards (https + public DNS)
+  // apply either way, inside trustedOAuthUrl.
+  const allowedOauthOrigins = isInstanceProvider(provider)
+    ? [mcpOrigin]
+    : provider.oauthAuthorizationServerOrigins;
   // RFC 9728 metadata lives at the origin, but some servers (Gmail) only serve
   // it PATH-SUFFIXED with the resource's path (…/oauth-protected-resource/mcp/v1)
   // and 404 at the bare origin. Try the origin first (all current providers),
-  // then the path-suffixed form derived from the catalog MCP URL.
-  const resourcePath = new URL(provider.mcpServerUrl).pathname.replace(/\/+$/, "");
+  // then the path-suffixed form derived from the MCP URL.
+  const resourcePath = new URL(mcpServerUrl).pathname.replace(/\/+$/, "");
   const prCandidates = [`${mcpOrigin}/.well-known/oauth-protected-resource`];
   if (resourcePath && resourcePath !== "/") {
     prCandidates.push(
@@ -293,7 +321,7 @@ export async function GET(
   try {
     authServerUrl = await trustedOAuthUrl(
       authServerUrlRaw,
-      provider,
+      allowedOauthOrigins,
       "Authorization server URL",
     );
   } catch (e) {
@@ -369,12 +397,12 @@ export async function GET(
   try {
     authorizationEndpoint = await trustedOAuthUrl(
       asMeta.authorization_endpoint,
-      provider,
+      allowedOauthOrigins,
       "Authorization endpoint",
     );
     tokenEndpoint = await trustedOAuthUrl(
       asMeta.token_endpoint,
-      provider,
+      allowedOauthOrigins,
       "Token endpoint",
     );
   } catch (e) {
@@ -432,7 +460,7 @@ export async function GET(
     try {
       registrationEndpoint = await trustedOAuthUrl(
         asMeta.registration_endpoint as string,
-        provider,
+        allowedOauthOrigins,
         "Registration endpoint",
       );
     } catch (e) {
@@ -518,6 +546,9 @@ export async function GET(
     tokenEndpoint: tokenEndpoint.toString(),
     authMode: isManual ? "manual" : confidentialDcr ? "dcr_confidential" : "dcr",
     ...(isManual ? { instance } : {}),
+    // Instance-based: persist the resolved per-connection URL so the callback
+    // stores it (and validates same-origin) — provider.mcpServerUrl is empty.
+    ...(isInstanceProvider(provider) ? { mcpServerUrl } : {}),
     // Carry the DCR-issued client_secret to the callback ENCRYPTED (state is
     // signed but readable, and round-trips through the provider). AAD-bound to
     // this connection so the ciphertext is useless elsewhere.

--- a/web/src/app/api/connections/native/[provider]/callback/route.ts
+++ b/web/src/app/api/connections/native/[provider]/callback/route.ts
@@ -121,11 +121,17 @@ export async function GET(
     scope?: string;
     token_type?: string;
   };
+  // Instance-based providers carry their resolved per-connection URL in the
+  // state (catalog mcpServerUrl is empty); trust is same-origin to that host.
+  const mcpServerUrl = state.mcpServerUrl ?? provider.mcpServerUrl;
+  const allowedOauthOrigins = state.mcpServerUrl
+    ? [new URL(state.mcpServerUrl).origin]
+    : provider.oauthAuthorizationServerOrigins;
   let tokenEndpoint: URL;
   try {
     tokenEndpoint = await trustedOAuthUrl(
       state.tokenEndpoint,
-      provider,
+      allowedOauthOrigins,
       "Token endpoint",
     );
   } catch (e) {
@@ -238,7 +244,7 @@ export async function GET(
     userId: state.userId,
     type: provider.slug as McpProviderSlug,
     name: state.connectionName,
-    mcpServerUrl: provider.mcpServerUrl,
+    mcpServerUrl,
     authType: "oauth2",
     credentials: {
       access_token: tokenJson.access_token,
@@ -259,8 +265,8 @@ export async function GET(
     //  - dcr_confidential: auth_mode → refresh reads client_id/secret from the
     //    credentials blob (above) and uses Basic.
     //  - dcr (public): just the registered client_id, no secret.
-    metadata:
-      state.authMode === "manual"
+    metadata: {
+      ...(state.authMode === "manual"
         ? {
             auth_mode: "manual",
             client_id: state.clientId,
@@ -268,7 +274,11 @@ export async function GET(
           }
         : state.authMode === "dcr_confidential"
           ? { auth_mode: "dcr_confidential", dcr_client_id: state.clientId }
-          : { dcr_client_id: state.clientId },
+          : { dcr_client_id: state.clientId }),
+      // Instance-based: tell the Rust refresh to trust this connection's own
+      // (same-origin) endpoints rather than the fixed compile-time allowlist.
+      ...(state.mcpServerUrl ? { instance_based: true } : {}),
+    },
   });
 
   await writeAuditEvent({
@@ -293,7 +303,7 @@ export async function GET(
   // render). Just log so a recurring failure is visible.
   try {
     const tools = await fetchNativeMcpTools(
-      provider.mcpServerUrl,
+      mcpServerUrl,
       tokenJson.access_token,
     );
     await replaceToolsForConnection({

--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -26,6 +26,7 @@ export type McpProviderSlug =
   | "amplemarket"
   | "clay"
   | "avoma"
+  | "metabase"
   | "gmail"
   | "tembo-agent-studio";
 
@@ -88,6 +89,19 @@ export type McpProvider = {
    * ops (Attio: no record/note/delete scopes). Plain text.
    */
   auxKeyHint?: string;
+  /**
+   * Set for INSTANCE-BASED providers whose MCP server is self-hosted, so the
+   * host isn't a fixed constant — the user supplies it at Connect time. The
+   * template's `{instance}` is replaced with the user's host to form the MCP
+   * URL (e.g. Metabase: `https://{instance}/api/metabase-mcp`). For these,
+   * `mcpServerUrl`/`oauthAuthorizationServerOrigins` are empty: the per-connection
+   * URL is resolved + stored on the row, and OAuth trust is same-origin (every
+   * discovered endpoint must share the user-entered origin) rather than a fixed
+   * allowlist. Still SSRF-guarded (https + public-DNS, same as other providers).
+   */
+  instanceUrlTemplate?: string;
+  /** UI hint for the instance-URL field on instance-based providers. */
+  instanceUrlLabel?: string;
 };
 
 export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
@@ -228,6 +242,20 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
       "external_api:engagement-list",
     ],
   },
+  metabase: {
+    slug: "metabase",
+    displayName: "Metabase",
+    // Instance-based: Metabase is self-hosted, so the MCP server is the user's
+    // own instance + the fixed path /api/metabase-mcp. Metabase runs its OWN
+    // embedded OAuth (DCR, same-origin), scoped to the connecting person's
+    // permissions — so it slots into the DCR / confidential-DCR path; trust is
+    // same-origin (the user's instance), not a fixed allowlist.
+    // Docs: https://www.metabase.com/docs/latest/ai/mcp
+    mcpServerUrl: "",
+    oauthAuthorizationServerOrigins: [],
+    instanceUrlTemplate: "https://{instance}/api/metabase-mcp",
+    instanceUrlLabel: "Your Metabase URL",
+  },
   gmail: {
     slug: "gmail",
     displayName: "Gmail",
@@ -288,6 +316,41 @@ export function isDcrProvider(provider: McpProvider | null | undefined): boolean
     provider.authMode !== "manual" &&
     provider.authMode !== "self-key"
   );
+}
+
+/** Instance-based providers (self-hosted; user supplies the host at Connect). */
+export function isInstanceProvider(
+  provider: McpProvider | null | undefined,
+): boolean {
+  return !!provider?.instanceUrlTemplate;
+}
+
+/**
+ * Resolve an instance-based provider's MCP URL from the user's input. Takes the
+ * origin of whatever they entered (bare host or full URL) and applies the
+ * template's fixed path. Returns null if the input can't be parsed as a URL.
+ * https-ness / public-IP are enforced later by the OAuth security layer.
+ */
+export function resolveInstanceMcpUrl(
+  provider: McpProvider,
+  input: string,
+): string | null {
+  if (!provider.instanceUrlTemplate) return null;
+  const raw = input.trim();
+  if (!raw) return null;
+  let origin: string;
+  try {
+    const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    origin = new URL(withScheme).origin;
+  } catch {
+    return null;
+  }
+  // Everything in the template after `https://{instance}` is the fixed path.
+  const path = provider.instanceUrlTemplate.replace(
+    /^https?:\/\/\{instance\}/i,
+    "",
+  );
+  return `${origin}${path}`;
 }
 
 /**

--- a/web/src/lib/native-oauth-security.test.ts
+++ b/web/src/lib/native-oauth-security.test.ts
@@ -1,14 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { isPublicIpAddress, trustedOAuthUrl } from "./native-oauth-security";
-import type { McpProvider } from "./mcp-providers";
 
-const provider: McpProvider = {
-  slug: "attio",
-  displayName: "Attio",
-  mcpServerUrl: "https://mcp.attio.com/mcp",
-  oauthAuthorizationServerOrigins: ["https://app.attio.com"],
-};
+const allowed = ["https://app.attio.com"];
 
 describe("native OAuth URL trust checks", () => {
   it("rejects non-public IP literals", () => {
@@ -25,33 +19,31 @@ describe("native OAuth URL trust checks", () => {
     expect(isPublicIpAddress("2606:4700:4700::1111")).toBe(true);
   });
 
-  it("requires discovered OAuth endpoints to stay on the provider allowlist", async () => {
+  it("requires discovered OAuth endpoints to stay on the allowed origins", async () => {
     await expect(
-      trustedOAuthUrl("https://app.attio.com/oidc/token", provider, "Token"),
+      trustedOAuthUrl("https://app.attio.com/oidc/token", allowed, "Token"),
     ).resolves.toMatchObject({ origin: "https://app.attio.com" });
 
     await expect(
-      trustedOAuthUrl("https://evil.example/oidc/token", provider, "Token"),
+      trustedOAuthUrl("https://evil.example/oidc/token", allowed, "Token"),
     ).rejects.toThrow(/allowed provider origin/);
   });
 
   it("rejects http and private-address endpoints before fetch", async () => {
     await expect(
-      trustedOAuthUrl("http://app.attio.com/oidc/token", provider, "Token"),
+      trustedOAuthUrl("http://app.attio.com/oidc/token", allowed, "Token"),
     ).rejects.toThrow(/https/);
 
     await expect(
-      trustedOAuthUrl("https://169.254.169.254/token", {
-        ...provider,
-        oauthAuthorizationServerOrigins: ["https://169.254.169.254"],
-      }, "Token"),
+      trustedOAuthUrl(
+        "https://169.254.169.254/token",
+        ["https://169.254.169.254"],
+        "Token",
+      ),
     ).rejects.toThrow(/non-public IP/);
 
     await expect(
-      trustedOAuthUrl("https://[::1]/token", {
-        ...provider,
-        oauthAuthorizationServerOrigins: ["https://[::1]"],
-      }, "Token"),
+      trustedOAuthUrl("https://[::1]/token", ["https://[::1]"], "Token"),
     ).rejects.toThrow(/non-public IP/);
   });
 });

--- a/web/src/lib/native-oauth-security.ts
+++ b/web/src/lib/native-oauth-security.ts
@@ -3,8 +3,6 @@ import "server-only";
 import { lookup } from "node:dns/promises";
 import { BlockList, isIP } from "node:net";
 
-import type { McpProvider } from "@/lib/mcp-providers";
-
 const privateIpBlocks = new BlockList();
 
 privateIpBlocks.addSubnet("0.0.0.0", 8, "ipv4");
@@ -119,21 +117,27 @@ async function assertPublicDns(url: URL, label: string): Promise<void> {
   }
 }
 
-export async function trustedProviderMcpOrigin(
-  provider: McpProvider,
-): Promise<string> {
-  const url = parseHttpsUrl(provider.mcpServerUrl, "MCP server URL");
+/** Validate an MCP server URL (https + public DNS) and return its origin. The
+ *  URL is the catalog's fixed `mcpServerUrl` for normal providers, or the
+ *  per-connection resolved URL for instance-based (self-hosted) ones. */
+export async function trustedMcpOrigin(mcpServerUrl: string): Promise<string> {
+  const url = parseHttpsUrl(mcpServerUrl, "MCP server URL");
   await assertPublicDns(url, "MCP server URL");
   return url.origin;
 }
 
+/** Validate an OAuth endpoint URL against an explicit set of allowed origins
+ *  (https + origin-allowlist + public DNS). For fixed providers the caller
+ *  passes the catalog's `oauthAuthorizationServerOrigins`; for instance-based
+ *  providers it passes `[the user-entered instance origin]` — a same-origin
+ *  constraint (every endpoint must live on the host the operator typed). */
 export async function trustedOAuthUrl(
   rawUrl: string,
-  provider: McpProvider,
+  allowedOrigins: string[],
   label: string,
 ): Promise<URL> {
   const url = parseHttpsUrl(rawUrl, label);
-  if (!provider.oauthAuthorizationServerOrigins.includes(url.origin)) {
+  if (!allowedOrigins.includes(url.origin)) {
     throw new Error(`${label} is not on an allowed provider origin.`);
   }
   await assertPublicDns(url, label);

--- a/web/src/lib/oauth-state.ts
+++ b/web/src/lib/oauth-state.ts
@@ -83,6 +83,10 @@ export type NativeMcpStatePayload = {
    *  callback decrypts it for the token exchange and persists it (encrypted) on
    *  the connection so refresh can present it. Never plaintext in the URL. */
   clientSecretCiphertext?: string;
+  /** Instance-based providers only: the per-connection MCP server URL resolved
+   *  from the operator-entered host. The callback stores it on the row (the
+   *  catalog `mcpServerUrl` is empty) and trusts its origin (same-origin OAuth). */
+  mcpServerUrl?: string;
   /** Short random nonce — defends against state replay across users. */
   nonce: string;
   /** Issued-at (epoch ms); states older than STATE_TTL_MS are rejected (#46). */


### PR DESCRIPTION
Adds support for **self-hosted** native MCP servers where the user supplies the host at Connect time, and ships **Metabase** as the first one. Docs: https://www.metabase.com/docs/latest/ai/mcp

## Why
Metabase's MCP server is the customer's own instance: `https://{your-metabase}/api/metabase-mcp`. It runs Metabase's **embedded OAuth** (DCR, same-origin, scoped to the connecting person's permissions). Our catalog assumed a fixed `mcpServerUrl` + a compile-time origin allowlist, so a per-customer host didn't fit.

## What this adds — an "instance-based" provider mode
- **Catalog** (`mcp-providers.ts`): `instanceUrlTemplate` (`https://{instance}/api/metabase-mcp`) + label; `mcpServerUrl`/`oauthAuthorizationServerOrigins` empty. Helpers `isInstanceProvider()` / `resolveInstanceMcpUrl()`.
- **Connect form**: instance-based providers get a required **instance-URL** field, passed as `?base=` into the authorize flow.
- **authorize**: resolve the MCP URL from `base`, run discovery against it, and carry the resolved URL in the **signed state**. Plugs straight into the existing DCR (and confidential-DCR) paths.
- **callback**: persist the resolved **per-connection** `mcp_server_url` (the column's already per-row) + `metadata.instance_based = true`.
- **Rust refresh**: when `instance_based`, trust the connection's own origin (same-origin) instead of `NATIVE_MCP_OAUTH_ALLOWLIST`.

## Trust / SSRF
The OAuth trust helpers (`native-oauth-security.ts` / `native_oauth.rs`) now take an **explicit allowed-origins set** instead of reading the catalog. Fixed providers pass their allowlist; instance-based pass **`[the operator-entered origin]`** — a *same-origin* constraint (tighter than a wildcard: every discovered endpoint must live on the one host the operator typed). The existing **https + public-DNS** SSRF guards are unchanged and still run, so it can't be pointed at internal/metadata IPs. Connections are operator-gated and TAS is single-tenant, so an operator naming their own instance is intended.

Generalizes to any self-hosted MCP (GitLab self-managed, Sentry self-hosted, …) — just add `instanceUrlTemplate`.

## Checks
web `tsc`/`eslint` clean · `vitest` 149/149 (trust-helper test updated to the new signature) · Rust `cargo check`/`clippy`/`fmt` clean · `cargo test` 43/43.

## Verify
After deploy: Connections → New → Metabase → enter your Metabase URL → Connect → Metabase consent → connection lands active, tools cached. Token refresh works against the same origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)