### PR TITLE
Drop the "Create an agent that handles this task:" prefill prefix

### DIFF
--- a/web/src/app/[workspace]/agents/new/page.tsx
+++ b/web/src/app/[workspace]/agents/new/page.tsx
@@ -28,7 +28,7 @@ function starterDefaults(starterId: string | undefined) {
     : "";
   return {
     name: agent.title,
-    description: `Create an agent that handles this task: ${agent.task}.${connLine}${inboxLine}`,
+    description: `${agent.task}.${connLine}${inboxLine}`,
   };
 }
 


### PR DESCRIPTION
Per feedback: the Agent Library prefill seeded the New Agent description with a boilerplate `Create an agent that handles this task: …` prefix. Drop it — the description now leads with the starter's task text directly (the connection + Tasks Inbox lines still append).

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)