### PR TITLE
feat(inbox): render markdown context + link the producing run in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ they are no longer release versions. Phase scope now lives in
 
 ## [Unreleased]
 
+### Added
+- **Inbox item detail: markdown context + run link.** Context fields that
+  contain Markdown (agent digests) now render formatted instead of as raw
+  text, and the header links to the run that produced the item.
+
 ## [v2026.7.3] — pydantic-ai 2.x runner, WebSearch run + agent-change dispatch fixes, catalog batch 3 — shipped 2026-07-20
 
 ### Added

--- a/web/src/app/[workspace]/inbox/[id]/context-view.test.ts
+++ b/web/src/app/[workspace]/inbox/[id]/context-view.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { looksLikeMarkdown } from "./context-view";
+
+describe("looksLikeMarkdown", () => {
+  it("detects common markdown constructs", () => {
+    expect(looksLikeMarkdown("# Digest\nbody")).toBe(true);
+    expect(looksLikeMarkdown("**TOP 3 TO ACT ON**")).toBe(true);
+    expect(looksLikeMarkdown("intro\n- first\n- second")).toBe(true);
+    expect(looksLikeMarkdown("1. first\n2. second")).toBe(true);
+    expect(looksLikeMarkdown("see [the source](https://example.com)")).toBe(
+      true,
+    );
+    expect(looksLikeMarkdown("```\ncode\n```")).toBe(true);
+    expect(looksLikeMarkdown("> quoted")).toBe(true);
+  });
+
+  it("leaves plain text alone", () => {
+    expect(looksLikeMarkdown("Deal moved to Evaluation")).toBe(false);
+    // Multiline plain text with meaningful line breaks must stay pre-wrap —
+    // markdown rendering would collapse the single newlines.
+    expect(looksLikeMarkdown("line one\nline two\nline three")).toBe(false);
+    // Bare URLs render via the existing link branch, not markdown.
+    expect(looksLikeMarkdown("https://example.com/thing")).toBe(false);
+    // Asterisks/underscores mid-word (identifiers, emphasis-less text).
+    expect(looksLikeMarkdown("snake_case and 2*3=6")).toBe(false);
+  });
+});

--- a/web/src/app/[workspace]/inbox/[id]/context-view.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/context-view.tsx
@@ -5,6 +5,27 @@
 
 import type { ReactNode } from "react";
 
+import { Markdown } from "@/components/markdown";
+
+// Agents routinely put Markdown in context fields (the digest agents write
+// whole documents). Only strings that clearly use markdown syntax are routed
+// through the Markdown renderer — plain text keeps `whitespace-pre-wrap`,
+// because markdown collapses single newlines and would mangle the line
+// breaks of ordinary multiline values.
+const MARKDOWN_MARKERS = [
+  /^#{1,6}\s/m, // heading
+  /\*\*[^*\n]+\*\*/, // bold
+  /^\s*[-*+]\s+\S/m, // bullet list
+  /^\s*\d+\.\s+\S/m, // ordered list
+  /\[[^\]\n]+\]\([^)\s]+\)/, // link
+  /^```/m, // fenced code
+  /^>\s/m, // blockquote
+];
+
+export function looksLikeMarkdown(s: string): boolean {
+  return MARKDOWN_MARKERS.some((re) => re.test(s));
+}
+
 function humanizeKey(key: string): string {
   return key
     .replace(/[_-]+/g, " ")
@@ -37,6 +58,9 @@ function Value({ value }: { value: unknown }): ReactNode {
           {value}
         </a>
       );
+    }
+    if (looksLikeMarkdown(value)) {
+      return <Markdown>{value}</Markdown>;
     }
     return <span className="whitespace-pre-wrap">{value}</span>;
   }

--- a/web/src/app/[workspace]/inbox/[id]/page.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/page.tsx
@@ -92,6 +92,17 @@ export default async function InboxItemPage({
         )}
         <p className="text-foreground-weak text-sm">
           Created <LocalTime iso={item.createdAt.toISOString()} style="relative" />
+          {item.producedByRunId && item.producedByAgentName && (
+            <>
+              {" · "}
+              <Link
+                href={`/${workspace.slug}/agents/${item.producedByAgentName}/runs/${item.producedByRunId}`}
+                className="text-foreground font-medium hover:underline"
+              >
+                {item.producedByAgentName} run
+              </Link>
+            </>
+          )}
         </p>
         {!resolved && (
           <p className="text-foreground-muted text-sm">

--- a/web/src/lib/inbox-api.ts
+++ b/web/src/lib/inbox-api.ts
@@ -78,6 +78,9 @@ export interface InboxItem {
   assigneeKind: InboxAssigneeKind | null;
   assigneeId: string | null;
   producedByRunId: string | null;
+  /** Agent that produced this item (from the producing run). Null for
+   *  human/source-created items. Used to deep-link the run. */
+  producedByAgentName: string | null;
   improvementId: string | null;
   signalConsumedAt: Date | null;
   // Null when produced by an agent/source/system rather than a person.
@@ -110,6 +113,7 @@ type Row = {
   assignee_kind: InboxAssigneeKind | null;
   assignee_id: string | null;
   produced_by_run_id: string | null;
+  produced_by_agent_name: string | null;
   improvement_id: string | null;
   signal_consumed_at: Date | null;
   created_by: string | null;
@@ -140,6 +144,7 @@ function rowToInboxItem(r: Row): InboxItem {
     assigneeKind: r.assignee_kind,
     assigneeId: r.assignee_id,
     producedByRunId: r.produced_by_run_id,
+    producedByAgentName: r.produced_by_agent_name,
     improvementId: r.improvement_id,
     signalConsumedAt: r.signal_consumed_at,
     createdBy: r.created_by,
@@ -161,9 +166,12 @@ const COLUMNS = `
   i.assignee_kind, i.assignee_id, i.produced_by_run_id, i.improvement_id,
   i.signal_consumed_at, i.created_by,
   u.name AS created_by_name, u.email AS created_by_email,
+  r.agent_name AS produced_by_agent_name,
   i.created_at, i.updated_at, i.resolved_at, i.snoozed_until
 `;
-const FROM_JOIN = `FROM inbox_item i LEFT JOIN "user" u ON u.id = i.created_by`;
+const FROM_JOIN = `FROM inbox_item i
+  LEFT JOIN "user" u ON u.id = i.created_by
+  LEFT JOIN run r ON r.id = i.produced_by_run_id`;
 
 export interface CreateInboxItemInput {
   workspaceId: string;
@@ -247,7 +255,8 @@ export async function createInboxItem(
      )
      SELECT ${COLUMNS}
      FROM upserted i
-     LEFT JOIN "user" u ON u.id = i.created_by`,
+     LEFT JOIN "user" u ON u.id = i.created_by
+     LEFT JOIN run r ON r.id = i.produced_by_run_id`,
     [
       input.workspaceId,
       input.source,


### PR DESCRIPTION
Two inbox-item-detail improvements from dogfooding the competitor digest:

## Markdown context

Agents put whole Markdown documents in `context` fields; the detail page rendered them raw. String values that clearly use markdown syntax (headings, bold, lists, links, fences, quotes) now render through the shared `<Markdown>` component. Plain strings keep `whitespace-pre-wrap` — markdown collapses single newlines, which would mangle ordinary multiline values — via a small `looksLikeMarkdown` heuristic (unit-tested).

## Run link in the header

`inbox_item.produced_by_run_id` existed but was never surfaced. The item query now left-joins `run` for the agent name, and the header shows `Created 2h ago · competitor-monitoring-digest run` with the run name linking to the run detail page. Human/source-created items are unchanged (null join).

## Verification

- `npx vitest run` — 198 passed (196 + 2 new)
- `npx tsc --noEmit` — clean
- All four `COLUMNS` query sites carry the new join (list, get, upsert-returning, unconsumed-signals which already joined `run r`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)