### PR TITLE
perf(navigation): defer improvement scans until after response

### DIFF
--- a/web/src/app/[workspace]/agents/[agent]/agent-page-context.ts
+++ b/web/src/app/[workspace]/agents/[agent]/agent-page-context.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { notFound, redirect } from "next/navigation";
+import { cache } from "react";
 
 import { isAgentLocked } from "@/lib/agent-lock";
 import { getServerSession } from "@/lib/session";
@@ -28,7 +29,7 @@ export type AgentPageContext = {
   locked: boolean;
 };
 
-export async function loadAgentContext(
+export const loadAgentContext = cache(async function loadAgentContext(
   slug: string,
   agentName: string,
 ): Promise<AgentPageContext> {
@@ -62,4 +63,4 @@ export async function loadAgentContext(
     canonicalName,
     locked,
   };
-}
+});

--- a/web/src/app/[workspace]/dashboard/page.tsx
+++ b/web/src/app/[workspace]/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import { LocalTime } from "@/components/local-time";
 import { Section } from "@/components/section";
 import { Badge } from "@/components/ui/badge";
-import { scanImprovementsForPRs } from "@/lib/improvement-scan";
+import { scheduleImprovementScan } from "@/lib/improvement-scan";
 import {
   countImprovementsSince,
   listImprovements,
@@ -49,12 +49,6 @@ export default async function DashboardPage({
   // Server component: compute the rolling window from the request-time clock.
   // eslint-disable-next-line react-hooks/purity
   const since = new Date(Date.now() - WEEK_MS);
-  // Refresh open PR statuses before reading counts so the headline
-  // numbers reflect reality. listOpenImprovements returns every non-
-  // terminal row regardless of age.
-  const open = await listOpenImprovements(workspace.id);
-  await scanImprovementsForPRs(workspace.id, open);
-
   const [
     stats,
     daily,
@@ -66,6 +60,7 @@ export default async function DashboardPage({
     agentsListing,
     agentOwners,
     role,
+    openImprovements,
   ] = await Promise.all([
     getWorkspaceStats30d(workspace.id),
     getWorkspaceDailyRunBands30d(workspace.id),
@@ -77,7 +72,9 @@ export default async function DashboardPage({
     listAgents(workspace.id).catch(() => null),
     listAgentOwners(workspace.id).catch(() => new Map<string, string>()),
     getWorkspaceRole(workspace.id, session.user.id),
+    listOpenImprovements(workspace.id),
   ]);
+  scheduleImprovementScan(workspace.id, openImprovements);
   const isAdmin = role === "workspace_admin";
 
   // Tally agents-owned per member, plus what's left unowned. The live agent

--- a/web/src/app/[workspace]/page.tsx
+++ b/web/src/app/[workspace]/page.tsx
@@ -6,7 +6,7 @@ import { agentDisplayName } from "@/lib/agent-format";
 import { listStarredAgentNames } from "@/lib/agent-stars";
 import { listOwnedAgentNames } from "@/lib/agent-versions";
 import { toolkitLabel } from "@/lib/composio-label";
-import { scanImprovementsForPRs } from "@/lib/improvement-scan";
+import { scheduleImprovementScan } from "@/lib/improvement-scan";
 import {
   listPendingCreatesForWorkspace,
   reconcileLandedCreates,
@@ -150,16 +150,10 @@ export default async function WorkspacePage({
     if (icons.length > 0) subMcpsByAgent.set(parent, icons);
   }
 
-  // Refresh pending creates' PR status (submitted → pr_opened → merged)
-  // so the inventory reflects reality without a separate poll. The
-  // scanner writes back to postgres, so the in-memory array is stale
-  // — re-derive `pending` from the scanner's return value and then
-  // drop rows that have moved past the non-terminal window.
-  const pendingScanned = await scanImprovementsForPRs(
-    workspace.id,
-    pendingActive,
-  );
-  const pending = pendingScanned.filter(
+  // Refresh PR state after this response. Pending creates remain visible for
+  // at most one extra navigation while GitHub reconciliation catches up.
+  scheduleImprovementScan(workspace.id, pendingActive);
+  const pending = pendingActive.filter(
     (p) =>
       p.status === "submitted" ||
       p.status === "pr_opened" ||

--- a/web/src/lib/improvement-scan.test.ts
+++ b/web/src/lib/improvement-scan.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Improvement } from "@/lib/improvements-api";
 
+const scheduleAfterResponse = vi.fn();
+vi.mock("next/server", () => ({
+  after: (callback: () => Promise<void>) => scheduleAfterResponse(callback),
+}));
+
 const setImprovementPr = vi.fn();
 const setImprovementCommit = vi.fn();
 vi.mock("@/lib/improvements-api", () => ({
@@ -19,7 +24,10 @@ vi.mock("@/lib/workspace", () => ({
     getWorkspaceSecretPlaintext(...a),
 }));
 
-import { scanImprovementsForPRs } from "./improvement-scan";
+import {
+  scanImprovementsForPRs,
+  scheduleImprovementScan,
+} from "./improvement-scan";
 
 function improvement(over: Partial<Improvement> & { id: string }): Improvement {
   return {
@@ -49,6 +57,7 @@ let wsCounter = 0;
 const nextWorkspace = () => `ws-${++wsCounter}`;
 
 beforeEach(() => {
+  scheduleAfterResponse.mockReset();
   setImprovementPr.mockReset().mockResolvedValue(undefined);
   setImprovementCommit.mockReset().mockResolvedValue(undefined);
   getWorkspaceRepo.mockReset().mockResolvedValue({ owner: "o", name: "r" });
@@ -207,5 +216,41 @@ describe("scanImprovementsForPRs", () => {
     expect(out[0].status).toBe("merged");
     expect(out[0].prNumber).toBe(7);
     vi.unstubAllGlobals();
+  });
+});
+
+describe("scheduleImprovementScan", () => {
+  it("defers GitHub reconciliation until after the response", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        number: 1,
+        html_url: "https://github.com/o/r/pull/1",
+        state: "open",
+        merged_at: null,
+        merged: false,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    scheduleImprovementScan(nextWorkspace(), [
+      improvement({ id: "a", prNumber: 1 }),
+    ]);
+
+    expect(scheduleAfterResponse).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const callback = scheduleAfterResponse.mock.calls[0][0];
+    await callback();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it("does not schedule work when every improvement is terminal", () => {
+    scheduleImprovementScan(nextWorkspace(), [
+      improvement({ id: "a", status: "merged" }),
+      improvement({ id: "b", status: "closed" }),
+    ]);
+
+    expect(scheduleAfterResponse).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/improvement-scan.ts
+++ b/web/src/lib/improvement-scan.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { after } from "next/server";
+
 // On-demand scan that reconciles each open improvement row's PR state with
 // GitHub. Called when the user visits /<workspace>/improvements (and the
 // dashboard / inventory). No webhook infra — trades freshness for simplicity.
@@ -64,12 +66,13 @@ const GH_HEADERS = (token: string) => ({
   "X-GitHub-Api-Version": "2022-11-28",
 });
 
-// Every workspace surface that renders improvement state calls this scan
-// during its server render, and the scan is several GitHub round trips —
+// Every workspace surface that renders improvement state requests this scan,
+// and the scan is several GitHub round trips —
 // two of them on the search endpoints, which are capped at ~30 req/min and
 // routinely take a second each. Unthrottled, a dashboard refresh pays the
-// full cost every time. Re-scanning at most once per window per workspace
-// keeps a merge visible within a minute while making repeat views free.
+// full cost every time if it waits for the result. Re-scanning at most once per
+// window per workspace keeps a merge visible within a minute while making
+// repeat views free.
 //
 // In-process and per-instance on purpose: this throttles redundant work, it
 // doesn't guard correctness, so a second web replica scanning once more per
@@ -82,6 +85,22 @@ const lastScanAt = new Map<string, number>();
 // workspace can have dozens) draws 403s that fetchPull silently swallows, so
 // the scan does the work and throws the answers away. Cap the burst instead.
 const PR_FETCH_CONCURRENCY = 8;
+
+/** Refresh stored GitHub state without holding the current page response open. */
+export function scheduleImprovementScan(
+  workspaceId: string,
+  improvements: Improvement[],
+): void {
+  const hasOpen = improvements.some(
+    (improvement) =>
+      improvement.status !== "merged" && improvement.status !== "closed",
+  );
+  if (!hasOpen) return;
+
+  after(async () => {
+    await scanImprovementsForPRs(workspaceId, improvements);
+  });
+}
 
 async function mapWithConcurrency<T>(
   items: T[],

--- a/web/src/lib/workspace-agents.test.ts
+++ b/web/src/lib/workspace-agents.test.ts
@@ -12,7 +12,10 @@ vi.mock("@/lib/agent-versions", () => ({
 import { resolveAgentReader, type AgentReader } from "@/lib/agent-source";
 import { getStableVersion } from "@/lib/agent-versions";
 import type { ListDirectoryResult } from "@/lib/github";
-import { resolveAgentForDispatch } from "@/lib/workspace-agents";
+import {
+  getAgentByName,
+  resolveAgentForDispatch,
+} from "@/lib/workspace-agents";
 
 const mockResolveAgentReader = vi.mocked(resolveAgentReader);
 const mockGetStableVersion = vi.mocked(getStableVersion);
@@ -20,7 +23,7 @@ const mockGetStableVersion = vi.mocked(getStableVersion);
 function readerWithListing(result: ListDirectoryResult): AgentReader {
   return {
     listDirectory: vi.fn().mockResolvedValue(result),
-    readFile: vi.fn(),
+    readFile: vi.fn().mockResolvedValue({ ok: false, error: "not-found" }),
   };
 }
 
@@ -86,5 +89,76 @@ describe("resolveAgentForDispatch source failures", () => {
         message: 'Agent "daily-report" is no longer in the connected repo.',
       },
     });
+  });
+});
+
+describe("getAgentByName", () => {
+  const agentYaml = [
+    "name: daily-report",
+    "model: anthropic:claude-sonnet-5",
+    "instructions: Write a daily report.",
+  ].join("\n");
+
+  it("reads a canonical agent path without listing the full inventory", async () => {
+    const reader: AgentReader = {
+      listDirectory: vi.fn(),
+      readFile: vi.fn().mockImplementation(async (path: string) =>
+        path === "agents/pydantic-agentspec/daily-report.yaml"
+          ? { ok: true, content: agentYaml, sha: "agent-sha" }
+          : { ok: false, error: "not-found" },
+      ),
+    };
+    mockResolveAgentReader.mockResolvedValue(reader);
+
+    const result = await getAgentByName("ws-1", "daily-report");
+
+    expect(result).toMatchObject({
+      agent: {
+        ok: true,
+        path: "agents/pydantic-agentspec/daily-report.yaml",
+        spec: { name: "daily-report" },
+      },
+      raw: agentYaml,
+    });
+    expect(reader.listDirectory).not.toHaveBeenCalled();
+    expect(reader.readFile).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to inventory lookup for a noncanonical filename", async () => {
+    const legacyPath = "agents/pydantic-agentspec/report-agent.yaml";
+    const reader: AgentReader = {
+      listDirectory: vi.fn().mockImplementation(async (path: string) =>
+        path === "agents/pydantic-agentspec"
+          ? {
+              ok: true,
+              entries: [
+                {
+                  type: "file",
+                  name: "report-agent.yaml",
+                  path: legacyPath,
+                  size: agentYaml.length,
+                  sha: "agent-sha",
+                  download_url: null,
+                },
+              ],
+            }
+          : { ok: true, entries: [], missing: true },
+      ),
+      readFile: vi.fn().mockImplementation(async (path: string) =>
+        path === legacyPath
+          ? { ok: true, content: agentYaml, sha: "agent-sha" }
+          : { ok: false, error: "not-found" },
+      ),
+    };
+    mockResolveAgentReader.mockResolvedValue(reader);
+
+    const result = await getAgentByName("ws-1", "daily-report");
+
+    expect(result?.agent).toMatchObject({
+      ok: true,
+      path: legacyPath,
+      spec: { name: "daily-report" },
+    });
+    expect(reader.listDirectory).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/lib/workspace-agents.ts
+++ b/web/src/lib/workspace-agents.ts
@@ -6,6 +6,7 @@ import {
   ownerHandle,
   parseAgentContent,
   parseAgentFile,
+  validateAgentName,
   type AgentConnection,
   type AgentFileFormat,
   type AgentSpec,
@@ -43,6 +44,12 @@ const FRAMEWORK_DIRS: Record<Framework, string> = {
 };
 
 const FRAMEWORK_DIR_VALUES = Object.values(FRAMEWORK_DIRS);
+
+const DIRECT_AGENT_FILES = [
+  { dir: FRAMEWORK_DIRS["pydantic-agentspec"], extension: "yaml" },
+  { dir: FRAMEWORK_DIRS["pydantic-agentspec"], extension: "yml" },
+  { dir: FRAMEWORK_DIRS["cargo-ai"], extension: "json" },
+] as const;
 
 // ── Sidecar tools module ─────────────────────────────────────────────
 //
@@ -215,6 +222,31 @@ type AgentLookupResult =
   | { ok: true; found: AgentRecord | null }
   | { ok: false; error: AgentSourceError; detail?: string };
 
+function listedAgentFromContent(
+  filename: string,
+  path: string,
+  content: string,
+): ListedAgent {
+  const parsed = parseAgentFile(filename, content);
+  if (!parsed.ok) {
+    return {
+      filename,
+      path,
+      format: detectFormat(filename),
+      ok: false,
+      error: parsed.error,
+      detail: parsed.detail,
+    };
+  }
+  return {
+    filename,
+    path,
+    format: parsed.format,
+    ok: true,
+    spec: parsed.spec,
+  };
+}
+
 /**
  * Walk the connected repo's `agents/` tree and parse every file we find.
  *
@@ -266,24 +298,7 @@ export async function listAgents(workspaceId: string): Promise<ListAgentsResult>
           detail: read.detail ?? read.error,
         };
       }
-      const parsed = parseAgentFile(entry.name, read.content);
-      if (!parsed.ok) {
-        return {
-          filename: entry.name,
-          path: entry.path,
-          format: detectFormat(entry.name),
-          ok: false,
-          error: parsed.error,
-          detail: parsed.detail,
-        };
-      }
-      return {
-        filename: entry.name,
-        path: entry.path,
-        format: parsed.format,
-        ok: true,
-        spec: parsed.spec,
-      };
+      return listedAgentFromContent(entry.name, entry.path, read.content);
     }),
   );
 
@@ -309,22 +324,58 @@ async function lookupAgentByName(
   workspaceId: string,
   agentName: string,
 ): Promise<AgentLookupResult> {
-  const list = await listAgents(workspaceId);
-  if (!list.ok) return list;
-
-  const match = list.agents.find((a) => {
-    if (a.ok) return a.spec.name === agentName;
-    const base = a.filename.replace(/\.(yaml|yml|json)$/i, "");
-    return base === agentName;
-  });
-  if (!match) return { ok: true, found: null };
-
   const reader = await resolveAgentReader(workspaceId);
   if (!reader) return { ok: false, error: "no-repo" };
-  const read = await reader.readFile(match.path);
-  if (!read.ok) {
-    if (read.error === "not-found") return { ok: true, found: null };
-    return { ok: false, error: read.error, detail: read.detail };
+
+  let match: ListedAgent | undefined;
+  let raw: string | undefined;
+
+  // Agent files normally share their validated agent name. Resolve those
+  // canonical paths directly so opening one agent doesn't read every file in
+  // a large repository. The inventory fallback preserves support for legacy
+  // files whose filename differs from their declared name.
+  if (validateAgentName(agentName)) {
+    const candidates = await Promise.all(
+      DIRECT_AGENT_FILES.map(async ({ dir, extension }) => {
+        const filename = `${agentName}.${extension}`;
+        const path = `${AGENTS_DIR}/${dir}/${filename}`;
+        return { filename, path, read: await reader.readFile(path) };
+      }),
+    );
+    for (const candidate of candidates) {
+      if (!candidate.read.ok) continue;
+      const agent = listedAgentFromContent(
+        candidate.filename,
+        candidate.path,
+        candidate.read.content,
+      );
+      if (!agent.ok || agent.spec.name === agentName) {
+        match = agent;
+        raw = candidate.read.content;
+        break;
+      }
+    }
+  }
+
+  if (!match) {
+    const list = await listAgents(workspaceId);
+    if (!list.ok) return list;
+
+    match = list.agents.find((agent) => {
+      if (agent.ok) return agent.spec.name === agentName;
+      const base = agent.filename.replace(/\.(yaml|yml|json)$/i, "");
+      return base === agentName;
+    });
+    if (!match) return { ok: true, found: null };
+  }
+
+  if (raw === undefined) {
+    const read = await reader.readFile(match.path);
+    if (!read.ok) {
+      if (read.error === "not-found") return { ok: true, found: null };
+      return { ok: false, error: read.error, detail: read.detail };
+    }
+    raw = read.content;
   }
 
   let toolsModuleContent: string | undefined;
@@ -345,7 +396,7 @@ async function lookupAgentByName(
     ok: true,
     found: {
       agent: match,
-      raw: read.content,
+      raw,
       toolsModuleContent,
       skillsContent,
     },


### PR DESCRIPTION
## Summary

- schedule GitHub improvement reconciliation after the Agents and Dashboard responses finish
- fetch the dashboard's open-improvement rows alongside its other data instead of as a serial phase
- retain the existing per-workspace throttle and skip scheduling when every row is terminal
- add tests proving GitHub work does not begin before the post-response callback

## Why

Improvement reconciliation performs several GitHub requests, including rate-limited search endpoints. It was awaited on the critical render path even though its results are persisted for later reads. Live customer navigation showed multi-second RSC responses on both Agents and Dashboard.

This is PR 3 in the stack and depends on #410.

Status changes may remain visible for one additional navigation; the existing reconciliation window already permits up to one minute of staleness.

## Verification

- `pnpm exec eslint 'src/lib/improvement-scan.ts' 'src/lib/improvement-scan.test.ts' 'src/app/[workspace]/page.tsx' 'src/app/[workspace]/dashboard/page.tsx'`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/lib/improvement-scan.test.ts` — 7 tests passed
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/af81dfe0-d1a3-4905-a3fc-1591ffe01949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=af81dfe0-d1a3-4905-a3fc-1591ffe01949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>