### PR TITLE
fix(ci): fail deploy-internal when Railway returns GraphQL errors

### DIFF
--- a/.github/workflows/deploy-internal.yml
+++ b/.github/workflows/deploy-internal.yml
@@ -102,10 +102,19 @@ jobs:
           rw() {
             # Project tokens authenticate via the Project-Access-Token
             # header (Authorization: Bearer is for account/team tokens).
-            curl -fsS https://backboard.railway.app/graphql/v2 \
+            local res
+            res=$(curl -fsS https://backboard.railway.app/graphql/v2 \
               -H "Project-Access-Token: $RAILWAY_TOKEN" \
               -H "Content-Type: application/json" \
-              -d "$1"
+              -d "$1")
+            echo "$res"
+            # GraphQL reports failures in-band with HTTP 200, so curl -f
+            # alone can't catch them (an expired Railway plan once left this
+            # step green while deploying nothing).
+            if jq -e '(.errors // []) | length > 0' <<<"$res" >/dev/null; then
+              echo "::error::Railway API returned errors — deploy did not happen"
+              return 1
+            fi
           }
           echo "Pinning $SERVICE_ID → $IMAGE"
           # Pin to the immutable digest (not :edge) so Railway always


### PR DESCRIPTION
Railway's GraphQL API reports failures in-band with HTTP 200, so `curl -f` never trips. When the Railway trial expired, deploy-internal kept reporting green while deploying nothing (caught when the dogfood box didn't pick up #327). The `rw` helper now echoes the response and exits nonzero when it carries an `errors` array.

Verified the jq predicate against both a clean response (exit 1 → no trip) and the actual trial-expired error payload (exit 0 → step fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)