### PR TITLE
fix(cap): follow CAP rename of /public-api/task → /public-api/session

### DIFF
--- a/web/src/lib/cap-api.ts
+++ b/web/src/lib/cap-api.ts
@@ -12,11 +12,13 @@ import type { CommitMode } from "@/lib/commit-mode-constants";
 
 // Thin client for the Tembo Coding Agent Platform task API. The task
 // endpoints live under the **/public-api** namespace and authenticate
-// with the workspace's Tembo API key as `Authorization: Bearer` — the
-// bare `/task/create` path hits a different internal auth gate that
-// rejects the public key ("Invalid token"). POSTs a free-text prompt +
-// repo URL to POST /public-api/task/create and returns a task record
-// with an htmlUrl the user can follow; the task is what opens the PR.
+// with the workspace's Tembo API key as `Authorization: Bearer`. POSTs
+// a free-text prompt + repo URL to POST /public-api/session/create and
+// returns a task record with an htmlUrl the user can follow; the task
+// is what opens the PR. CAP renamed the mount from /public-api/task to
+// /public-api/session with no alias (tembo/monorepo#9519, 2026-07-16);
+// the old path falls through to a catch-all that 400s with
+// {"error":{"message":"invalid request path"}}.
 
 const DEFAULT_TEMBO_API_URL = "https://api.tembo.io";
 
@@ -61,7 +63,7 @@ export async function createTemboTask(args: {
     queueRightAway: true,
   };
 
-  const url = `${baseUrl}/public-api/task/create`;
+  const url = `${baseUrl}/public-api/session/create`;
   // Breadcrumb only — never log `body`: it embeds the prompt (run input/output,
   // user data) and would leak to plaintext container logs / aggregators (#44).
   console.log("[cap] POST", url);


### PR DESCRIPTION
Closes out the second half of Kevin's report (agent-update submissions failing since Friday).

## Root cause

CAP renamed its public task route mount from `/public-api/task` to `/public-api/session` with **no backward-compat alias** ([tembo/monorepo#9519](https://github.com/tembo/monorepo/pull/9519), merged 2026-07-16 19:58 UTC). Since then, TAS's `createTemboTask` POST to `/public-api/task/create` passes CAP's auth middleware, misses the renamed route, and falls through to the Zenstack catch-all:

> `400 {"error":{"message":"invalid request path"}}`

Exactly matches Kevin's screenshot and my `request_agent_change` probes against the dogfood box. Timeline fits: his first failed submit was 7/17, the day after the rename deployed.

[#9519](https://github.com/tembo/monorepo/pull/9519) kept the handler and response shape identical — only the mount moved — so this is a one-line path change (`cap-api.ts` is the only CAP call site in TAS).

## Verification

- `cd web && npx vitest run` — 196 passed
- Post-deploy: will re-run the `request_agent_change` probe against the dogfood instance and confirm a task gets created end-to-end

## Note for the platform team

Any TAS deployment pinned to an older release is equally broken until it picks this up — worth asking whether CAP should carry a `/public-api/task` alias for a deprecation window, since it's a public, documented API namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)