### PR TITLE
Fix: "Action needed" header showing over an empty section

### DIFF
--- a/web/src/components/action-needed.tsx
+++ b/web/src/components/action-needed.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { IconExclamationTriangle } from "central-icons";
 
 import { Button } from "@/components/ui/button";
 
-// One "Action needed" missing-connection card per item, with a per-user
-// dismiss. A user who doesn't intend to wire up a given connection can hide its
-// nag; the choice persists in localStorage (no server round-trip, matches the
-// sidebar-nav / docs-nav persistence pattern). Dismissals are keyed by the
-// connection identity (source:toolkit:name), so a brand-new missing connection
-// still shows.
+// The sidebar "Action needed" section. Owns its own visibility: the header only
+// renders when there's ACTUALLY-visible content. That has to be client-side,
+// because the missing-connection cards can be dismissed per-user (localStorage),
+// and a server-side gate on the raw count would leave a lonely "Action needed"
+// header over an empty section once the only items left are all dismissed.
+//
+// `staticContent` (the LLM-key / failing-agent cards) is server-rendered and
+// passed in; `hasStaticContent` says whether it's non-empty.
 
 export type MissingConnectionItem = {
   /** Stable identity = `${source}:${toolkit}:${name}` — also the dismiss key. */
@@ -34,18 +36,21 @@ function loadDismissed(): Set<string> {
   }
 }
 
-export function MissingConnectionCards({
-  items,
+export function ActionNeeded({
+  hasStaticContent,
+  staticContent,
+  missingItems,
 }: {
-  items: MissingConnectionItem[];
+  hasStaticContent: boolean;
+  staticContent: ReactNode;
+  missingItems: MissingConnectionItem[];
 }) {
-  // Hydrate dismissals after mount (localStorage is client-only; reading it in
-  // the initializer would mismatch SSR). `ready` gates the first paint so we
-  // don't briefly flash a card the user already dismissed.
+  // Hydrate dismissals after mount (localStorage is client-only). Until then we
+  // withhold the dismissable cards so a dismissed one never flashes — they
+  // appear on the next tick.
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   const [ready, setReady] = useState(false);
   useEffect(() => {
-    // Hydrate from localStorage after mount (client-only).
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setDismissed(loadDismissed());
     setReady(true);
@@ -63,12 +68,19 @@ export function MissingConnectionCards({
     });
   }
 
-  if (!ready) return null;
-  const visible = items.filter((it) => !dismissed.has(it.key));
+  const visibleMissing = ready
+    ? missingItems.filter((it) => !dismissed.has(it.key))
+    : [];
+  // The whole point: no visible content → no header.
+  if (!hasStaticContent && visibleMissing.length === 0) return null;
 
   return (
-    <>
-      {visible.map((it) => (
+    <div className="mt-6 flex flex-col gap-1.5">
+      <span className="text-foreground-muted px-2 text-sm font-medium uppercase tracking-widest">
+        Action needed
+      </span>
+      {staticContent}
+      {visibleMissing.map((it) => (
         <div
           key={it.key}
           className="flex items-start gap-2 rounded-md bg-[var(--color-sentiment-caution-subtle)] px-2 py-2"
@@ -97,6 +109,6 @@ export function MissingConnectionCards({
           </div>
         </div>
       ))}
-    </>
+    </div>
   );
 }

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 import { DocsSidebarLink } from "@/components/docs-sidebar-link";
-import { MissingConnectionCards } from "@/components/missing-connection-cards";
+import { ActionNeeded } from "@/components/action-needed";
 import { SidebarNav } from "@/components/sidebar-nav";
 import { countActiveInboxItems } from "@/lib/inbox-api";
 import { Button } from "@/components/ui/button";
@@ -128,104 +128,99 @@ export async function AppShell({
         <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-3 pt-6">
           <SidebarNav home={home} inboxCount={inboxCount} />
 
-          {(!hasLlmProvider ||
-            failingAgents.length > 0 ||
-            missingConnections.length > 0) && (
-            <div className="mt-6 flex flex-col gap-1.5">
-              <span className="text-foreground-muted px-2 text-sm font-medium uppercase tracking-widest">
-                Action needed
-              </span>
-              {!hasLlmProvider && (
-                <div className="flex items-start gap-2 rounded-md bg-[var(--color-sentiment-caution-subtle)] px-2 py-2">
-                  <IconExclamationTriangle
-                    size={14}
-                    className="mt-0.5 shrink-0 text-[var(--color-icon-sentiment-caution)]"
-                  />
-                  <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
-                    <span className="text-sm leading-tight text-[var(--color-foreground-sentiment-caution)]">
-                      <span className="font-semibold">LLM provider needed</span>{" "}
-                      — add an Anthropic or OpenAI key to run agents
-                    </span>
-                    <Button asChild variant="orange" size="small">
-                      <Link href={`/${workspace.slug}/settings/providers`}>
-                        Add a key
-                      </Link>
-                    </Button>
-                  </div>
-                </div>
-              )}
-              {failingAgents.map((f) => {
-                const agentHref = `/${workspace.slug}/agents/${encodeURIComponent(f.agentName)}`;
-                return (
-                  <div
-                    key={`fail:${f.agentName}`}
-                    className="flex items-start gap-2 rounded-md bg-[var(--color-sentiment-negative-subtle)] px-2 py-2"
-                  >
+          <ActionNeeded
+            hasStaticContent={!hasLlmProvider || failingAgents.length > 0}
+            staticContent={
+              <>
+                {!hasLlmProvider && (
+                  <div className="flex items-start gap-2 rounded-md bg-[var(--color-sentiment-caution-subtle)] px-2 py-2">
                     <IconExclamationTriangle
                       size={14}
-                      className="text-sentiment-negative mt-0.5 shrink-0"
+                      className="mt-0.5 shrink-0 text-[var(--color-icon-sentiment-caution)]"
                     />
                     <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
-                      <span className="text-sentiment-negative text-sm leading-tight">
-                        <span className="font-semibold">{f.agentName}</span>{" "}
-                        failed{" "}
-                        <span className="font-semibold">{f.failures}×</span> in
-                        24h
+                      <span className="text-sm leading-tight text-[var(--color-foreground-sentiment-caution)]">
+                        <span className="font-semibold">
+                          LLM provider needed
+                        </span>{" "}
+                        — add an Anthropic or OpenAI key to run agents
                       </span>
-                      <Button asChild variant="destructive" size="small">
-                        <Link href={agentHref}>Open</Link>
+                      <Button asChild variant="orange" size="small">
+                        <Link href={`/${workspace.slug}/settings/providers`}>
+                          Add a key
+                        </Link>
                       </Button>
                     </div>
                   </div>
-                );
-              })}
-              <MissingConnectionCards
-                items={groupedMissing.map(({ rep: m, agentNames }) => {
-                  // Authorize endpoint differs per substrate: Composio is one
-                  // route per workspace (toolkit in query string), Native MCP
-                  // one route per provider (provider in path), secrets link to
-                  // the Secrets tab. Dispatch by source so Connect lands on the
-                  // right flow.
-                  let href: string;
-                  let providerLabel: string;
-                  if (m.source === "secret") {
-                    href = `/${workspace.slug}/connections/secrets`;
-                    providerLabel = m.toolkit;
-                  } else if (m.source === "native-mcp") {
-                    const params = new URLSearchParams({
-                      workspace: workspace.slug,
-                    });
-                    if (m.name && m.name !== "default") params.set("name", m.name);
-                    href = `/api/connections/native/${m.toolkit}/authorize?${params.toString()}`;
-                    providerLabel =
-                      getMcpProvider(m.toolkit)?.displayName ?? m.toolkit;
-                  } else {
-                    const params = new URLSearchParams({
-                      workspace: workspace.slug,
-                      toolkit: m.toolkit,
-                    });
-                    if (m.name && m.name !== "default") params.set("name", m.name);
-                    href = `/api/connections/composio/authorize?${params.toString()}`;
-                    providerLabel = toolkitLabel(m.toolkit);
-                  }
-                  const label =
-                    m.name && m.name !== "default"
-                      ? `${providerLabel} (${m.name})`
-                      : providerLabel;
-                  return {
-                    key: `${m.source}:${m.toolkit}:${m.name}`,
-                    label,
-                    agentLabel:
-                      agentNames.length === 1
-                        ? agentNames[0]
-                        : `${agentNames.length} agents`,
-                    href,
-                    action: m.source === "secret" ? "Set" : "Connect",
-                  };
+                )}
+                {failingAgents.map((f) => {
+                  const agentHref = `/${workspace.slug}/agents/${encodeURIComponent(f.agentName)}`;
+                  return (
+                    <div
+                      key={`fail:${f.agentName}`}
+                      className="flex items-start gap-2 rounded-md bg-[var(--color-sentiment-negative-subtle)] px-2 py-2"
+                    >
+                      <IconExclamationTriangle
+                        size={14}
+                        className="text-sentiment-negative mt-0.5 shrink-0"
+                      />
+                      <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
+                        <span className="text-sentiment-negative text-sm leading-tight">
+                          <span className="font-semibold">{f.agentName}</span>{" "}
+                          failed{" "}
+                          <span className="font-semibold">{f.failures}×</span> in
+                          24h
+                        </span>
+                        <Button asChild variant="destructive" size="small">
+                          <Link href={agentHref}>Open</Link>
+                        </Button>
+                      </div>
+                    </div>
+                  );
                 })}
-              />
-            </div>
-          )}
+              </>
+            }
+            missingItems={groupedMissing.map(({ rep: m, agentNames }) => {
+              // Authorize endpoint differs per substrate: Composio is one route
+              // per workspace (toolkit in query string), Native MCP one route per
+              // provider (provider in path), secrets link to the Secrets tab.
+              // Dispatch by source so Connect lands on the right flow.
+              let href: string;
+              let providerLabel: string;
+              if (m.source === "secret") {
+                href = `/${workspace.slug}/connections/secrets`;
+                providerLabel = m.toolkit;
+              } else if (m.source === "native-mcp") {
+                const params = new URLSearchParams({ workspace: workspace.slug });
+                if (m.name && m.name !== "default") params.set("name", m.name);
+                href = `/api/connections/native/${m.toolkit}/authorize?${params.toString()}`;
+                providerLabel =
+                  getMcpProvider(m.toolkit)?.displayName ?? m.toolkit;
+              } else {
+                const params = new URLSearchParams({
+                  workspace: workspace.slug,
+                  toolkit: m.toolkit,
+                });
+                if (m.name && m.name !== "default") params.set("name", m.name);
+                href = `/api/connections/composio/authorize?${params.toString()}`;
+                providerLabel = toolkitLabel(m.toolkit);
+              }
+              const label =
+                m.name && m.name !== "default"
+                  ? `${providerLabel} (${m.name})`
+                  : providerLabel;
+              return {
+                key: `${m.source}:${m.toolkit}:${m.name}`,
+                label,
+                agentLabel:
+                  agentNames.length === 1
+                    ? agentNames[0]
+                    : `${agentNames.length} agents`,
+                href,
+                action: m.source === "secret" ? "Set" : "Connect",
+              };
+            })}
+          />
         </nav>
 
         <div className="border-border border-t px-2 pb-1 pt-2">


### PR DESCRIPTION
Reported after #277: the "Action needed" sidebar header shows with nothing under it.

**Cause:** the header was gated server-side on `missingConnections.length > 0`, but the missing-connection cards are **dismissible per-user (localStorage, client-side)**. Once all are dismissed, `MissingConnectionCards` rendered nothing while the server gate stayed true → lonely header. #277 (per-user failing agents) exposed it by emptying the other condition.

**Fix:** consolidate the section into a dismissal-aware client component (`ActionNeeded`) that renders the header **only when there's actually-visible content** — the LLM-key / failing-agent cards (server-passed) or non-dismissed missing-connection cards. Folds in the old `MissingConnectionCards`. tsc/eslint clean, vitest 149/149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)