### PR TITLE
fix(auth): resolve invites on email/password instances

### DIFF
--- a/docs/src/content/docs/customer-setup.md
+++ b/docs/src/content/docs/customer-setup.md
@@ -32,8 +32,11 @@ involved in the optional chat-to-PR *authoring* flow. The instance is
   platform usually terminates TLS. **Recommended** — you can start on the
   platform-provided URL.
 
-**Authentication** — pick at least one *(Required)*. There is no password login;
-users sign in through an identity provider.
+**Authentication** *(Optional for a quickstart)* — with no OAuth provider
+configured, the login screen offers **email + password** (sign-up still gated
+by `INSTANCE_ADMIN_EMAILS` / invites), so there's nothing to procure. For
+production SSO, pick one provider — configuring it turns email/password off
+automatically:
 
 - [ ] **Google OAuth** *(easiest)* — create an OAuth 2.0 client at
   <https://console.cloud.google.com/apis/credentials>; or

--- a/web/src/lib/invitations.test.ts
+++ b/web/src/lib/invitations.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { inviteResolutionAllowed } from "./invitations";
+
+// invitations.ts pulls in audit-db/db (pg) transitively; neither is touched
+// by the pure gate under test, but mock them so importing the module never
+// opens a connection pool.
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/audit-db", () => ({ writeAuditEvent: vi.fn() }));
+
+const ORIGINAL_ENV = process.env;
+
+function setOAuthConfigured(configured: boolean) {
+  process.env = { ...ORIGINAL_ENV };
+  for (const key of [
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "MICROSOFT_CLIENT_ID",
+    "MICROSOFT_CLIENT_SECRET",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_DISCOVERY_URL",
+  ]) {
+    delete process.env[key];
+  }
+  if (configured) {
+    process.env.GOOGLE_CLIENT_ID = "google-id";
+    process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+  }
+}
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("inviteResolutionAllowed", () => {
+  it("requires a verified email when an OAuth IdP is configured", () => {
+    setOAuthConfigured(true);
+    expect(inviteResolutionAllowed(true)).toBe(true);
+    expect(inviteResolutionAllowed(false)).toBe(false);
+  });
+
+  it("resolves invites for unverified emails on an email/password instance", () => {
+    // No OAuth provider → email/password sign-in, where emailVerified is
+    // always false and the closed-instance sign-up gate is the authorization.
+    setOAuthConfigured(false);
+    expect(inviteResolutionAllowed(false)).toBe(true);
+    expect(inviteResolutionAllowed(true)).toBe(true);
+  });
+});

--- a/web/src/lib/invitations.ts
+++ b/web/src/lib/invitations.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { writeAuditEvent } from "@/lib/audit-db";
+import { emailPasswordEnabled } from "@/lib/auth-providers";
 import { db } from "@/lib/db";
 import { isWorkspaceRole, type WorkspaceRole } from "@/lib/rbac";
 
@@ -156,6 +157,29 @@ export async function hasPendingInvite(
 }
 
 /**
+ * Should a pending invite resolve into a membership for a user whose email
+ * carries this `emailVerified` flag? Honor an invite only when the IdP
+ * verified the email (#47) — better-auth stores `emailVerified` from the
+ * provider's `email_verified` claim (false when absent); Google/Microsoft
+ * verify. Without this, a user who can assert an unverified /
+ * attacker-controlled email at a permissive IdP could auto-join the invited
+ * workspace at the invited role.
+ *
+ * On an email/password instance (no OAuth provider configured — see
+ * emailPasswordEnabled) there is no IdP and `emailVerified` is always false,
+ * so requiring it would strand every invitee: the closed-instance gate lets
+ * them sign up, but the invite would never become a membership. There the
+ * sign-up gate itself is the authorization — only an invited (or instance
+ * admin) email may create an account at all — so resolve invites regardless.
+ * The IdP-permissiveness attack doesn't apply: no third-party assertion is
+ * involved, and configuring any OAuth provider turns email/password off and
+ * restores the strict check.
+ */
+export function inviteResolutionAllowed(emailVerified: boolean): boolean {
+  return emailVerified || emailPasswordEnabled();
+}
+
+/**
  * On first sign-in, turn this user's pending invites into memberships.
  * Idempotent: re-running adds nothing (membership upsert + invite marked
  * accepted). Returns how many workspaces were joined.
@@ -165,17 +189,13 @@ export async function resolvePendingInvitesForUser(
   email: string,
 ): Promise<number> {
   const e = email.trim().toLowerCase();
-  // Honor an invite only when the IdP verified the email (#47). better-auth
-  // stores `emailVerified` from the provider's `email_verified` claim (false
-  // when absent); Google/Microsoft verify. Without this, a user who can assert
-  // an unverified / attacker-controlled email at a permissive IdP could
-  // auto-join the invited workspace at the invited role. Central gate — both
-  // user-driven paths (first-sign-in hook + home-page resolve) funnel here.
+  // Central gate (see inviteResolutionAllowed) — both user-driven paths
+  // (first-sign-in hook + home-page resolve) funnel here.
   const { rows: verified } = await db.query<{ emailVerified: boolean }>(
     `SELECT "emailVerified" FROM "user" WHERE id = $1`,
     [userId],
   );
-  if (!verified[0]?.emailVerified) {
+  if (!inviteResolutionAllowed(verified[0]?.emailVerified ?? false)) {
     console.warn(
       `[invites] skipping invite resolve for ${userId}: email not verified by the IdP`,
     );


### PR DESCRIPTION
## Problem

On an email/password instance (no OAuth provider configured), workspace invitations never turn into memberships. Credential sign-ups always have `emailVerified=false` (no SMTP, no IdP), and `resolvePendingInvitesForUser` refuses unverified emails — so the closed-instance gate lets an invitee create an account, and then they land workspace-less with no way in.

Instance admins are unaffected (they don't need invites), which is why this stayed hidden; any non-admin invitee on a password instance hits it.

## Fix

Extract the gate into `inviteResolutionAllowed()`:

- **OAuth configured** → unchanged: invite resolves only for IdP-verified emails (#47's attack — asserting someone else's email at a permissive IdP — needs a third-party IdP).
- **Email/password instance** → resolve regardless. There is no IdP, `emailVerified` is structurally false, and the invite-gated sign-up itself is the authorization: only an invited or admin email can create an account at all. Configuring any OAuth provider turns email/password off and restores the strict check.

Also fixes the stale "There is no password login" block in the customer setup checklist, which predates the email/password quickstart (1888344).

## Testing

- New `invitations.test.ts` covers both env states.
- `npx vitest run`: 211 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)