### PR TITLE
Fix: LinkedIn (manual-credential) logo missing on connections

### DIFF
--- a/web/src/app/[workspace]/connections/[id]/page.tsx
+++ b/web/src/app/[workspace]/connections/[id]/page.tsx
@@ -157,7 +157,8 @@ export default async function ConnectionDetailPage({
   } else if (loaded.kind === "manual-cred") {
     const { provider, fields } = loaded;
     title = provider.displayName;
-    logoSlug = null;
+    // Same logo CDN as the list view (LinkedIn et al.); glyph fallback on 404.
+    logoSlug = provider.slug;
     rows.push({ label: "Type", value: "Manual credential" });
     for (const { field, preview } of fields) {
       rows.push({

--- a/web/src/app/[workspace]/connections/connection-ref.ts
+++ b/web/src/app/[workspace]/connections/connection-ref.ts
@@ -166,7 +166,9 @@ export async function listAllConnections(
       title: p.displayName,
       slot: null,
       typeLabel: "Manual credential",
-      logoSlug: null,
+      // Reuse the provider slug against the shared logo CDN (LinkedIn et al.
+      // resolve there); McpProviderLogo falls back to a glyph if it 404s.
+      logoSlug: p.slug,
       statusLabel: complete ? "connected" : "incomplete",
       statusVariant: complete ? "green" : "yellow",
     });

--- a/web/src/app/[workspace]/connections/new/page.tsx
+++ b/web/src/app/[workspace]/connections/new/page.tsx
@@ -84,7 +84,9 @@ export default async function NewConnectionPage({
       <FormShell
         back={<BackLink href={`${newHref}?type=manual`} label="Manual credential" />}
         title={`Connect ${provider.displayName}`}
-        logo={<Glyph />}
+        logo={
+          <McpProviderLogo slug={provider.slug} label={provider.displayName} size={24} />
+        }
       >
         {isAdmin ? (
           <>
@@ -193,7 +195,7 @@ export default async function NewConnectionPage({
             <OptionCard
               key={p.slug}
               href={`${newHref}?type=manual&provider=${encodeURIComponent(p.slug)}`}
-              logo={<Glyph />}
+              logo={<McpProviderLogo slug={p.slug} label={p.displayName} size={24} />}
               title={p.displayName}
               sublabel={`${p.fields.length} field${p.fields.length === 1 ? "" : "s"}`}
             />


### PR DESCRIPTION
Reported: *"linkedin logo is missing on connections."*

**Cause:** the manual-credential code paths hard-coded `logoSlug = null`, so LinkedIn always fell back to the generic connection glyph — even though the shared logo CDN (`logos.composio.dev/api/linkedin`) serves a real LinkedIn SVG (verified: 200, 3.2KB).

**Fix:** reuse the provider slug against `mcpLogoUrl()`, exactly like the native-MCP and Composio rows already do. `McpProviderLogo` keeps its `onError` glyph fallback, so a future manual-credential provider Composio doesn't carry still degrades cleanly.

Restores the logo across all four surfaces:
- connections list row (`connection-ref.ts`)
- connection detail page (`[id]/page.tsx`)
- provider picker card (`?type=manual`)
- connect-form header (`?type=manual&provider=linkedin`)

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)