### PR TITLE
ci: fail checks on duplicate migration version numbers

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,6 +55,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: api
+      # Two PRs each adding "the next" migration number merge cleanly but
+      # produce a duplicate sqlx version, which crashes the api at boot and
+      # poisons any database it touches (v2026.8.1 shipped that way).
+      - name: Migration version numbers are unique (blocking)
+        run: |
+          dups=$(ls migrations/*.sql | sed 's|.*/||; s|_.*||' | sort | uniq -d)
+          if [ -n "$dups" ]; then
+            echo "Duplicate migration version(s): $dups"
+            ls migrations/ | grep -E "^($(echo "$dups" | paste -sd'|' -))_"
+            exit 1
+          fi
       - name: Format (blocking)
         run: cargo fmt --check
       # No `-D warnings`: there's a pre-existing clippy lint


### PR DESCRIPTION
Two PRs each adding "the next" migration number merge cleanly but produce a duplicate sqlx version, which crashes the api at boot and poisons any database it touches — exactly how v2026.8.1 shipped with two `0069`s (#346 + #347, fixed on main in 669058c, released in v2026.8.2).

This adds a blocking step to the api checks job that fails when two files in `api/migrations/` share a version prefix. Verified it flags the v2026.8.1 migration set and passes on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)