### PR TITLE
perf(agents): avoid inventory scan for detail views

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/agent-page-context.ts
+++ b/web/src/app/[workspace]/agents/[agent]/agent-page-context.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { notFound, redirect } from "next/navigation";
+import { cache } from "react";
 
 import { isAgentLocked } from "@/lib/agent-lock";
 import { getServerSession } from "@/lib/session";
@@ -28,7 +29,7 @@ export type AgentPageContext = {
   locked: boolean;
 };
 
-export async function loadAgentContext(
+export const loadAgentContext = cache(async function loadAgentContext(
   slug: string,
   agentName: string,
 ): Promise<AgentPageContext> {
@@ -62,4 +63,4 @@ export async function loadAgentContext(
     canonicalName,
     locked,
   };
-}
+});

--- a/web/src/app/[workspace]/loading.tsx
+++ b/web/src/app/[workspace]/loading.tsx
@@ -1,0 +1,36 @@
+export default function WorkspaceLoading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-8"
+    >
+      <div className="flex motion-safe:animate-pulse flex-col gap-3">
+        <div className="bg-surface-tertiary h-7 w-48 rounded-md" />
+        <div className="bg-surface-tertiary h-4 w-full max-w-xl rounded-md" />
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        {Array.from({ length: 3 }, (_, index) => (
+          <div
+            key={index}
+            className="border-border bg-surface-card flex h-32 motion-safe:animate-pulse flex-col gap-3 rounded-lg border p-4"
+          >
+            <div className="bg-surface-tertiary h-4 w-24 rounded-md" />
+            <div className="bg-surface-tertiary h-8 w-16 rounded-md" />
+            <div className="bg-surface-tertiary mt-auto h-3 w-32 rounded-md" />
+          </div>
+        ))}
+      </div>
+      <div className="border-border bg-surface-card flex motion-safe:animate-pulse flex-col gap-4 rounded-lg border p-4">
+        <div className="bg-surface-tertiary h-5 w-36 rounded-md" />
+        {Array.from({ length: 4 }, (_, index) => (
+          <div
+            key={index}
+            className="bg-surface-tertiary h-10 w-full rounded-md"
+          />
+        ))}
+      </div>
+      <span className="sr-only">Loading page</span>
+    </div>
+  );
+}

--- a/web/src/components/sidebar-nav-item.tsx
+++ b/web/src/components/sidebar-nav-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link, { useLinkStatus } from "next/link";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
@@ -43,11 +43,28 @@ export function SidebarNavItem({
         {icon}
       </span>
       <span>{label}</span>
-      {count !== undefined && count > 0 && (
-        <span className="bg-category-neutral text-foreground-strong ml-auto min-w-[1.25rem] rounded-full px-1.5 py-0.5 text-center text-xs font-semibold tabular-nums">
-          {count}
-        </span>
-      )}
+      <span className="ml-auto flex items-center gap-1.5">
+        {count !== undefined && count > 0 && (
+          <span className="bg-category-neutral text-foreground-strong min-w-[1.25rem] rounded-full px-1.5 py-0.5 text-center text-xs font-semibold tabular-nums">
+            {count}
+          </span>
+        )}
+        <PendingHint />
+      </span>
     </Link>
+  );
+}
+
+function PendingHint() {
+  const { pending } = useLinkStatus();
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "bg-foreground-muted size-1.5 shrink-0 rounded-full opacity-0",
+        pending && "motion-safe:animate-pulse opacity-100",
+      )}
+    />
   );
 }

--- a/web/src/lib/workspace-agents.test.ts
+++ b/web/src/lib/workspace-agents.test.ts
@@ -12,7 +12,10 @@ vi.mock("@/lib/agent-versions", () => ({
 import { resolveAgentReader, type AgentReader } from "@/lib/agent-source";
 import { getStableVersion } from "@/lib/agent-versions";
 import type { ListDirectoryResult } from "@/lib/github";
-import { resolveAgentForDispatch } from "@/lib/workspace-agents";
+import {
+  getAgentByName,
+  resolveAgentForDispatch,
+} from "@/lib/workspace-agents";
 
 const mockResolveAgentReader = vi.mocked(resolveAgentReader);
 const mockGetStableVersion = vi.mocked(getStableVersion);
@@ -20,7 +23,7 @@ const mockGetStableVersion = vi.mocked(getStableVersion);
 function readerWithListing(result: ListDirectoryResult): AgentReader {
   return {
     listDirectory: vi.fn().mockResolvedValue(result),
-    readFile: vi.fn(),
+    readFile: vi.fn().mockResolvedValue({ ok: false, error: "not-found" }),
   };
 }
 
@@ -86,5 +89,76 @@ describe("resolveAgentForDispatch source failures", () => {
         message: 'Agent "daily-report" is no longer in the connected repo.',
       },
     });
+  });
+});
+
+describe("getAgentByName", () => {
+  const agentYaml = [
+    "name: daily-report",
+    "model: anthropic:claude-sonnet-5",
+    "instructions: Write a daily report.",
+  ].join("\n");
+
+  it("reads a canonical agent path without listing the full inventory", async () => {
+    const reader: AgentReader = {
+      listDirectory: vi.fn(),
+      readFile: vi.fn().mockImplementation(async (path: string) =>
+        path === "agents/pydantic-agentspec/daily-report.yaml"
+          ? { ok: true, content: agentYaml, sha: "agent-sha" }
+          : { ok: false, error: "not-found" },
+      ),
+    };
+    mockResolveAgentReader.mockResolvedValue(reader);
+
+    const result = await getAgentByName("ws-1", "daily-report");
+
+    expect(result).toMatchObject({
+      agent: {
+        ok: true,
+        path: "agents/pydantic-agentspec/daily-report.yaml",
+        spec: { name: "daily-report" },
+      },
+      raw: agentYaml,
+    });
+    expect(reader.listDirectory).not.toHaveBeenCalled();
+    expect(reader.readFile).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to inventory lookup for a noncanonical filename", async () => {
+    const legacyPath = "agents/pydantic-agentspec/report-agent.yaml";
+    const reader: AgentReader = {
+      listDirectory: vi.fn().mockImplementation(async (path: string) =>
+        path === "agents/pydantic-agentspec"
+          ? {
+              ok: true,
+              entries: [
+                {
+                  type: "file",
+                  name: "report-agent.yaml",
+                  path: legacyPath,
+                  size: agentYaml.length,
+                  sha: "agent-sha",
+                  download_url: null,
+                },
+              ],
+            }
+          : { ok: true, entries: [], missing: true },
+      ),
+      readFile: vi.fn().mockImplementation(async (path: string) =>
+        path === legacyPath
+          ? { ok: true, content: agentYaml, sha: "agent-sha" }
+          : { ok: false, error: "not-found" },
+      ),
+    };
+    mockResolveAgentReader.mockResolvedValue(reader);
+
+    const result = await getAgentByName("ws-1", "daily-report");
+
+    expect(result?.agent).toMatchObject({
+      ok: true,
+      path: legacyPath,
+      spec: { name: "daily-report" },
+    });
+    expect(reader.listDirectory).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/lib/workspace-agents.ts
+++ b/web/src/lib/workspace-agents.ts
@@ -6,6 +6,7 @@ import {
   ownerHandle,
   parseAgentContent,
   parseAgentFile,
+  validateAgentName,
   type AgentConnection,
   type AgentFileFormat,
   type AgentSpec,
@@ -43,6 +44,12 @@ const FRAMEWORK_DIRS: Record<Framework, string> = {
 };
 
 const FRAMEWORK_DIR_VALUES = Object.values(FRAMEWORK_DIRS);
+
+const DIRECT_AGENT_FILES = [
+  { dir: FRAMEWORK_DIRS["pydantic-agentspec"], extension: "yaml" },
+  { dir: FRAMEWORK_DIRS["pydantic-agentspec"], extension: "yml" },
+  { dir: FRAMEWORK_DIRS["cargo-ai"], extension: "json" },
+] as const;
 
 // ── Sidecar tools module ─────────────────────────────────────────────
 //
@@ -215,6 +222,31 @@ type AgentLookupResult =
   | { ok: true; found: AgentRecord | null }
   | { ok: false; error: AgentSourceError; detail?: string };
 
+function listedAgentFromContent(
+  filename: string,
+  path: string,
+  content: string,
+): ListedAgent {
+  const parsed = parseAgentFile(filename, content);
+  if (!parsed.ok) {
+    return {
+      filename,
+      path,
+      format: detectFormat(filename),
+      ok: false,
+      error: parsed.error,
+      detail: parsed.detail,
+    };
+  }
+  return {
+    filename,
+    path,
+    format: parsed.format,
+    ok: true,
+    spec: parsed.spec,
+  };
+}
+
 /**
  * Walk the connected repo's `agents/` tree and parse every file we find.
  *
@@ -266,24 +298,7 @@ export async function listAgents(workspaceId: string): Promise<ListAgentsResult>
           detail: read.detail ?? read.error,
         };
       }
-      const parsed = parseAgentFile(entry.name, read.content);
-      if (!parsed.ok) {
-        return {
-          filename: entry.name,
-          path: entry.path,
-          format: detectFormat(entry.name),
-          ok: false,
-          error: parsed.error,
-          detail: parsed.detail,
-        };
-      }
-      return {
-        filename: entry.name,
-        path: entry.path,
-        format: parsed.format,
-        ok: true,
-        spec: parsed.spec,
-      };
+      return listedAgentFromContent(entry.name, entry.path, read.content);
     }),
   );
 
@@ -309,22 +324,58 @@ async function lookupAgentByName(
   workspaceId: string,
   agentName: string,
 ): Promise<AgentLookupResult> {
-  const list = await listAgents(workspaceId);
-  if (!list.ok) return list;
-
-  const match = list.agents.find((a) => {
-    if (a.ok) return a.spec.name === agentName;
-    const base = a.filename.replace(/\.(yaml|yml|json)$/i, "");
-    return base === agentName;
-  });
-  if (!match) return { ok: true, found: null };
-
   const reader = await resolveAgentReader(workspaceId);
   if (!reader) return { ok: false, error: "no-repo" };
-  const read = await reader.readFile(match.path);
-  if (!read.ok) {
-    if (read.error === "not-found") return { ok: true, found: null };
-    return { ok: false, error: read.error, detail: read.detail };
+
+  let match: ListedAgent | undefined;
+  let raw: string | undefined;
+
+  // Agent files normally share their validated agent name. Resolve those
+  // canonical paths directly so opening one agent doesn't read every file in
+  // a large repository. The inventory fallback preserves support for legacy
+  // files whose filename differs from their declared name.
+  if (validateAgentName(agentName)) {
+    const candidates = await Promise.all(
+      DIRECT_AGENT_FILES.map(async ({ dir, extension }) => {
+        const filename = `${agentName}.${extension}`;
+        const path = `${AGENTS_DIR}/${dir}/${filename}`;
+        return { filename, path, read: await reader.readFile(path) };
+      }),
+    );
+    for (const candidate of candidates) {
+      if (!candidate.read.ok) continue;
+      const agent = listedAgentFromContent(
+        candidate.filename,
+        candidate.path,
+        candidate.read.content,
+      );
+      if (!agent.ok || agent.spec.name === agentName) {
+        match = agent;
+        raw = candidate.read.content;
+        break;
+      }
+    }
+  }
+
+  if (!match) {
+    const list = await listAgents(workspaceId);
+    if (!list.ok) return list;
+
+    match = list.agents.find((agent) => {
+      if (agent.ok) return agent.spec.name === agentName;
+      const base = agent.filename.replace(/\.(yaml|yml|json)$/i, "");
+      return base === agentName;
+    });
+    if (!match) return { ok: true, found: null };
+  }
+
+  if (raw === undefined) {
+    const read = await reader.readFile(match.path);
+    if (!read.ok) {
+      if (read.error === "not-found") return { ok: true, found: null };
+      return { ok: false, error: read.error, detail: read.detail };
+    }
+    raw = read.content;
   }
 
   let toolsModuleContent: string | undefined;
@@ -345,7 +396,7 @@ async function lookupAgentByName(
     ok: true,
     found: {
       agent: match,
-      raw: read.content,
+      raw,
       toolsModuleContent,
       skillsContent,
     },


### PR DESCRIPTION
## Summary

- resolve canonical agent filenames directly instead of listing and parsing the entire repository inventory
- retain the inventory scan as a compatibility fallback for legacy files whose filename differs from the declared agent name
- request-memoize the agent page context shared by the nested layout and overview page
- add tests for both the direct path and compatibility fallback

## Why

The customer workspace in #405 contains 207 agents. Opening one agent currently scans every agent file, and the nested layout and page independently repeat that context resolution. A live `rytest` navigation spent 2.49 seconds in its RSC response.

This is PR 2 in the stack and depends on #409.

## Verification

- `pnpm exec eslint 'src/lib/workspace-agents.ts' 'src/lib/workspace-agents.test.ts' 'src/app/[workspace]/agents/[agent]/agent-page-context.ts'`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/lib/workspace-agents.test.ts` — 5 tests passed
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/af81dfe0-d1a3-4905-a3fc-1591ffe01949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=af81dfe0-d1a3-4905-a3fc-1591ffe01949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>