### PR TITLE
Dashboard: agents-owned per member + unowned tally

### DIFF
--- a/web/src/app/[workspace]/dashboard/dashboard-team-table.tsx
+++ b/web/src/app/[workspace]/dashboard/dashboard-team-table.tsx
@@ -19,6 +19,10 @@ export type TeamRow = {
   slackRuns30d: number;
   slackBots: string[];
   runs30d: number;
+  /** Count of agents this member owns (agent_owner rows pointing at them). */
+  agentsOwned: number;
+  /** Their owned agent names, sorted — revealed on hover. */
+  ownedAgents: string[];
 };
 
 const COLUMNS: Column<TeamRow>[] = [
@@ -62,6 +66,18 @@ const COLUMNS: Column<TeamRow>[] = [
     ),
   },
   {
+    key: "agents",
+    header: "Agents owned",
+    align: "right",
+    cell: (r) => (
+      <CountCell
+        value={r.agentsOwned}
+        items={r.ownedAgents}
+        empty="Owns no agents"
+      />
+    ),
+  },
+  {
     key: "slack",
     header: "Slack (30d)",
     align: "right",
@@ -82,13 +98,39 @@ const COLUMNS: Column<TeamRow>[] = [
   },
 ];
 
-export function DashboardTeamTable({ rows }: { rows: TeamRow[] }) {
+export function DashboardTeamTable({
+  rows,
+  unownedCount,
+  unownedAgents,
+}: {
+  rows: TeamRow[];
+  /** Agents in the repo with no owner row — surfaced as a footer note so it's
+   *  obvious which agents nobody is accountable for. */
+  unownedCount: number;
+  unownedAgents: string[];
+}) {
   return (
-    <DataTable
-      columns={COLUMNS}
-      rows={rows}
-      getRowKey={(r) => r.userId}
-      // No whole-row navigation — member link (admin) is inside the cell.
-    />
+    <div className="flex flex-col gap-2">
+      <DataTable
+        columns={COLUMNS}
+        rows={rows}
+        getRowKey={(r) => r.userId}
+        // No whole-row navigation — member link (admin) is inside the cell.
+      />
+      <div className="text-foreground-muted px-1 text-sm">
+        {unownedCount === 0 ? (
+          "Every agent has an owner."
+        ) : (
+          <>
+            <CountCell
+              value={unownedCount}
+              items={unownedAgents}
+              empty="No unowned agents"
+            />{" "}
+            {unownedCount === 1 ? "agent is" : "agents are"} unowned.
+          </>
+        )}
+      </div>
+    </div>
   );
 }

--- a/web/src/app/[workspace]/dashboard/page.tsx
+++ b/web/src/app/[workspace]/dashboard/page.tsx
@@ -19,6 +19,8 @@ import {
   type RunListItem,
 } from "@/lib/runs-db";
 import { listMemberActivity } from "@/lib/member-stats";
+import { listAgentOwners } from "@/lib/agent-versions";
+import { listAgents } from "@/lib/workspace-agents";
 import { getServerSession } from "@/lib/session";
 import { getWorkspaceBySlug, getWorkspaceRole } from "@/lib/workspace";
 
@@ -61,6 +63,8 @@ export default async function DashboardPage({
     recentImprovements,
     recentRuns,
     memberActivity,
+    agentsListing,
+    agentOwners,
     role,
   ] = await Promise.all([
     getWorkspaceStats30d(workspace.id),
@@ -70,9 +74,34 @@ export default async function DashboardPage({
     listImprovements(workspace.id, 10),
     listRunsForWorkspace(workspace.id, {}, { limit: 8 }),
     listMemberActivity(workspace.id),
+    listAgents(workspace.id).catch(() => null),
+    listAgentOwners(workspace.id).catch(() => new Map<string, string>()),
     getWorkspaceRole(workspace.id, session.user.id),
   ]);
   const isAdmin = role === "workspace_admin";
+
+  // Tally agents-owned per member, plus what's left unowned. The live agent
+  // list (from the repo) is the inventory; agent_owner rows can outlive a
+  // deleted agent, so we walk the live agents and look each one's owner up —
+  // never the row set, which would over-count ghosts. An agent with an owner
+  // row pointing at a former member (no longer in memberActivity) still counts
+  // as "owned" for the unowned tally, but won't surface in any visible row.
+  const ownedNamesByUser = new Map<string, string[]>();
+  const unownedAgentNames: string[] = [];
+  if (agentsListing && agentsListing.ok) {
+    for (const a of agentsListing.agents) {
+      if (!a.ok) continue;
+      const name = a.spec.name;
+      const owner = agentOwners.get(name);
+      if (owner) {
+        const list = ownedNamesByUser.get(owner) ?? [];
+        list.push(name);
+        ownedNamesByUser.set(owner, list);
+      } else {
+        unownedAgentNames.push(name);
+      }
+    }
+  }
 
   // Disambiguate the Team table: when two members share a first name,
   // append the email in parens so "Ry" and "Ry" are distinguishable.
@@ -112,8 +141,9 @@ export default async function DashboardPage({
         description="Connections, automations, Slack-bot usage, and 30-day run activity per member. Hover a count for details."
       >
         <DashboardTeamTable
-          rows={memberActivity.map(
-            (m): TeamRow => ({
+          rows={memberActivity.map((m): TeamRow => {
+            const owned = ownedNamesByUser.get(m.userId) ?? [];
+            return {
               userId: m.userId,
               label: memberLabel(m),
               memberHref: isAdmin
@@ -126,8 +156,14 @@ export default async function DashboardPage({
               slackRuns30d: m.slackRuns30d,
               slackBots: m.slackBots,
               runs30d: m.runs30d,
-            }),
-          )}
+              agentsOwned: owned.length,
+              ownedAgents: owned.slice().sort((a, b) => a.localeCompare(b)),
+            };
+          })}
+          unownedCount={unownedAgentNames.length}
+          unownedAgents={unownedAgentNames
+            .slice()
+            .sort((a, b) => a.localeCompare(b))}
         />
       </Section>
 

--- a/web/src/lib/agent-versions.ts
+++ b/web/src/lib/agent-versions.ts
@@ -229,6 +229,20 @@ export async function getAgentOwner(
     : null;
 }
 
+/** Owner of every agent that has one, as agent_name → owner_user_id. Used by the
+ *  dashboard to tally agents-owned per member (and what's left unowned). Rows can
+ *  outlive a deleted agent, so callers should intersect with the live agent list
+ *  rather than trusting the row set as the agent inventory. */
+export async function listAgentOwners(
+  workspaceId: string,
+): Promise<Map<string, string>> {
+  const { rows } = await db.query<{ agent_name: string; owner_user_id: string }>(
+    `SELECT agent_name, owner_user_id FROM agent_owner WHERE workspace_id = $1`,
+    [workspaceId],
+  );
+  return new Map(rows.map((r) => [r.agent_name, r.owner_user_id]));
+}
+
 /** Agent names this user owns in the workspace — for the "owned + starred"
  *  default in the agents list. */
 export async function listOwnedAgentNames(


### PR DESCRIPTION
On the Team dashboard, add a per-member **"Agents owned"** count (hover for the agent names) and a footer line counting **unowned agents** — agents in the repo with no `agent_owner` row, so it's obvious which ones nobody is accountable for.

Requested: *"add owned agents count on 'Team' dashboard — at bottom show count of agents unowned."*

**Accuracy:** the live agent list (repo) is the inventory. We walk it and look up each agent's owner via `listAgentOwners()`, so a stale `agent_owner` row left behind by a deleted agent never inflates a count. An agent owned by a former member counts toward "owned" (so it's not falsely flagged unowned) but won't appear in any visible member row. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)