### PR TITLE
release: bump compose.release.yaml default to 2026.8.2

### DIFF
--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -43,7 +43,7 @@ services:
       retries: 10
 
   api:
-    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-api:${TAS_VERSION:-2026.8.1}
+    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-api:${TAS_VERSION:-2026.8.2}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -63,7 +63,7 @@ services:
       start_period: 30s
 
   web:
-    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-web:${TAS_VERSION:-2026.8.1}
+    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-web:${TAS_VERSION:-2026.8.2}
     restart: unless-stopped
     depends_on:
       api:


### PR DESCRIPTION
Automated bump from the v2026.8.2 release workflow (branch pushed by the workflow; Actions can't open PRs on this repo, so opening it manually — same as #365).

Keeps `compose.release.yaml`'s default pin in lockstep with the v2026.8.2 release, so customers deploying from published images get the matching version out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)