### PR TITLE
fix(runner): pydantic-ai 2.13.0 — restore WebSearch runs broken by Anthropic pause_turn

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -68,6 +68,6 @@ jobs:
         run: |
           python3 -m venv /tmp/pydantic-ai
           /tmp/pydantic-ai/bin/pip install --no-cache-dir \
-            'pydantic-ai[mcp]==1.102.0' pyyaml==6.0.2 composio==0.13.1 \
+            'pydantic-ai==2.13.0' pyyaml==6.0.2 composio==0.13.1 \
             pydantic-ai-skills==0.11.0 pytest==9.1.1
           /tmp/pydantic-ai/bin/pytest tests/test_run_pydantic_build_agent.py

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -44,9 +44,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # version bumps go through PR review so we can vet the changelog.
 ENV PYDANTIC_AI_VENV=/opt/pydantic-ai
 ENV PYDANTIC_AI_PY="${PYDANTIC_AI_VENV}/bin/python3"
-# `[mcp]` pulls in the MCP client deps so MCPServerStreamableHTTP is
-# available — that's how Composio exposes its toolkits to pydantic-ai
-# at run time. `composio` is the Python SDK we use to spin up a
+# pydantic-ai 2.x bundles the MCP client deps (MCPToolset) by default —
+# that's how Composio exposes its toolkits to pydantic-ai at run time.
+# 2.10.0+ is required for Anthropic `pause_turn` continuation: without it,
+# WebSearch runs on Claude die with a 400 ("web_search tool use without a
+# corresponding web_search_tool_result block") when the API pauses a long
+# server-tool turn. `composio` is the Python SDK we use to spin up a
 # Composio session keyed by workspace + toolkit list and read the
 # MCP URL back. All three are pinned so a rebuild of a given image
 # tag is reproducible — Composio in particular ships frequently and
@@ -54,7 +57,7 @@ ENV PYDANTIC_AI_PY="${PYDANTIC_AI_VENV}/bin/python3"
 # rebuild. Rev versions via PR so we can vet the changelog.
 RUN python3 -m venv "${PYDANTIC_AI_VENV}" && \
     "${PYDANTIC_AI_VENV}/bin/pip" install --no-cache-dir \
-        'pydantic-ai[mcp]==1.102.0' pyyaml==6.0.2 composio==0.13.1 \
+        'pydantic-ai==2.13.0' pyyaml==6.0.2 composio==0.13.1 \
         pydantic-ai-skills==0.11.0
 
 # Extra deps for agent sidecar tool modules (`tools_module:`). Ships

--- a/api/scripts/run_pydantic.py
+++ b/api/scripts/run_pydantic.py
@@ -1120,9 +1120,6 @@ def build_agent(
     retries = spec.get("retries")
     if isinstance(retries, int):
         kwargs["retries"] = retries
-    instrument = spec.get("instrument")
-    if isinstance(instrument, bool):
-        kwargs["instrument"] = instrument
     if toolsets:
         kwargs["toolsets"] = toolsets
     # Sidecar Python functions from the agent's `tools_module:`. These
@@ -1138,6 +1135,13 @@ def build_agent(
     capabilities = _build_capabilities(spec)
     if capabilities:
         kwargs["capabilities"] = capabilities
+
+    # `instrument: true` — pydantic-ai 2.x replaced Agent(instrument=...) with
+    # the Instrumentation capability.
+    if spec.get("instrument") is True:
+        from pydantic_ai.capabilities import Instrumentation
+
+        kwargs.setdefault("capabilities", []).append(Instrumentation())
 
     # ScaleDown prompt compression — opt-in per agent via `scaledown:`, and only
     # when the workspace set a key. Any non-`off` mode attaches a history
@@ -1155,12 +1159,13 @@ def build_agent(
             file=sys.stderr,
         )
         if sd_enabled and _scaledown_key():
-            kwargs["history_processors"] = [
-                _make_scaledown_processor(sd_rate, sd_min_chars)
-            ]
+            from pydantic_ai.capabilities import ProcessHistory
+
+            kwargs.setdefault("capabilities", []).append(
+                ProcessHistory(_make_scaledown_processor(sd_rate, sd_min_chars))
+            )
     except Exception as e:  # noqa: BLE001 — never block a run on compression setup
         print(f"[scaledown] setup skipped: {e}", file=sys.stderr)
-        kwargs.pop("history_processors", None)
 
     return Agent(model, **kwargs)
 
@@ -1170,8 +1175,7 @@ def build_composio_toolset(
 ):
     """Create a Composio Tool Router session for the declared toolkits
     and wrap it in an MCPToolset so pydantic-ai can call the tools.
-    (`MCPToolset` is the v1.x replacement for `MCPServerStreamableHTTP`;
-    streamable HTTP is its default transport for HTTP URLs.)
+    (Streamable HTTP is `MCPToolset`'s default transport for HTTP URLs.)
 
     Only entries with source="composio" are folded into the session;
     native-MCP entries are handled by `build_native_mcp_toolsets`

--- a/api/tests/test_run_pydantic_build_agent.py
+++ b/api/tests/test_run_pydantic_build_agent.py
@@ -100,6 +100,34 @@ def test_build_agent_attaches_websearch_capability() -> None:
     assert isinstance(agent, Agent)
 
 
+def test_build_agent_with_scaledown_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # scaledown attaches its compressor as a ProcessHistory capability
+    # (pydantic-ai 2.x dropped Agent(history_processors=...)).
+    monkeypatch.setenv("TAS_SCALEDOWN_API_KEY", "test-scaledown-key")
+    agent = run_pydantic.build_agent(
+        {
+            "name": "compressed",
+            "model": "anthropic:claude-sonnet-4-5",
+            "instructions": "Reply briefly.",
+            "scaledown": {"mode": "on"},
+        }
+    )
+    assert isinstance(agent, Agent)
+
+
+def test_build_agent_with_instrument_true() -> None:
+    # `instrument: true` maps to the Instrumentation capability in 2.x.
+    agent = run_pydantic.build_agent(
+        {
+            "name": "instrumented",
+            "model": "anthropic:claude-sonnet-4-5",
+            "instructions": "Reply briefly.",
+            "instrument": True,
+        }
+    )
+    assert isinstance(agent, Agent)
+
+
 def test_uncached_input_excludes_cache_halves() -> None:
     from types import SimpleNamespace
 

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -446,10 +446,22 @@ async function finishTask(args: {
     },
   });
   if (!res.ok) {
-    const status = res.error.kind === "http" && (res.error.status === 401 || res.error.status === 403)
-      ? 502
-      : 502;
-    return { ok: false, status, error: `Tembo Coding Agent rejected the request (${res.error.kind})` };
+    // Include the upstream status + response body so a failing dispatch is
+    // diagnosable from the caller's error alone. Kind-only ("http") proved
+    // undebuggable in the field. Returning the body to the authorized caller
+    // matches what the chat UI already shows (formatCapError); it's LOGGING
+    // the body that #44 forbids — it can echo the submitted prompt.
+    const detail =
+      res.error.kind === "http"
+        ? `HTTP ${res.error.status}: ${res.error.body.slice(0, 300) || "(no body)"}`
+        : res.error.kind === "network"
+          ? `network: ${res.error.message}`
+          : res.error.kind;
+    return {
+      ok: false,
+      status: 502,
+      error: `Tembo Coding Agent rejected the request (${detail})`,
+    };
   }
 
   if (args.ctx.workspace.commitMode === "direct") {


### PR DESCRIPTION
## What

Two fixes from investigating Kevin's report (competitor-monitoring-digest failing every scheduled run since Thu 7/16, and agent-update submissions erroring):

### 1. Upgrade pydantic-ai 1.102.0 → 2.13.0 (fixes the failing runs)

Every run of the `WebSearch`-capability agent has died since 7/16 with:

> 400 `web_search` tool use with id `srvtoolu_…` was found without a corresponding `web_search_tool_result` block

Anthropic now routinely ends long server-tool turns with `stop_reason=pause_turn`; pydantic-ai 1.x replays the paused history malformed ([pydantic-ai#2600](https://github.com/pydantic/pydantic-ai/issues/2600)). The fix ([pydantic-ai#6303](https://github.com/pydantic/pydantic-ai/pull/6303), merged 7/15, first released in v2.10.0) continues paused turns and merges the segments; it was never backported to 1.x. The same failure hit once on 7/9 and became deterministic on 7/16 — consistent with an Anthropic-side ramp, not a TAS deploy (no runner changes since 7/8).

Wrapper adaptations for the 2.x API (small — late-1.x already used the v2-style names):
- `Agent(history_processors=…)` removed → scaledown compressor attaches via the `ProcessHistory` capability
- `Agent(instrument=…)` removed → spec `instrument: true` maps to the `Instrumentation` capability
- `[mcp]` extra no longer exists — MCP client deps ship by default

### 2. Surface CAP status/body on agent-change dispatch failures

The REST/MCP path collapsed all CAP failures to `(http)`, which is why Kevin's update-submission error was undiagnosable remotely. Now returns `HTTP <status>: <body ≤300 chars>`, matching what the chat UI already shows. (This does **not** fix his submission failure — root cause is upstream at CAP, still being pinned down — but makes the next failure self-describing.)

## Verification

- `pytest tests/test_run_pydantic_build_agent.py` — 10 passed on 2.13.0 (8 existing unchanged + 2 new capability-path tests)
- Live smoke: basic haiku run streams deltas/steps/usage correctly
- Live smoke: 6-web-search single-turn run on `claude-sonnet-5` (the exact failing shape) completes on 2.13.0
- `cd web && npx vitest run` — 196 passed

## Follow-up (not in this PR)

- v2 ships a real `Thinking` capability — the wrapper still ignores spec `Thinking:` entries (competitor-monitoring-digest declares one)
- Live per-step token usage streams 0s on v2 (final totals correct) — `ctx.usage` timing changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)