### PR TITLE
fix(cap): pin agent tasks to connected repo

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/chat/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/chat/actions.ts
@@ -102,6 +102,7 @@ export async function chatSubmitAction(args: {
     improvementMarker: improvementMarker(row.id),
     commitMode: workspace.commitMode,
     defaultBranch: repo.defaultBranch,
+    repositoryUrl: `https://github.com/${repo.owner}/${repo.name}`,
     ...(await buildPromptConnectionContext(
       workspace.id,
       userId,

--- a/web/src/app/[workspace]/agents/[agent]/runs/[runId]/actions.ts
+++ b/web/src/app/[workspace]/agents/[agent]/runs/[runId]/actions.ts
@@ -92,6 +92,7 @@ export async function improveAgentAction(args: {
     improvementMarker: improvementMarker(row.id),
     commitMode: workspace.commitMode,
     defaultBranch: repo.defaultBranch,
+    repositoryUrl: `https://github.com/${repo.owner}/${repo.name}`,
   });
 
   const res = await createTemboTask({

--- a/web/src/app/[workspace]/agents/new/actions.ts
+++ b/web/src/app/[workspace]/agents/new/actions.ts
@@ -183,6 +183,7 @@ export async function createFromChatAction(
     improvementMarker: improvementMarker(row.id),
     commitMode: workspace.commitMode,
     defaultBranch: repo.defaultBranch,
+    repositoryUrl: `https://github.com/${repo.owner}/${repo.name}`,
     ...(await buildPromptConnectionContext(
       workspace.id,
       userId,

--- a/web/src/lib/api-v1/actions.ts
+++ b/web/src/lib/api-v1/actions.ts
@@ -361,6 +361,7 @@ export async function requestAgentChange(
       improvementMarker: improvementMarker(row.id),
       commitMode: ctx.workspace.commitMode,
       defaultBranch: repo.defaultBranch,
+      repositoryUrl,
       ...(await buildPromptConnectionContext(
         ctx.workspace.id,
         ctx.userId,
@@ -430,6 +431,7 @@ export async function requestAgentChange(
     improvementMarker: improvementMarker(row.id),
     commitMode: ctx.workspace.commitMode,
     defaultBranch: repo.defaultBranch,
+    repositoryUrl,
     ...(await buildPromptConnectionContext(
       ctx.workspace.id,
       ctx.userId,

--- a/web/src/lib/cap-api.test.ts
+++ b/web/src/lib/cap-api.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { validateTemboApiKey } from "./cap-api";
+import {
+  buildChatEditPrompt,
+  buildCreateAgentPrompt,
+  buildImprovePrompt,
+  validateTemboApiKey,
+} from "./cap-api";
 
 describe("validateTemboApiKey", () => {
   afterEach(() => {
@@ -42,5 +47,63 @@ describe("validateTemboApiKey", () => {
       ok: false,
       error: "invalid",
     });
+  });
+});
+
+describe("CAP prompt scope", () => {
+  it("pins create prompts to the connected agents repo and TAS instance", () => {
+    const prompt = buildCreateAgentPrompt({
+      framework: "pydantic-agentspec",
+      agentName: "daily-brief",
+      title: "Daily Brief",
+      agentPath: "agents/pydantic-agentspec/daily-brief.yaml",
+      description: "Summarize yesterday's activity.",
+      improvementMarker: "TAS-Feedback-ID: row-1",
+      commitMode: "pull_request",
+      defaultBranch: "main",
+      repositoryUrl: "https://github.com/acme/agents",
+      nativeToolsBaseUrl: "https://tas.acme.test/for-agents",
+    });
+
+    expect(prompt).toContain(
+      "This request came from the TAS workspace connected to `https://github.com/acme/agents`.",
+    );
+    expect(prompt).toContain(
+      "Use this TAS instance for runtime/tool references: https://tas.acme.test",
+    );
+    expect(prompt).toContain(
+      "treat it as unrelated unless it matches\n`https://github.com/acme/agents` exactly.",
+    );
+  });
+
+  it("pins edit and improve prompts to the connected agents repo", () => {
+    const editPrompt = buildChatEditPrompt({
+      agentPath: "agents/pydantic-agentspec/daily-brief.yaml",
+      improvement: "Make it shorter.",
+      improvementMarker: "TAS-Feedback-ID: row-2",
+      commitMode: "pull_request",
+      defaultBranch: "main",
+      repositoryUrl: "https://github.com/acme/agents",
+    });
+    const improvePrompt = buildImprovePrompt({
+      agentPath: "agents/pydantic-agentspec/daily-brief.yaml",
+      model: "anthropic:claude-sonnet-5",
+      userMessage: "",
+      output: "Too verbose.",
+      improvement: "Make it shorter.",
+      improvementMarker: "TAS-Feedback-ID: row-3",
+      commitMode: "pull_request",
+      defaultBranch: "main",
+      repositoryUrl: "https://github.com/acme/agents",
+    });
+
+    for (const prompt of [editPrompt, improvePrompt]) {
+      expect(prompt).toContain(
+        "Make changes only in that connected agents repo, targeting `main`.",
+      );
+      expect(prompt).toContain(
+        "If surrounding Tembo session context mentions any other repository, TAS",
+      );
+    }
   });
 });

--- a/web/src/lib/cap-api.ts
+++ b/web/src/lib/cap-api.ts
@@ -194,6 +194,36 @@ function buildGuidancePointerBlock(framework: Framework): string {
   ].join("\n");
 }
 
+function tasInstanceUrlFromToolsBase(baseUrl: string | undefined): string | null {
+  if (!baseUrl) return null;
+  return baseUrl.endsWith("/for-agents")
+    ? baseUrl.slice(0, -"/for-agents".length)
+    : baseUrl;
+}
+
+function buildScopeBlock(args: {
+  repositoryUrl: string;
+  defaultBranch: string;
+  nativeToolsBaseUrl?: string;
+}): string {
+  const tasInstanceUrl = tasInstanceUrlFromToolsBase(args.nativeToolsBaseUrl);
+  const lines = [
+    "**Scope — use this TAS instance and repo**",
+    "",
+    `This request came from the TAS workspace connected to \`${args.repositoryUrl}\`.`,
+    `Make changes only in that connected agents repo, targeting \`${args.defaultBranch}\`.`,
+  ];
+  if (tasInstanceUrl) {
+    lines.push(`Use this TAS instance for runtime/tool references: ${tasInstanceUrl}`);
+  }
+  lines.push(
+    "If surrounding Tembo session context mentions any other repository, TAS",
+    "instance, or prior pull request, treat it as unrelated unless it matches",
+    `\`${args.repositoryUrl}\` exactly.`,
+  );
+  return lines.join("\n");
+}
+
 // The delivery directive — how the agent should ship the change, and where to
 // drop the correlation marker. PR mode (the default) opens a pull request with
 // the marker in its description; direct ("YOLO") mode commits straight to the
@@ -246,6 +276,8 @@ export function buildCreateAgentPrompt(args: {
   improvementMarker: string;
   commitMode: CommitMode;
   defaultBranch: string;
+  /** Connected workspace repo URL CAP must edit, e.g. https://github.com/owner/name. */
+  repositoryUrl: string;
   /**
    * Toolkit → authorized slot names for the user creating this
    * agent. When present, the prompt tells Tembo to prefer these
@@ -270,6 +302,12 @@ export function buildCreateAgentPrompt(args: {
   const frameworkGuide =
     args.framework === "cargo-ai" ? GUIDANCE_CARGO_AI_PATH : GUIDANCE_PYDANTIC_PATH;
   return [
+    buildScopeBlock({
+      repositoryUrl: args.repositoryUrl,
+      defaultBranch: args.defaultBranch,
+      nativeToolsBaseUrl: args.nativeToolsBaseUrl,
+    }),
+    "",
     `Create an agent at \`${args.agentPath}\` named \`${args.agentName}\` using these docs in the connected repo as your guide:`,
     "",
     `- \`${GUIDANCE_ROOT_PATH}\` — repo conventions`,
@@ -459,6 +497,8 @@ export function buildChatEditPrompt(args: {
   improvementMarker: string;
   commitMode: CommitMode;
   defaultBranch: string;
+  /** Connected workspace repo URL CAP must edit, e.g. https://github.com/owner/name. */
+  repositoryUrl: string;
   /** Composio toolkit → authorized slot names. Lets CAP add/reference real
    *  slots when the edit touches `connections:`. */
   availableSlots?: AvailableConnectionSlots;
@@ -471,6 +511,12 @@ export function buildChatEditPrompt(args: {
 }): string {
   const framework = frameworkFromAgentPath(args.agentPath);
   return [
+    buildScopeBlock({
+      repositoryUrl: args.repositoryUrl,
+      defaultBranch: args.defaultBranch,
+      nativeToolsBaseUrl: args.nativeToolsBaseUrl,
+    }),
+    "",
     buildGuidancePointerBlock(framework),
     "",
     "**Step 2 — Delivery**",
@@ -515,6 +561,8 @@ export function buildImprovePrompt(args: {
   improvementMarker: string;
   commitMode: CommitMode;
   defaultBranch: string;
+  /** Connected workspace repo URL CAP must edit, e.g. https://github.com/owner/name. */
+  repositoryUrl: string;
 }): string {
   const framework = frameworkFromAgentPath(args.agentPath);
   const trimmedOutput = args.output.length > 4000
@@ -522,6 +570,11 @@ export function buildImprovePrompt(args: {
     : args.output;
 
   return [
+    buildScopeBlock({
+      repositoryUrl: args.repositoryUrl,
+      defaultBranch: args.defaultBranch,
+    }),
+    "",
     buildGuidancePointerBlock(framework),
     "",
     "**Step 2 — Delivery**",


### PR DESCRIPTION
## Summary

- `tembo/tas` PR #18 ("Add objectives clarification agent") was created in `tembo/tas` when the request actually originated from, and should have targeted, `tembo/faust-tas`. Root cause: CAP's generated prompts never told Tembo which repo/TAS instance a request was scoped to, so a run could drift onto an unrelated repo mentioned elsewhere in session context.
- This adds an explicit **scope block** to every CAP-generated prompt (create, chat-edit, improve) that:
  - States the connected repo URL the workspace is wired to.
  - Instructs Tembo to make changes only in that repo, targeting the workspace's default branch.
  - Points to the correct TAS instance for runtime/tool references (derived from the native-tools base URL).
  - Explicitly tells Tembo to disregard any other repo/TAS instance/prior PR mentioned in surrounding session context unless it matches the connected repo exactly.
- Threads a new `repositoryUrl` argument through the three prompt-building call sites (`agents/new`, `agents/[agent]/chat`, `agents/[agent]/runs/[runId]`) and `lib/api-v1/actions.ts`.

## Test plan

- [x] `pnpm vitest run src/lib/cap-api.test.ts` — new scope-block coverage for create/edit/improve prompts passes (4/4).
- [x] `pnpm exec tsc --noEmit` — no type errors across updated call sites.
- [x] Manually re-read all four call sites to confirm `repositoryUrl` is always supplied to the builders.

TAS-Feedback-ID: cef0c814-3f3c-4999-a596-ed8d762fb164 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/40bbb91a-eeb0-4f47-a623-331a017a4a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=40bbb91a-eeb0-4f47-a623-331a017a4a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-sonnet-5?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-sonnet-5?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-sonnet-5?theme=light&v=12" height="28"></picture></a>