### PR TITLE
feat(auth): lost / reset / change password for email/password instances

### DIFF
--- a/web/src/app/[workspace]/settings/account/page.tsx
+++ b/web/src/app/[workspace]/settings/account/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+
+import { Section } from "@/components/section";
+import { emailPasswordEnabled } from "@/lib/auth-providers";
+import { getServerSession } from "@/lib/session";
+
+import { ChangePasswordForm } from "../change-password-form";
+
+export const dynamic = "force-dynamic";
+
+// Account: the signed-in user's own credentials. Only exists on
+// email/password instances — with an OAuth provider configured,
+// credentials live at the identity provider and there's nothing to
+// manage here (the nav link is hidden too; this gate is the backstop).
+export default async function AccountPage() {
+  if (!emailPasswordEnabled()) notFound();
+  const session = await getServerSession();
+  if (!session) notFound();
+
+  return (
+    <Section
+      title="Password"
+      description={`Change the password for ${session.user.email}. Other sessions are signed out when it changes. Locked out instead? A workspace admin can generate a reset link from your member page.`}
+    >
+      <ChangePasswordForm />
+    </Section>
+  );
+}

--- a/web/src/app/[workspace]/settings/actions.ts
+++ b/web/src/app/[workspace]/settings/actions.ts
@@ -19,23 +19,18 @@ import {
   deleteToolsForConnection,
   replaceToolsForConnection,
 } from "@/lib/mcp-tools";
-import { isWorkspaceRole, type WorkspaceRole } from "@/lib/rbac";
+import { type WorkspaceRole } from "@/lib/rbac";
 import {
   refreshAllGuidanceFiles,
   restoreAgent,
   type RestoreAgentError,
 } from "@/lib/workspace-agents";
-import { getPublicOrigin } from "@/lib/config";
-import { getInstanceName } from "@/lib/instance-settings";
-import { createInvitation, revokeInvitation } from "@/lib/invitations";
 import {
-  changeMemberRole,
   DEFAULT_FAVICON_KINDS,
   deleteWorkspace,
   disconnectWorkspaceRepo,
   getWorkspaceSecretPlaintext,
   getWorkspaceSecretPreview,
-  removeWorkspaceMember,
   removeWorkspaceSecret,
   renameWorkspace,
   setFaviconCustom,
@@ -604,229 +599,6 @@ export async function syncGuidanceAction(
     message:
       "Synced agents/AGENTS.md and the per-framework AGENT_GUIDE.md files. Check the repo for new commits.",
   };
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Members (US-0.4-02)
-
-export type MemberFormState = {
-  message?: string;
-  error?: string;
-  /** Copy-paste invite text, set after a successful invitation. */
-  template?: string;
-  invitedEmail?: string;
-};
-
-const MEMBER_EMPTY: MemberFormState = {};
-
-/**
- * Add a workspace member by email. Workspace-admin only. The
- * invitee must have signed in to TAS at least once so a user row
- * exists; we don't email invitations from TAS itself today.
- */
-export async function inviteMemberAction(
-  _prev: MemberFormState,
-  formData: FormData,
-): Promise<MemberFormState> {
-  const slug = String(formData.get("workspace") ?? "");
-  const email = String(formData.get("email") ?? "").trim();
-  const roleRaw = String(formData.get("role") ?? "").trim();
-
-  if (!email) return { error: "Enter an email address." };
-  if (!isWorkspaceRole(roleRaw)) return { error: "Pick a role." };
-  const role: WorkspaceRole = roleRaw;
-
-  const auth = await authorizeWorkspace(slug, "workspace_admin");
-  if (auth.denied) return { error: DENIED_MESSAGE };
-  const { workspace, userId } = auth;
-
-  const result = await createInvitation(workspace.id, email, role, userId);
-  if (!result.ok) {
-    switch (result.error) {
-      case "bad-email":
-        return { error: "That doesn't look like a valid email address." };
-      case "bad-role":
-        return { error: "Pick a role." };
-      case "already-member":
-        return {
-          error:
-            "That person is already a member. Change their role on the member row instead.",
-        };
-      case "already-invited":
-        return { error: "That email already has a pending invitation." };
-    }
-  }
-
-  // Existing account → added straight to the workspace, no invite to send.
-  if (result.joinedDirectly) {
-    await writeAuditEvent({
-      workspaceId: workspace.id,
-      actorUserId: userId,
-      source: "policy_change",
-      kind: "member.added",
-      targetType: "member",
-      targetId: null,
-      agentName: null,
-      payload: { email, role, via: "admin_added_existing" },
-    });
-    revalidatePath(`/${slug}/settings`);
-    return { message: `Added ${email} to the workspace.`, invitedEmail: email };
-  }
-
-  await writeAuditEvent({
-    workspaceId: workspace.id,
-    actorUserId: userId,
-    source: "policy_change",
-    kind: "member.invited",
-    targetType: "member",
-    targetId: result.invitation.id,
-    agentName: null,
-    payload: { email, role },
-  });
-
-  // Build the copy-paste invite (no email infra yet — the admin sends it).
-  const [instanceName] = await Promise.all([getInstanceName()]);
-  const origin = getPublicOrigin();
-  const template = [
-    `You've been invited to the "${workspace.name}" workspace on ${instanceName}.`,
-    ``,
-    `To join, sign in with this email (${email}) at:`,
-    origin,
-    ``,
-    `You'll be added automatically on your first sign-in.`,
-  ].join("\n");
-
-  revalidatePath(`/${slug}/settings`);
-  return {
-    message: `Invited ${email}.`,
-    template,
-    invitedEmail: email,
-  };
-}
-
-// Plain form action (fire-and-forget) so it can be used directly in a
-// server-rendered <form action={...}> on each pending-invite row.
-export async function revokeInvitationAction(formData: FormData): Promise<void> {
-  const slug = String(formData.get("workspace") ?? "");
-  const invitationId = String(formData.get("invitationId") ?? "");
-
-  const auth = await authorizeWorkspace(slug, "workspace_admin");
-  if (auth.denied) return;
-
-  const revoked = await revokeInvitation(invitationId, auth.workspace.id);
-  if (revoked) {
-    await writeAuditEvent({
-      workspaceId: auth.workspace.id,
-      actorUserId: auth.userId,
-      source: "policy_change",
-      kind: "member.invite_revoked",
-      targetType: "member",
-      targetId: invitationId,
-      agentName: null,
-      payload: { email: revoked.email, role: revoked.role },
-    });
-  }
-  revalidatePath(`/${slug}/settings`);
-}
-
-/**
- * Change an existing member's role. Workspace-admin only. Blocks
- * demoting the last admin — the lib helper enforces this.
- */
-export async function changeMemberRoleAction(
-  _prev: MemberFormState,
-  formData: FormData,
-): Promise<MemberFormState> {
-  const slug = String(formData.get("workspace") ?? "");
-  const targetUserId = String(formData.get("user_id") ?? "").trim();
-  const newRoleRaw = String(formData.get("role") ?? "").trim();
-  if (!targetUserId) return { error: "Missing user id." };
-  if (!isWorkspaceRole(newRoleRaw)) return { error: "Pick a role." };
-  const newRole: WorkspaceRole = newRoleRaw;
-
-  const auth = await authorizeWorkspace(slug, "workspace_admin");
-  if (auth.denied) return { error: DENIED_MESSAGE };
-  const { workspace, userId } = auth;
-
-  const result = await changeMemberRole(workspace.id, targetUserId, newRole);
-  if (!result.ok) {
-    switch (result.error) {
-      case "not-found":
-        return { error: "Member no longer exists in this workspace." };
-      case "last-admin":
-        return {
-          error:
-            "Can't demote the last workspace admin. Promote someone else first.",
-        };
-    }
-  }
-
-  if (result.previousRole !== result.newRole) {
-    await writeAuditEvent({
-      workspaceId: workspace.id,
-      actorUserId: userId,
-      source: "policy_change",
-      kind: "member.role_changed",
-      targetType: "member",
-      targetId: targetUserId,
-      agentName: null,
-      payload: {
-        target: result.target,
-        previousRole: result.previousRole,
-        newRole: result.newRole,
-      },
-    });
-  }
-
-  revalidatePath(`/${slug}/settings`);
-  return MEMBER_EMPTY;
-}
-
-/**
- * Remove a member from a workspace. Workspace-admin only. Blocks
- * removing the last admin.
- */
-export async function removeMemberAction(
-  _prev: MemberFormState,
-  formData: FormData,
-): Promise<MemberFormState> {
-  const slug = String(formData.get("workspace") ?? "");
-  const targetUserId = String(formData.get("user_id") ?? "").trim();
-  if (!targetUserId) return { error: "Missing user id." };
-
-  const auth = await authorizeWorkspace(slug, "workspace_admin");
-  if (auth.denied) return { error: DENIED_MESSAGE };
-  const { workspace, userId } = auth;
-
-  const result = await removeWorkspaceMember(workspace.id, targetUserId);
-  if (!result.ok) {
-    switch (result.error) {
-      case "not-found":
-        return { error: "Member no longer exists in this workspace." };
-      case "last-admin":
-        return {
-          error:
-            "Can't remove the last workspace admin. Promote someone else first.",
-        };
-    }
-  }
-
-  await writeAuditEvent({
-    workspaceId: workspace.id,
-    actorUserId: userId,
-    source: "policy_change",
-    kind: "member.removed",
-    targetType: "member",
-    targetId: targetUserId,
-    agentName: null,
-    payload: {
-      target: result.target,
-      previousRole: result.previousRole,
-    },
-  });
-
-  revalidatePath(`/${slug}/settings`);
-  return MEMBER_EMPTY;
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/web/src/app/[workspace]/settings/add-member-form.tsx
+++ b/web/src/app/[workspace]/settings/add-member-form.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ROLE_DESCRIPTIONS, type WorkspaceRole } from "@/lib/rbac";
 
-import { inviteMemberAction, type MemberFormState } from "./actions";
+import { inviteMemberAction, type MemberFormState } from "./members-actions";
 
 const INITIAL: MemberFormState = {};
 

--- a/web/src/app/[workspace]/settings/change-password-form.tsx
+++ b/web/src/app/[workspace]/settings/change-password-form.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/lib/auth-client";
+
+// Self-serve password change for email/password instances. Goes through
+// better-auth's changePassword (verifies the current password server-side)
+// and revokes every other session — if the reason for the change is a
+// leaked password, the leak's sessions die with it.
+export function ChangePasswordForm() {
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (next !== confirm) {
+      setError("New passwords don't match.");
+      return;
+    }
+    startTransition(async () => {
+      const res = await authClient.changePassword({
+        currentPassword: current,
+        newPassword: next,
+        revokeOtherSessions: true,
+      });
+      if (res.error) {
+        setError(res.error.message ?? "Couldn't change the password.");
+        return;
+      }
+      setCurrent("");
+      setNext("");
+      setConfirm("");
+      toast.success("Password changed.");
+    });
+  }
+
+  return (
+    <form onSubmit={submit} className="flex max-w-sm flex-col gap-3">
+      <Input
+        type="password"
+        placeholder="Current password"
+        value={current}
+        onChange={(e) => setCurrent(e.target.value)}
+        autoComplete="current-password"
+        required
+        disabled={pending}
+      />
+      <Input
+        type="password"
+        placeholder="New password"
+        value={next}
+        onChange={(e) => setNext(e.target.value)}
+        autoComplete="new-password"
+        minLength={8}
+        required
+        disabled={pending}
+      />
+      <Input
+        type="password"
+        placeholder="Confirm new password"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+        autoComplete="new-password"
+        minLength={8}
+        required
+        disabled={pending}
+      />
+
+      {error && (
+        <p className="text-sentiment-negative text-sm" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div>
+        <Button type="submit" size="small" variant="secondary" disabled={pending}>
+          {pending ? "Changing…" : "Change password"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/app/[workspace]/settings/layout.tsx
+++ b/web/src/app/[workspace]/settings/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
 
+import { emailPasswordEnabled } from "@/lib/auth-providers";
 import { isInstanceAdminEmail } from "@/lib/instance";
 import { getServerSession } from "@/lib/session";
 import { getWorkspaceBySlug, userIsMember } from "@/lib/workspace";
@@ -65,7 +66,10 @@ export default async function SettingsLayout({
       <hr className="border-[var(--color-border-weak)]" />
 
       <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:gap-10">
-        <SettingsNav workspaceSlug={workspace.slug} />
+        <SettingsNav
+          workspaceSlug={workspace.slug}
+          showAccount={emailPasswordEnabled()}
+        />
         <div className="flex min-w-0 flex-1 flex-col gap-8">{children}</div>
       </div>
     </div>

--- a/web/src/app/[workspace]/settings/member-row.tsx
+++ b/web/src/app/[workspace]/settings/member-row.tsx
@@ -13,7 +13,7 @@ import {
   changeMemberRoleAction,
   removeMemberAction,
   type MemberFormState,
-} from "./actions";
+} from "./members-actions";
 
 const INITIAL: MemberFormState = {};
 

--- a/web/src/app/[workspace]/settings/members-actions.ts
+++ b/web/src/app/[workspace]/settings/members-actions.ts
@@ -1,0 +1,333 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { notFound } from "next/navigation";
+
+import { writeAuditEvent } from "@/lib/audit-db";
+import { emailPasswordEnabled } from "@/lib/auth-providers";
+import {
+  authorizeWorkspace as authorizeWorkspaceShared,
+  DENIED_MESSAGE,
+} from "@/lib/auth-server";
+import { getPublicOrigin } from "@/lib/config";
+import { getInstanceName } from "@/lib/instance-settings";
+import { createInvitation, revokeInvitation } from "@/lib/invitations";
+import {
+  createPasswordResetToken,
+  resetPasswordPath,
+} from "@/lib/password-reset";
+import { isWorkspaceRole, type WorkspaceRole } from "@/lib/rbac";
+import {
+  changeMemberRole,
+  listWorkspaceMembers,
+  removeWorkspaceMember,
+} from "@/lib/workspace";
+
+// Member management actions, extracted from the settings grab-bag
+// actions.ts (boy-scout rule — see AGENTS.md). Same authorization
+// pattern: workspace-admin only, 404 on missing session/workspace,
+// DENIED_MESSAGE in form state on role denial.
+
+async function authorizeWorkspace(
+  slug: string,
+  minRole: WorkspaceRole = "workspace_admin",
+) {
+  const auth = await authorizeWorkspaceShared(slug, minRole);
+  if (!auth.ok) {
+    if (auth.reason === "denied") return { denied: true as const };
+    notFound();
+  }
+  return {
+    denied: false as const,
+    workspace: auth.workspace,
+    userId: auth.userId,
+    role: auth.role,
+  };
+}
+
+export type MemberFormState = {
+  message?: string;
+  error?: string;
+  /** Copy-paste invite text, set after a successful invitation. */
+  template?: string;
+  invitedEmail?: string;
+};
+
+const MEMBER_EMPTY: MemberFormState = {};
+
+/**
+ * Add a workspace member by email. Workspace-admin only. The
+ * invitee must have signed in to TAS at least once so a user row
+ * exists; we don't email invitations from TAS itself today.
+ */
+export async function inviteMemberAction(
+  _prev: MemberFormState,
+  formData: FormData,
+): Promise<MemberFormState> {
+  const slug = String(formData.get("workspace") ?? "");
+  const email = String(formData.get("email") ?? "").trim();
+  const roleRaw = String(formData.get("role") ?? "").trim();
+
+  if (!email) return { error: "Enter an email address." };
+  if (!isWorkspaceRole(roleRaw)) return { error: "Pick a role." };
+  const role: WorkspaceRole = roleRaw;
+
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (auth.denied) return { error: DENIED_MESSAGE };
+  const { workspace, userId } = auth;
+
+  const result = await createInvitation(workspace.id, email, role, userId);
+  if (!result.ok) {
+    switch (result.error) {
+      case "bad-email":
+        return { error: "That doesn't look like a valid email address." };
+      case "bad-role":
+        return { error: "Pick a role." };
+      case "already-member":
+        return {
+          error:
+            "That person is already a member. Change their role on the member row instead.",
+        };
+      case "already-invited":
+        return { error: "That email already has a pending invitation." };
+    }
+  }
+
+  // Existing account → added straight to the workspace, no invite to send.
+  if (result.joinedDirectly) {
+    await writeAuditEvent({
+      workspaceId: workspace.id,
+      actorUserId: userId,
+      source: "policy_change",
+      kind: "member.added",
+      targetType: "member",
+      targetId: null,
+      agentName: null,
+      payload: { email, role, via: "admin_added_existing" },
+    });
+    revalidatePath(`/${slug}/settings`);
+    return { message: `Added ${email} to the workspace.`, invitedEmail: email };
+  }
+
+  await writeAuditEvent({
+    workspaceId: workspace.id,
+    actorUserId: userId,
+    source: "policy_change",
+    kind: "member.invited",
+    targetType: "member",
+    targetId: result.invitation.id,
+    agentName: null,
+    payload: { email, role },
+  });
+
+  // Build the copy-paste invite (no email infra yet — the admin sends it).
+  const [instanceName] = await Promise.all([getInstanceName()]);
+  const origin = getPublicOrigin();
+  const template = [
+    `You've been invited to the "${workspace.name}" workspace on ${instanceName}.`,
+    ``,
+    `To join, sign in with this email (${email}) at:`,
+    origin,
+    ``,
+    `You'll be added automatically on your first sign-in.`,
+  ].join("\n");
+
+  revalidatePath(`/${slug}/settings`);
+  return {
+    message: `Invited ${email}.`,
+    template,
+    invitedEmail: email,
+  };
+}
+
+// Plain form action (fire-and-forget) so it can be used directly in a
+// server-rendered <form action={...}> on each pending-invite row.
+export async function revokeInvitationAction(formData: FormData): Promise<void> {
+  const slug = String(formData.get("workspace") ?? "");
+  const invitationId = String(formData.get("invitationId") ?? "");
+
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (auth.denied) return;
+
+  const revoked = await revokeInvitation(invitationId, auth.workspace.id);
+  if (revoked) {
+    await writeAuditEvent({
+      workspaceId: auth.workspace.id,
+      actorUserId: auth.userId,
+      source: "policy_change",
+      kind: "member.invite_revoked",
+      targetType: "member",
+      targetId: invitationId,
+      agentName: null,
+      payload: { email: revoked.email, role: revoked.role },
+    });
+  }
+  revalidatePath(`/${slug}/settings`);
+}
+
+/**
+ * Change an existing member's role. Workspace-admin only. Blocks
+ * demoting the last admin — the lib helper enforces this.
+ */
+export async function changeMemberRoleAction(
+  _prev: MemberFormState,
+  formData: FormData,
+): Promise<MemberFormState> {
+  const slug = String(formData.get("workspace") ?? "");
+  const targetUserId = String(formData.get("user_id") ?? "").trim();
+  const newRoleRaw = String(formData.get("role") ?? "").trim();
+  if (!targetUserId) return { error: "Missing user id." };
+  if (!isWorkspaceRole(newRoleRaw)) return { error: "Pick a role." };
+  const newRole: WorkspaceRole = newRoleRaw;
+
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (auth.denied) return { error: DENIED_MESSAGE };
+  const { workspace, userId } = auth;
+
+  const result = await changeMemberRole(workspace.id, targetUserId, newRole);
+  if (!result.ok) {
+    switch (result.error) {
+      case "not-found":
+        return { error: "Member no longer exists in this workspace." };
+      case "last-admin":
+        return {
+          error:
+            "Can't demote the last workspace admin. Promote someone else first.",
+        };
+    }
+  }
+
+  if (result.previousRole !== result.newRole) {
+    await writeAuditEvent({
+      workspaceId: workspace.id,
+      actorUserId: userId,
+      source: "policy_change",
+      kind: "member.role_changed",
+      targetType: "member",
+      targetId: targetUserId,
+      agentName: null,
+      payload: {
+        target: result.target,
+        previousRole: result.previousRole,
+        newRole: result.newRole,
+      },
+    });
+  }
+
+  revalidatePath(`/${slug}/settings`);
+  return MEMBER_EMPTY;
+}
+
+/**
+ * Remove a member from a workspace. Workspace-admin only. Blocks
+ * removing the last admin.
+ */
+export async function removeMemberAction(
+  _prev: MemberFormState,
+  formData: FormData,
+): Promise<MemberFormState> {
+  const slug = String(formData.get("workspace") ?? "");
+  const targetUserId = String(formData.get("user_id") ?? "").trim();
+  if (!targetUserId) return { error: "Missing user id." };
+
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (auth.denied) return { error: DENIED_MESSAGE };
+  const { workspace, userId } = auth;
+
+  const result = await removeWorkspaceMember(workspace.id, targetUserId);
+  if (!result.ok) {
+    switch (result.error) {
+      case "not-found":
+        return { error: "Member no longer exists in this workspace." };
+      case "last-admin":
+        return {
+          error:
+            "Can't remove the last workspace admin. Promote someone else first.",
+        };
+    }
+  }
+
+  await writeAuditEvent({
+    workspaceId: workspace.id,
+    actorUserId: userId,
+    source: "policy_change",
+    kind: "member.removed",
+    targetType: "member",
+    targetId: targetUserId,
+    agentName: null,
+    payload: {
+      target: result.target,
+      previousRole: result.previousRole,
+    },
+  });
+
+  revalidatePath(`/${slug}/settings`);
+  return MEMBER_EMPTY;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Password reset links (email/password instances)
+
+export type ResetLinkState = {
+  message?: string;
+  error?: string;
+  /** One-time reset URL to hand to the member out-of-band. */
+  url?: string;
+  /** ISO expiry of the link. */
+  expiresAt?: string;
+};
+
+/**
+ * Mint a one-time password reset link for a member. Workspace-admin
+ * only, and only on email/password instances — OAuth instances reset
+ * passwords at the identity provider, and the stock reset endpoint
+ * being able to CREATE a credential account for an OAuth-only user
+ * would amount to a second sign-in method the instance didn't enable.
+ * The admin shares the link out-of-band; it expires in an hour and is
+ * consumed on use.
+ */
+export async function createResetLinkAction(
+  _prev: ResetLinkState,
+  formData: FormData,
+): Promise<ResetLinkState> {
+  const slug = String(formData.get("workspace") ?? "");
+  const targetUserId = String(formData.get("user_id") ?? "").trim();
+  if (!targetUserId) return { error: "Missing user id." };
+
+  if (!emailPasswordEnabled()) {
+    return {
+      error:
+        "Password reset links only apply to email/password instances. This instance signs in through an identity provider.",
+    };
+  }
+
+  const auth = await authorizeWorkspace(slug, "workspace_admin");
+  if (auth.denied) return { error: DENIED_MESSAGE };
+  const { workspace, userId } = auth;
+
+  // Scope check: the admin may only reset members of their own workspace.
+  const members = await listWorkspaceMembers(workspace.id);
+  const target = members.find((m) => m.userId === targetUserId);
+  if (!target) return { error: "Member no longer exists in this workspace." };
+
+  const { token, expiresAt } = await createPasswordResetToken(targetUserId);
+
+  await writeAuditEvent({
+    workspaceId: workspace.id,
+    actorUserId: userId,
+    source: "policy_change",
+    kind: "member.password_reset_link_created",
+    targetType: "member",
+    targetId: targetUserId,
+    agentName: null,
+    // Never the token itself — the audit log records that a link was
+    // minted and for whom, not a credential equivalent.
+    payload: { email: target.email, expiresAt: expiresAt.toISOString() },
+  });
+
+  return {
+    message: `Reset link created for ${target.email}.`,
+    url: `${getPublicOrigin()}${resetPasswordPath(token)}`,
+    expiresAt: expiresAt.toISOString(),
+  };
+}

--- a/web/src/app/[workspace]/settings/members-section.tsx
+++ b/web/src/app/[workspace]/settings/members-section.tsx
@@ -6,7 +6,7 @@ import { type PendingInvitation } from "@/lib/invitations";
 import { ROLE_DESCRIPTIONS, type WorkspaceRole } from "@/lib/rbac";
 import { type WorkspaceMember } from "@/lib/workspace";
 
-import { revokeInvitationAction } from "./actions";
+import { revokeInvitationAction } from "./members-actions";
 import { AddMemberForm } from "./add-member-form";
 import { MemberRow } from "./member-row";
 

--- a/web/src/app/[workspace]/settings/members/[userId]/page.tsx
+++ b/web/src/app/[workspace]/settings/members/[userId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { LocalTime } from "@/components/local-time";
 import { Section } from "@/components/section";
 import { Badge } from "@/components/ui/badge";
+import { emailPasswordEnabled } from "@/lib/auth-providers";
 import { listAutomations } from "@/lib/automations-api";
 import { toolkitLabel } from "@/lib/composio";
 import { listConnectionsForUser } from "@/lib/composio-connections";
@@ -17,12 +18,15 @@ import {
   listWorkspaceMembers,
 } from "@/lib/workspace";
 
+import { ResetPasswordLink } from "../../reset-password-link";
+
 export const dynamic = "force-dynamic";
 
 // Member detail — workspace-admin view of one member's footprint:
 // their per-user tool connections, the automations that "Run as" them,
-// and the runs they've triggered. Read-only; the actionable bits
-// (reassign automation owner, remove member) live elsewhere. Useful for
+// and the runs they've triggered. Mostly read-only (role change /
+// remove live on the members list); the one action here is the
+// password-reset link on email/password instances. Useful for
 // offboarding ("what does this person own before I remove them?").
 export default async function MemberDetailPage({
   params,
@@ -72,6 +76,19 @@ export default async function MemberDetailPage({
           joined <LocalTime iso={member.joinedAt.toISOString()} />
         </p>
       </div>
+
+      {emailPasswordEnabled() && (
+        <Section
+          title="Password"
+          description="Generate a one-time reset link if this member is locked out. Share it with them directly — TAS doesn't send email."
+        >
+          <ResetPasswordLink
+            workspaceSlug={slug}
+            userId={member.userId}
+            email={member.email}
+          />
+        </Section>
+      )}
 
       <Section
         title="Connections"

--- a/web/src/app/[workspace]/settings/reset-password-link.tsx
+++ b/web/src/app/[workspace]/settings/reset-password-link.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { CopyButton } from "@/components/copy-button";
+import { Button } from "@/components/ui/button";
+import { useActionToast } from "@/lib/use-action-toast";
+
+import { createResetLinkAction, type ResetLinkState } from "./members-actions";
+
+const INITIAL: ResetLinkState = {};
+
+// Admin control on the member detail page (email/password instances
+// only — the server action re-checks). Mints a one-time reset link and
+// presents it for copy; TAS sends no email, the admin delivers it.
+export function ResetPasswordLink({
+  workspaceSlug,
+  userId,
+  email,
+}: {
+  workspaceSlug: string;
+  userId: string;
+  email: string;
+}) {
+  const [state, action, pending] = useActionState(createResetLinkAction, INITIAL);
+  useActionToast(state);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <form action={action}>
+        <input type="hidden" name="workspace" value={workspaceSlug} />
+        <input type="hidden" name="user_id" value={userId} />
+        <Button type="submit" size="small" variant="secondary" disabled={pending}>
+          {pending ? "Generating…" : "Generate reset link"}
+        </Button>
+      </form>
+
+      {state.error && (
+        <p className="text-sentiment-negative text-sm" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      {state.url && (
+        <div className="border-border bg-surface flex flex-col gap-2 rounded-lg border p-3">
+          <p className="text-foreground-weak text-sm">
+            Send this link to <span className="text-foreground">{email}</span>.
+            It works once and expires in an hour.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="text-foreground bg-surface-secondary min-w-0 flex-1 truncate rounded-md px-2 py-1.5 text-sm">
+              {state.url}
+            </code>
+            <CopyButton text={state.url} ariaLabel="Copy reset link" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/[workspace]/settings/settings-nav.tsx
+++ b/web/src/app/[workspace]/settings/settings-nav.tsx
@@ -24,16 +24,30 @@ const ITEMS: Item[] = [
   { slug: "danger", label: "Danger" },
 ];
 
-export function SettingsNav({ workspaceSlug }: { workspaceSlug: string }) {
+export function SettingsNav({
+  workspaceSlug,
+  showAccount = false,
+}: {
+  workspaceSlug: string;
+  /** Email/password instances get an "Account" (change password) page. */
+  showAccount?: boolean;
+}) {
   const pathname = usePathname();
   const base = `/${workspaceSlug}/settings`;
+  const items = showAccount
+    ? [
+        ...ITEMS.slice(0, ITEMS.length - 3),
+        { slug: "account", label: "Account" },
+        ...ITEMS.slice(ITEMS.length - 3),
+      ]
+    : ITEMS;
 
   return (
     <nav
       aria-label="Settings sections"
       className="flex w-full shrink-0 flex-row gap-1 overflow-x-auto sm:w-52 sm:flex-col"
     >
-      {ITEMS.map((item) => {
+      {items.map((item) => {
         const href = `${base}/${item.slug}`;
         // active when current path starts with this href, OR (for
         // the API-keys default) when the user is on bare /settings

--- a/web/src/app/reset-password/page.tsx
+++ b/web/src/app/reset-password/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import { ResetPasswordForm } from "@/components/reset-password-form";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { emailPasswordEnabled } from "@/lib/auth-providers";
+import { getInstanceName } from "@/lib/instance-settings";
+
+export const dynamic = "force-dynamic";
+
+// Public landing for admin-minted password reset links
+// (/reset-password?token=…). Unauthenticated by design — the person
+// arriving here is locked out. The token is only judged server-side
+// when the form submits; a bad token fails there with a clear message.
+export default async function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string | string[] }>;
+}) {
+  const { token: raw } = await searchParams;
+  const token = Array.isArray(raw) ? raw[0] : raw;
+  const instanceName = await getInstanceName();
+
+  return (
+    <main className="bg-surface relative flex min-h-screen flex-col items-center justify-center px-6 py-12">
+      <div className="flex w-full max-w-md flex-col items-center gap-6">
+        <h1 className="text-foreground-title text-center text-lg font-medium">
+          {instanceName}
+        </h1>
+
+        <Card className="w-full max-w-md p-3">
+          <CardHeader className="px-1 pb-3 pt-1">
+            <CardTitle className="text-foreground-title text-base">
+              Reset your password
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-1 pb-1">
+            {!emailPasswordEnabled() ? (
+              <p className="text-foreground-weak text-sm">
+                This instance signs in through an identity provider — reset
+                your password there instead.{" "}
+                <Link href="/" className="text-foreground underline">
+                  Back to sign in
+                </Link>
+                .
+              </p>
+            ) : !token ? (
+              <p className="text-foreground-weak text-sm">
+                This reset link is missing its token. Ask a workspace admin to
+                generate a new one, and open the full link they send you.
+              </p>
+            ) : (
+              <ResetPasswordForm token={token} />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/web/src/components/email-password-form.tsx
+++ b/web/src/components/email-password-form.tsx
@@ -116,6 +116,12 @@ export function EmailPasswordForm({
           ? "First time? Create an account"
           : "Already have an account? Sign in"}
       </button>
+
+      {mode === "signin" && (
+        <p className="text-foreground-muted text-center text-sm">
+          Forgot your password? Ask a workspace admin to generate a reset link.
+        </p>
+      )}
     </form>
   );
 }

--- a/web/src/components/reset-password-form.tsx
+++ b/web/src/components/reset-password-form.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/lib/auth-client";
+
+// Sets a new password from an admin-minted reset link (see
+// lib/password-reset.ts). better-auth validates + consumes the token
+// server-side; on success we send the user to sign in fresh (the reset
+// revoked their sessions).
+export function ResetPasswordForm({ token }: { token: string }) {
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (next !== confirm) {
+      setError("Passwords don't match.");
+      return;
+    }
+    startTransition(async () => {
+      const res = await authClient.resetPassword({
+        newPassword: next,
+        token,
+      });
+      if (res.error) {
+        setError(
+          res.error.code === "INVALID_TOKEN"
+            ? "This reset link is invalid or has expired. Ask a workspace admin for a new one."
+            : (res.error.message ?? "Couldn't reset the password."),
+        );
+        return;
+      }
+      setDone(true);
+    });
+  }
+
+  if (done) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-foreground text-sm">
+          Password updated. Sign in with your new password.
+        </p>
+        <Button onClick={() => (window.location.href = "/")}>Sign in</Button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3">
+      <Input
+        type="password"
+        placeholder="New password"
+        value={next}
+        onChange={(e) => setNext(e.target.value)}
+        autoComplete="new-password"
+        minLength={8}
+        required
+        disabled={pending}
+      />
+      <Input
+        type="password"
+        placeholder="Confirm new password"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+        autoComplete="new-password"
+        minLength={8}
+        required
+        disabled={pending}
+      />
+
+      {error && (
+        <p className="text-sentiment-negative text-sm" role="alert">
+          {error}
+        </p>
+      )}
+
+      <Button type="submit" disabled={pending}>
+        {pending ? "Saving…" : "Set new password"}
+      </Button>
+    </form>
+  );
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -38,7 +38,14 @@ export const auth = betterAuth({
   // still governs who may sign up. No email verification — keep first-run
   // SMTP-free; configure an OAuth provider for production.
   emailAndPassword: emailPasswordEnabled()
-    ? { enabled: true, requireEmailVerification: false, autoSignIn: true }
+    ? {
+        enabled: true,
+        requireEmailVerification: false,
+        autoSignIn: true,
+        // Reset links are admin-minted (lib/password-reset.ts) and often
+        // follow a lockout or leak — kill existing sessions on reset.
+        revokeSessionsOnPasswordReset: true,
+      }
     : { enabled: false },
   socialProviders:
     googleClientId && googleClientSecret

--- a/web/src/lib/password-reset.test.ts
+++ b/web/src/lib/password-reset.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.fn();
+vi.mock("@/lib/db", () => ({ db: { query: (...args: unknown[]) => queryMock(...args) } }));
+
+import {
+  createPasswordResetToken,
+  resetPasswordPath,
+  RESET_TOKEN_TTL_MS,
+} from "./password-reset";
+
+beforeEach(() => {
+  queryMock.mockReset();
+  queryMock.mockResolvedValue({ rowCount: 1 });
+});
+
+describe("createPasswordResetToken", () => {
+  it("writes a verification row in better-auth's reset-password shape", async () => {
+    const before = Date.now();
+    const { token, expiresAt } = await createPasswordResetToken("user-123");
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO verification");
+    const [id, identifier, value, expires] = params;
+    // The identifier is what the stock POST /api/auth/reset-password
+    // endpoint looks up — the prefix must match better-auth exactly.
+    expect(identifier).toBe(`reset-password:${token}`);
+    expect(value).toBe("user-123");
+    expect(expires).toBe(expiresAt);
+    expect(id).toBeTruthy();
+    expect(id).not.toBe(token);
+
+    // URL-safe token with enough entropy to be unguessable.
+    expect(token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(
+      before + RESET_TOKEN_TTL_MS - 1000,
+    );
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(
+      Date.now() + RESET_TOKEN_TTL_MS + 1000,
+    );
+  });
+
+  it("mints a distinct token per call", async () => {
+    const a = await createPasswordResetToken("u");
+    const b = await createPasswordResetToken("u");
+    expect(a.token).not.toBe(b.token);
+  });
+});
+
+describe("resetPasswordPath", () => {
+  it("routes to the public reset page with the token query-encoded", () => {
+    expect(resetPasswordPath("abc")).toBe("/reset-password?token=abc");
+    expect(resetPasswordPath("a+b/c")).toBe(
+      `/reset-password?token=${encodeURIComponent("a+b/c")}`,
+    );
+  });
+});

--- a/web/src/lib/password-reset.ts
+++ b/web/src/lib/password-reset.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import { randomBytes } from "crypto";
+
+import { db } from "@/lib/db";
+
+// Admin-minted password reset links for email/password instances. TAS is
+// SMTP-free, so "forgot password" is admin-driven: a workspace admin
+// generates a one-time link and hands it to the member out-of-band (the
+// same trust path as the copy-paste invite template).
+//
+// The token row is written in exactly the shape better-auth's own
+// `requestPasswordReset` produces (verification row with identifier
+// `reset-password:<token>`, value = user id), so the stock
+// `POST /api/auth/reset-password` endpoint consumes it — we only mint,
+// better-auth validates, expires, single-uses, and (per
+// `revokeSessionsOnPasswordReset` in lib/auth.ts) revokes sessions.
+
+export const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour, better-auth's own default
+
+export function resetPasswordPath(token: string): string {
+  return `/reset-password?token=${encodeURIComponent(token)}`;
+}
+
+export async function createPasswordResetToken(
+  userId: string,
+  ttlMs: number = RESET_TOKEN_TTL_MS,
+): Promise<{ token: string; expiresAt: Date }> {
+  const token = randomBytes(24).toString("base64url");
+  const expiresAt = new Date(Date.now() + ttlMs);
+  await db.query(
+    `INSERT INTO verification (id, identifier, value, "expiresAt")
+     VALUES ($1, $2, $3, $4)`,
+    [randomBytes(16).toString("base64url"), `reset-password:${token}`, userId, expiresAt],
+  );
+  return { token, expiresAt };
+}

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -3,9 +3,11 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 // Routes that don't require a signed-in session:
-//   /            — the sign-in landing
-//   /mcp         — MCP server, authed by `Authorization: Bearer tas_…`
-//   /for-agents  — native-MCP tool reference, authed by a signed bearer token
+//   /                — the sign-in landing
+//   /mcp             — MCP server, authed by `Authorization: Bearer tas_…`
+//   /for-agents      — native-MCP tool reference, authed by a signed bearer token
+//   /reset-password  — admin-minted reset links; the visitor is locked out
+//                      by definition, the token is validated on submit
 // Everything else under the matcher (/<workspace>/…, /onboarding, /settings)
 // is session-gated.
 function isPublicPath(pathname: string): boolean {
@@ -13,7 +15,8 @@ function isPublicPath(pathname: string): boolean {
     pathname === "/" ||
     pathname === "/mcp" ||
     pathname === "/for-agents" ||
-    pathname.startsWith("/for-agents/")
+    pathname.startsWith("/for-agents/") ||
+    pathname === "/reset-password"
   );
 }
 


### PR DESCRIPTION
## What

Password lifecycle for email/password instances (faust-tas, fireroad-tas, and any quickstart deploy), designed around TAS being SMTP-free — recovery is admin-driven, not emailed. **Everything here renders only when `emailPasswordEnabled()`** (i.e. no OAuth provider configured); OAuth instances manage credentials at the IdP and see none of it.

### Change password (self-serve)
Settings → **Account** (new nav item + page, email/password instances only). better-auth `changePassword` verifies the current password server-side; other sessions are revoked on success.

### Lost password (admin-driven)
Workspace admin → member detail page → **Generate reset link**. Mints a one-time token (1h expiry) and shows a copyable `/reset-password?token=…` URL to hand over out-of-band — same trust path as the copy-paste invite template. The verification row is written in exactly the shape better-auth's own `requestPasswordReset` produces, so the stock `POST /api/auth/reset-password` endpoint does all validation/consumption — we only mint. Minting writes an audit event (email + expiry, never the token). The action also refuses on OAuth instances server-side: the stock endpoint would otherwise *create* a credential account for an OAuth-only user, i.e. a second sign-in method the instance didn't enable.

### Reset
New public `/reset-password` page (proxy allowlisted — the visitor is locked out by definition; the token is only judged on submit). `revokeSessionsOnPasswordReset: true` kills existing sessions when it lands. The login form now hints "Forgot your password? Ask a workspace admin…".

### Housekeeping
Member actions extracted from the `settings/actions.ts` grab-bag into `settings/members-actions.ts` (boy-scout rule, AGENTS.md); mechanical move, the new reset action lives there.

## Testing

- `password-reset.test.ts` pins the verification-row shape to better-auth's `reset-password:<token>` contract, token entropy/uniqueness, and the public path helper.
- `npx vitest run`: 212 passed · `tsc --noEmit` clean · `next build` clean (route present) · lint: only the 3 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)