### PR TITLE
Fix Metabase connect: don't request offline_access

### DIFF
--- a/web/src/lib/mcp-providers.ts
+++ b/web/src/lib/mcp-providers.ts
@@ -255,6 +255,11 @@ export const MCP_PROVIDERS: Record<McpProviderSlug, McpProvider> = {
     oauthAuthorizationServerOrigins: [],
     instanceUrlTemplate: "https://{instance}/api/metabase-mcp",
     instanceUrlLabel: "Your Metabase URL",
+    // Metabase advertises the refresh_token grant but its scopes_supported is
+    // agent:* + mb:full — NO offline_access. It strictly validates the scope at
+    // the (post-login) authorize step and rejects the auto-appended offline_access
+    // with "invalid_request", so suppress it.
+    omitOfflineAccess: true,
   },
   gmail: {
     slug: "gmail",


### PR DESCRIPTION
Connecting Metabase (#276) failed at the post-login authorize with `invalid_request — The authorization request is invalid.`

**Cause:** Metabase's `scopes_supported` is `agent:*` + `mb:full` — no `offline_access` — but TAS auto-appends `offline_access` (Metabase advertises the `refresh_token` grant). Metabase strictly validates the scope at the authorize step (after login, which is why an unauthenticated probe couldn't reproduce it — it redirects to login before validating) and rejects the unknown scope.

**Fix:** `omitOfflineAccess: true` on the Metabase catalog entry (same one-liner as Amplemarket). tsc/eslint clean.

Note: Metabase may not issue a refresh token without the scope, in which case the access token is short-lived and reconnect is needed periodically — a degradation, not a blocker. Verify by connecting again after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)