### PR TITLE
feat(inbox): newsletter rendering for digest items + links rollup

### DIFF
--- a/web/src/app/[workspace]/inbox/[id]/context-view.test.ts
+++ b/web/src/app/[workspace]/inbox/[id]/context-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { looksLikeMarkdown } from "./context-view";
+import { documentText, looksLikeMarkdown } from "./context-view";
 
 describe("looksLikeMarkdown", () => {
   it("detects common markdown constructs", () => {
@@ -24,5 +24,24 @@ describe("looksLikeMarkdown", () => {
     expect(looksLikeMarkdown("https://example.com/thing")).toBe(false);
     // Asterisks/underscores mid-word (identifiers, emphasis-less text).
     expect(looksLikeMarkdown("snake_case and 2*3=6")).toBe(false);
+  });
+});
+
+describe("documentText", () => {
+  const digest = "**Digest — last 30 days**\n\n- [move](https://example.com)";
+
+  it("returns the text for a { text } markdown context", () => {
+    expect(documentText({ text: digest })).toBe(digest);
+  });
+
+  it("returns null for plain text (line breaks need pre-wrap)", () => {
+    expect(documentText({ text: "line one\nline two" })).toBeNull();
+  });
+
+  it("returns null for structured payloads", () => {
+    expect(documentText({ text: digest, severity: "high" })).toBeNull();
+    expect(documentText({ subject: digest })).toBeNull();
+    expect(documentText({ text: 42 } as never)).toBeNull();
+    expect(documentText({})).toBeNull();
   });
 });

--- a/web/src/app/[workspace]/inbox/[id]/context-view.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/context-view.tsx
@@ -26,6 +26,21 @@ export function looksLikeMarkdown(s: string): boolean {
   return MARKDOWN_MARKERS.some((re) => re.test(s));
 }
 
+// A context of exactly `{ text: "<markdown>" }` is a document, not a payload —
+// it's what produce_inbox_item stores when the producer passes a plain string,
+// and the digest agents write whole newsletters that way. Returns the text so
+// the item page can render it as full-width prose instead of a labeled field
+// inside a box; anything else (structured payloads, plain non-markdown text
+// whose line breaks need pre-wrap) returns null and keeps the fields view.
+export function documentText(context: Record<string, unknown>): string | null {
+  if (!isPlainObject(context)) return null;
+  const keys = Object.keys(context);
+  if (keys.length !== 1 || keys[0] !== "text") return null;
+  const text = context.text;
+  if (typeof text !== "string" || !looksLikeMarkdown(text)) return null;
+  return text;
+}
+
 function humanizeKey(key: string): string {
   return key
     .replace(/[_-]+/g, " ")

--- a/web/src/app/[workspace]/inbox/[id]/page.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/page.tsx
@@ -1,16 +1,59 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { IconChevronDownSmall } from "central-icons";
 
 import { LocalTime } from "@/components/local-time";
+import { Markdown } from "@/components/markdown";
 import { McpProviderLogo } from "@/components/mcp-provider-logo";
-import { getInboxItem, listInboxItems, type InboxItem } from "@/lib/inbox-api";
+import {
+  getInboxItem,
+  listInboxItems,
+  type InboxItem,
+  type InboxLink,
+} from "@/lib/inbox-api";
 import { getServerSession } from "@/lib/session";
+import { cn } from "@/lib/utils";
 import { getWorkspaceBySlug } from "@/lib/workspace";
 
-import { ContextView } from "./context-view";
+import { ContextView, documentText } from "./context-view";
 import { ReviewForm } from "./review-form";
 
 export const dynamic = "force-dynamic";
+
+// Past this many links the list collapses behind a "Links (N)" disclosure —
+// a digest citing 20 sources shouldn't dominate the page, while a triage item
+// pointing at a handful of tickets keeps them all visible.
+const LINKS_COLLAPSE_THRESHOLD = 5;
+
+function LinksList({
+  links,
+  className,
+}: {
+  links: InboxLink[];
+  className?: string;
+}) {
+  return (
+    <ul
+      className={cn(
+        "bg-surface-secondary flex flex-col gap-1 rounded-lg border border-[var(--color-border-weak)] p-4",
+        className,
+      )}
+    >
+      {links.map((link, i) => (
+        <li key={`${link.url}-${i}`}>
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground inline-flex w-fit items-center gap-1 text-sm font-medium hover:underline"
+          >
+            {link.label ?? link.url} ↗
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 // Drop currently-snoozed items (snoozed_until in the future) from the triage
 // queue. Module-scope so `Date.now()` stays out of the server component's render.
@@ -42,6 +85,7 @@ export default async function InboxItemPage({
   if (!item) notFound();
 
   const resolved = item.status === "done" || item.status === "dismissed";
+  const doc = documentText(item.context);
 
   // For an active item, find the next one to triage so resolving this one
   // advances the user through their queue (and show how many remain). "Next" is
@@ -113,36 +157,44 @@ export default async function InboxItemPage({
         )}
       </div>
 
-      {item.links && item.links.length > 0 && (
+      {doc ? (
+        // A pure-markdown context (the digest agents) reads like an article:
+        // full-width prose at reading size, no box, no "Context" chrome.
+        <Markdown size="lg">{doc}</Markdown>
+      ) : (
         <section className="flex flex-col gap-2">
           <h2 className="text-foreground text-sm font-semibold uppercase tracking-wide">
-            Links
+            Context
           </h2>
-          <ul className="bg-surface-secondary flex flex-col gap-1 rounded-lg border border-[var(--color-border-weak)] p-4">
-            {item.links.map((link, i) => (
-              <li key={`${link.url}-${i}`}>
-                <a
-                  href={link.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-foreground inline-flex w-fit items-center gap-1 text-sm font-medium hover:underline"
-                >
-                  {link.label ?? link.url} ↗
-                </a>
-              </li>
-            ))}
-          </ul>
+          <div className="bg-surface-secondary rounded-lg border border-[var(--color-border-weak)] p-4">
+            <ContextView context={item.context} />
+          </div>
         </section>
       )}
 
-      <section className="flex flex-col gap-2">
-        <h2 className="text-foreground text-sm font-semibold uppercase tracking-wide">
-          Context
-        </h2>
-        <div className="bg-surface-secondary rounded-lg border border-[var(--color-border-weak)] p-4">
-          <ContextView context={item.context} />
-        </div>
-      </section>
+      {item.links && item.links.length > 0 && (
+        <section className="flex flex-col gap-2">
+          {item.links.length > LINKS_COLLAPSE_THRESHOLD ? (
+            <details className="group">
+              <summary className="text-foreground flex w-fit cursor-pointer list-none items-center gap-1 text-sm font-semibold uppercase tracking-wide [&::-webkit-details-marker]:hidden">
+                Links ({item.links.length})
+                <IconChevronDownSmall
+                  aria-hidden
+                  className="text-foreground-muted h-3.5 w-3.5 -rotate-90 transition-transform group-open:rotate-0"
+                />
+              </summary>
+              <LinksList links={item.links} className="mt-2" />
+            </details>
+          ) : (
+            <>
+              <h2 className="text-foreground text-sm font-semibold uppercase tracking-wide">
+                Links
+              </h2>
+              <LinksList links={item.links} />
+            </>
+          )}
+        </section>
+      )}
 
       {resolved ? (
         <section className="flex flex-col gap-2">

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -17,17 +17,26 @@ import { cn } from "@/lib/utils";
 type Props = {
   children: string;
   className?: string;
+  size?: "sm" | "lg";
 };
 
-export function Markdown({ children, className }: Props) {
+// `sm` matches the surrounding "small body copy" we use for inline content.
+// `lg` is for long-form reading (inbox digests): sized like the tembo.io blog
+// (19px body on a ~1.6 line-height, em-scaled headings via prose-lg), where
+// the text IS the page rather than a field inside it.
+const SIZE_CLASSES = {
+  sm: "prose-sm",
+  lg: "prose-lg text-[19px] leading-[1.6] prose-headings:font-semibold",
+};
+
+export function Markdown({ children, className, size = "sm" }: Props) {
   return (
     <div
       className={cn(
-        // Tailwind Typography handles most of the rendering. `prose-sm`
-        // matches the surrounding "small body copy" we use elsewhere
-        // for inline content; `max-w-none` lets it stretch to the
-        // container.
-        "prose prose-sm dark:prose-invert max-w-none",
+        // Tailwind Typography handles most of the rendering; `max-w-none`
+        // lets it stretch to the container.
+        "prose dark:prose-invert max-w-none",
+        SIZE_CLASSES[size],
         // Strip Typography's default margins around code blocks so
         // they sit flush like our existing <pre> blocks. Inline code
         // gets a subtle surface tint for legibility.

--- a/web/src/lib/mcp/server.ts
+++ b/web/src/lib/mcp/server.ts
@@ -423,7 +423,10 @@ export function buildMcpServer(
         "without one it sits 'open' for someone to pick up. To point one item at " +
         "several things to review (e.g. the top 10 Linear triage tickets as one " +
         "task), pass `links: [{ label, url }]` — they render as a clickable list, " +
-        "preferable to a Markdown link list in proposedActionText. Returns the item.",
+        "preferable to a Markdown link list in proposedActionText. For a narrative " +
+        "digest, pass the document as a plain-string Markdown `context` (rendered " +
+        "full-width at reading size) with sources linked inline, and mirror them " +
+        "in `links`. Returns the item.",
       inputSchema: {
         itemType: z
           .string()
@@ -449,7 +452,13 @@ export function buildMcpServer(
         context: z
           .union([z.record(z.string(), z.unknown()), z.string()])
           .optional()
-          .describe("The raw payload to review — a JSON object, or a plain string (stored as { text })."),
+          .describe(
+            "The raw payload to review — a JSON object (rendered as labeled " +
+            "fields), or a plain string (stored as { text }). A plain string " +
+            "that is Markdown renders as a full-width document — write " +
+            "digests/newsletters this way, most important items first, with " +
+            "every claim's source linked inline.",
+          ),
         proposedActionText: z.string().optional().describe("Your proposed reply / decision."),
         proposedActionFields: z.record(z.string(), z.unknown()).optional().describe("Structured proposal params."),
         options: z
@@ -493,8 +502,10 @@ export function buildMcpServer(
           .optional()
           .describe(
             "Deep links for the human to open, one row each — e.g. the Linear tickets " +
-            "behind a single triage item. Rendered as a clickable 'Links' list on the " +
-            "item (separate from the single `url` source link). Non-http(s) urls are dropped.",
+            "behind a single triage item. Rendered as a clickable 'Links' list below " +
+            "the context (separate from the single `url` source link; collapses " +
+            "behind a count past 5 links, so a long source list stays out of the " +
+            "way). Non-http(s) urls are dropped.",
           ),
       },
     },


### PR DESCRIPTION
## What

Digest-style inbox items (a plain-string Markdown `context`, stored as `{ text }`) now render like an article instead of a labeled field in a grey box:

- **Unboxed, full-width prose at reading size** — new `size="lg"` on the `Markdown` component (19px body / 1.6 line-height, matching the tembo.io blog typography). No more `CONTEXT` / `TEXT` headers for these items.
- **Links move below the content** and **collapse behind a `Links (N)` disclosure when more than 5** (native `<details>`, zero client JS) — a digest citing 20 sources no longer opens with a wall of links, while short triage lists (≤5) stay fully visible and open.
- **Structured contexts are unchanged**: multi-field payloads keep the boxed labeled-fields `ContextView`.
- `produce_inbox_item` tool + param descriptions updated to steer agents: narrative digests should link sources inline in the Markdown; `links` stays as the machine-readable source list rendered as a collapsed appendix.

Pairs with a tas-repo update to `competitor-monitoring-digest` (newsletter composition: TOP 3 first, inline source links, coverage footer).

## Testing

- `npx vitest run` — 28 files / 201 tests pass (new `documentText` cases added), `tsc --noEmit` clean.
- Verified in the local Docker stack with seeded items: digest item renders as 19px unboxed prose with inline links and a collapsed `Links (12)` appendix that expands; a structured 3-link item renders exactly as before (boxed fields, open links list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)