### PR TITLE
fix(inbox): one document rendering for all text-only items, GFM tables, 18px

### DIFF
--- a/web/src/app/[workspace]/inbox/[id]/context-view.test.ts
+++ b/web/src/app/[workspace]/inbox/[id]/context-view.test.ts
@@ -13,6 +13,13 @@ describe("looksLikeMarkdown", () => {
     );
     expect(looksLikeMarkdown("```\ncode\n```")).toBe(true);
     expect(looksLikeMarkdown("> quoted")).toBe(true);
+    // GFM table via its delimiter row (register agents emit table-only docs).
+    expect(
+      looksLikeMarkdown("| A | B |\n| --- | --- |\n| 1 | 2 |"),
+    ).toBe(true);
+    expect(looksLikeMarkdown("| A | B |\n| :--- | ---: |\n| 1 | 2 |")).toBe(
+      true,
+    );
   });
 
   it("leaves plain text alone", () => {
@@ -24,24 +31,28 @@ describe("looksLikeMarkdown", () => {
     expect(looksLikeMarkdown("https://example.com/thing")).toBe(false);
     // Asterisks/underscores mid-word (identifiers, emphasis-less text).
     expect(looksLikeMarkdown("snake_case and 2*3=6")).toBe(false);
+    // A pipe in prose is not a table — only the delimiter row counts.
+    expect(looksLikeMarkdown("either a | b works\nfoo | bar")).toBe(false);
   });
 });
 
 describe("documentText", () => {
   const digest = "**Digest — last 30 days**\n\n- [move](https://example.com)";
 
-  it("returns the text for a { text } markdown context", () => {
+  it("returns the text for any text-only context, markdown or plain", () => {
     expect(documentText({ text: digest })).toBe(digest);
+    // Plain text is still a document — the page picks pre-wrap rendering for
+    // it, but it must not fall back to the boxed labeled-fields view.
+    expect(documentText({ text: "line one\nline two" })).toBe(
+      "line one\nline two",
+    );
   });
 
-  it("returns null for plain text (line breaks need pre-wrap)", () => {
-    expect(documentText({ text: "line one\nline two" })).toBeNull();
-  });
-
-  it("returns null for structured payloads", () => {
+  it("returns null for structured payloads and empty text", () => {
     expect(documentText({ text: digest, severity: "high" })).toBeNull();
     expect(documentText({ subject: digest })).toBeNull();
     expect(documentText({ text: 42 } as never)).toBeNull();
+    expect(documentText({ text: "  " })).toBeNull();
     expect(documentText({})).toBeNull();
   });
 });

--- a/web/src/app/[workspace]/inbox/[id]/context-view.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/context-view.tsx
@@ -20,24 +20,28 @@ const MARKDOWN_MARKERS = [
   /\[[^\]\n]+\]\([^)\s]+\)/, // link
   /^```/m, // fenced code
   /^>\s/m, // blockquote
+  // GFM table — match the delimiter row (`| --- | :--- |`), not just any
+  // pipe-bearing line, so prose that happens to contain "a | b" stays plain.
+  /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{0,}:?\s*\|?\s*$/m,
 ];
 
 export function looksLikeMarkdown(s: string): boolean {
   return MARKDOWN_MARKERS.some((re) => re.test(s));
 }
 
-// A context of exactly `{ text: "<markdown>" }` is a document, not a payload —
-// it's what produce_inbox_item stores when the producer passes a plain string,
-// and the digest agents write whole newsletters that way. Returns the text so
-// the item page can render it as full-width prose instead of a labeled field
-// inside a box; anything else (structured payloads, plain non-markdown text
-// whose line breaks need pre-wrap) returns null and keeps the fields view.
+// A context of exactly `{ text: "..." }` is a document, not a payload — it's
+// what produce_inbox_item stores when the producer passes a plain string, and
+// the digest/register agents write whole reports that way. Returns the text so
+// the item page can render it as full-width prose (no box, no CONTEXT/TEXT
+// chrome) — every text-only item gets the same treatment, whether or not it
+// uses markdown syntax. Structured multi-field payloads return null and keep
+// the labeled-fields view.
 export function documentText(context: Record<string, unknown>): string | null {
   if (!isPlainObject(context)) return null;
   const keys = Object.keys(context);
   if (keys.length !== 1 || keys[0] !== "text") return null;
   const text = context.text;
-  if (typeof text !== "string" || !looksLikeMarkdown(text)) return null;
+  if (typeof text !== "string" || text.trim() === "") return null;
   return text;
 }
 

--- a/web/src/app/[workspace]/inbox/[id]/page.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/page.tsx
@@ -15,7 +15,7 @@ import { getServerSession } from "@/lib/session";
 import { cn } from "@/lib/utils";
 import { getWorkspaceBySlug } from "@/lib/workspace";
 
-import { ContextView, documentText } from "./context-view";
+import { ContextView, documentText, looksLikeMarkdown } from "./context-view";
 import { ReviewForm } from "./review-form";
 
 export const dynamic = "force-dynamic";
@@ -158,9 +158,17 @@ export default async function InboxItemPage({
       </div>
 
       {doc ? (
-        // A pure-markdown context (the digest agents) reads like an article:
-        // full-width prose at reading size, no box, no "Context" chrome.
-        <Markdown size="lg">{doc}</Markdown>
+        // A text-only context (digests, registers, reports) reads like an
+        // article: full-width prose at reading size, no box, no "Context"
+        // chrome. The markdown sniff only picks the renderer — plain text
+        // keeps pre-wrap so its line breaks survive.
+        looksLikeMarkdown(doc) ? (
+          <Markdown size="lg">{doc}</Markdown>
+        ) : (
+          <p className="text-foreground text-[19px] leading-[1.6] whitespace-pre-wrap">
+            {doc}
+          </p>
+        )
       ) : (
         <section className="flex flex-col gap-2">
           <h2 className="text-foreground text-sm font-semibold uppercase tracking-wide">

--- a/web/src/app/[workspace]/inbox/[id]/page.tsx
+++ b/web/src/app/[workspace]/inbox/[id]/page.tsx
@@ -165,7 +165,7 @@ export default async function InboxItemPage({
         looksLikeMarkdown(doc) ? (
           <Markdown size="lg">{doc}</Markdown>
         ) : (
-          <p className="text-foreground text-[19px] leading-[1.6] whitespace-pre-wrap">
+          <p className="text-foreground text-lg leading-[1.6] whitespace-pre-wrap">
             {doc}
           </p>
         )

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -47,7 +47,20 @@ export function Markdown({ children, className, size = "sm" }: Props) {
         className,
       )}
     >
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // Register-style agents emit tables with 10+ columns; scroll them
+          // horizontally instead of blowing out the reading column.
+          table: (props) => (
+            <div className="overflow-x-auto">
+              <table {...props} />
+            </div>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -21,12 +21,12 @@ type Props = {
 };
 
 // `sm` matches the surrounding "small body copy" we use for inline content.
-// `lg` is for long-form reading (inbox digests): sized like the tembo.io blog
-// (19px body on a ~1.6 line-height, em-scaled headings via prose-lg), where
-// the text IS the page rather than a field inside it.
+// `lg` is for long-form reading (inbox digests) where the text IS the page
+// rather than a field inside it: 18px body on a 1.6 line-height (a notch
+// under the tembo.io blog's 19px, which reads oversized inside app chrome).
 const SIZE_CLASSES = {
   sm: "prose-sm",
-  lg: "prose-lg text-[19px] leading-[1.6] prose-headings:font-semibold",
+  lg: "prose-lg leading-[1.6] prose-headings:font-semibold",
 };
 
 export function Markdown({ children, className, size = "sm" }: Props) {


### PR DESCRIPTION
Follow-ups to #327 from dogfooding:

- **One output type for text-only items.** Any `{ text }` context now renders as the unboxed full-width document — the markdown sniff only picks the renderer (Markdown vs pre-wrap for plain text whose line breaks matter), so a text item can never fall back to the boxed CONTEXT/TEXT labeled-fields view. The Attio duplicate register was doing exactly that, because its table-only markdown matched none of the `looksLikeMarkdown` markers.
- **GFM tables detected + scrollable.** `looksLikeMarkdown` gains a table-delimiter-row marker (`| --- | --- |`, not just any pipe-bearing line), and the Markdown component wraps tables in `overflow-x-auto` so a 10-column register scrolls instead of blowing out the reading column.
- **Reading size 19px → 18px** (`prose-lg` native) — 19px read slightly oversized inside the app shell.

## Testing

- `npx vitest run` — 28 files / 200 tests pass (table-marker + documentText cases updated), `tsc --noEmit` clean.
- Verified in the local Docker stack: a seeded table-only register renders as a real table (scrolls horizontally), a plain-text note renders unboxed with line breaks preserved, both with no CONTEXT/TEXT chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)