### PR TITLE
for-agents: document Agent Skills + refresh authoring guidance

### DIFF
--- a/web/src/app/for-agents/route.ts
+++ b/web/src/app/for-agents/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/for-agents-token";
 import { listMcpProviders } from "@/lib/mcp-providers";
 import { listCachedNativeProviders, listToolsForUser } from "@/lib/mcp-tools";
+import { listInstalledSkills } from "@/lib/workspace-skills";
 
 // Agent-facing index: GET /for-agents → a linked list of the per-provider
 // tool-reference pages. Token-gated by default; an instance can opt into a
@@ -37,10 +38,19 @@ export async function GET(request: NextRequest): Promise<Response> {
           .map((t) => t.provider)
       : await listCachedNativeProviders(),
   );
+  // With a token, list the workspace's installed Agent Skills so an authoring
+  // agent knows which `skills:` it can reference. Tokenless: omit (no workspace).
+  const skills = payload
+    ? (await listInstalledSkills(payload.w).catch(() => [])).map((s) => ({
+        name: s.name,
+        description: s.description,
+      }))
+    : undefined;
   const md = renderIndexMarkdown(
     `${getPublicOrigin()}/for-agents`,
     listMcpProviders(),
     connected,
+    skills,
   );
   return new Response(md, {
     status: 200,

--- a/web/src/lib/agent-guidance.ts
+++ b/web/src/lib/agent-guidance.ts
@@ -498,12 +498,13 @@ Opt the agent into one or more **Agent Skills** — reusable \`SKILL.md\`
 folders (instructions + optional scripts/resources) installed in this
 repo under \`skills/<name>/\`. At run time the model can load a skill's
 instructions and run its scripts. Skills are installed out-of-band (the
-Skills page: skills.sh, a custom upload, or imported from the Claude
-API), so only reference skills that already exist under \`skills/\`.
+Skills page: Anthropic's knowledge-work library, skills.sh, a custom
+upload, or imported from the Claude API), so only reference skills that
+already exist under \`skills/\`.
 
 \`\`\`yaml
 name: deck-builder
-model: anthropic:claude-opus-4-7
+model: anthropic:claude-sonnet-5
 skills:
   - pptx                 # folder name under skills/pptx/
   - brand-guidelines

--- a/web/src/lib/for-agents-markdown.test.ts
+++ b/web/src/lib/for-agents-markdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  renderIndexMarkdown,
   renderProviderMarkdown,
   type ForAgentsTool,
 } from "@/lib/for-agents-markdown";
@@ -60,5 +61,31 @@ describe("renderProviderMarkdown — parameter tables", () => {
     ];
     const md = renderProviderMarkdown(provider, tools);
     expect(md).not.toContain("## Parameters");
+  });
+});
+
+describe("renderIndexMarkdown — Agent Skills section", () => {
+  const base = "https://tas.example/for-agents";
+  const providers = [provider];
+
+  it("lists installed skills with descriptions", () => {
+    const md = renderIndexMarkdown(base, providers, new Set(), [
+      { name: "pdf", description: "Read + fill PDFs." },
+      { name: "brand", description: null },
+    ]);
+    expect(md).toContain("## Agent Skills");
+    expect(md).toContain("`skills: [pdf]`");
+    expect(md).toContain("- `pdf` — Read + fill PDFs.");
+    expect(md).toContain("- `brand`");
+  });
+
+  it("notes when none are installed, and hints at the token in the public view", () => {
+    expect(renderIndexMarkdown(base, providers, new Set(), [])).toContain(
+      "No skills installed here yet._",
+    );
+    // tokenless (skills omitted): suggest sending a token
+    expect(renderIndexMarkdown(base, providers, new Set())).toContain(
+      "send a token to list this workspace's skills",
+    );
   });
 });

--- a/web/src/lib/for-agents-markdown.ts
+++ b/web/src/lib/for-agents-markdown.ts
@@ -135,6 +135,9 @@ export function renderIndexMarkdown(
   baseUrl: string,
   providers: McpProvider[],
   connected: Set<string>,
+  /** Installed Agent Skills for this workspace (token-gated). Omitted/empty in
+   *  the public/tokenless view, which still documents the field + sources. */
+  skills?: { name: string; description: string | null }[],
 ): string {
   const lines = [
     "# Native MCP tool reference (for agents)",
@@ -152,5 +155,33 @@ export function renderIndexMarkdown(
     lines.push(`- [${p.displayName}](${baseUrl}/${p.slug}.md) — \`${p.slug}\`${note}`);
   }
   lines.push("");
+
+  // Agent Skills — reusable SKILL.md capabilities an agent opts into with its
+  // `skills:` field. Only skills already installed under skills/<name>/ can be
+  // referenced (a missing one fails the run), so list what's installed here.
+  lines.push(
+    "## Agent Skills",
+    "",
+    "Reusable `SKILL.md` capabilities an agent opts into with its `skills:` field",
+    "(e.g. `skills: [pdf]`). They live in `skills/<name>/` in this repo — only",
+    "reference ones already installed (a missing skill fails the run). Operators",
+    "install more from the Skills page: **Anthropic's knowledge-work library**,",
+    "skills.sh, a custom `.zip` upload, or the Claude API.",
+    "",
+  );
+  if (skills && skills.length > 0) {
+    lines.push("Installed here:", "");
+    for (const s of [...skills].sort((a, b) => a.name.localeCompare(b.name))) {
+      lines.push(`- \`${s.name}\`${s.description ? ` — ${s.description}` : ""}`);
+    }
+    lines.push("");
+  } else {
+    lines.push(
+      "_No skills installed here yet" +
+        (skills ? "" : " (send a token to list this workspace's skills)") +
+        "._",
+      "",
+    );
+  }
   return lines.join("\n");
 }


### PR DESCRIPTION
Follow-up to the skills work: make the readable references CAP consults aware of skills, so authored agents actually set `skills:`.

**The gap:** the authoring guide explained the `skills:` field and said "only reference installed skills" — but nothing told CAP *which* skills are installed or that the new **Anthropic knowledge-work** source exists, and `/for-agents` documented tools but not skills.

## Changes
- **`/for-agents` index** — new **"Agent Skills"** section. With a token it lists the workspace's **installed skills** (name + description) so an authoring agent knows exactly which `skills:` it can reference; tokenless, it documents the field + install sources.
- **`agent-guidance.ts`** — add **Anthropic's knowledge-work library** to the `skills:` section's source list (also fixed a stale model example → `claude-sonnet-5`).

Deliberately **no CAP-prompt change** (per the chosen scope) — CAP already reads both `AGENT_GUIDE.md` (from `agent-guidance.ts`) and can fetch `/for-agents`, so expanding those surfaces is enough.

web suite **204/204** (2 new for the skills section); tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)