### PR TITLE
fix(web): include SWC helpers in standalone image

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -36,6 +36,9 @@ RUN addgroup --system --gid 1001 nodejs && \
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+# Resolve Next's startup hook inside the stripped runner filesystem so a
+# dangling pnpm dependency link fails the image build instead of production.
+RUN node -e "require('./node_modules/next/dist/server/require-hook.js')"
 USER nextjs
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -6,7 +6,11 @@ const nextConfig: NextConfig = {
   // template; the agent-library starter YAML files). Next.js's tracing won't
   // include raw assets by default, so opt them in here for the standalone build.
   outputFileTracingIncludes: {
-    "*": ["./src/lib/templates/**/*.md", "./src/lib/agent-library/**/*.yaml"],
+    "*": [
+      "./node_modules/@swc/helpers/**/*",
+      "./src/lib/templates/**/*.md",
+      "./src/lib/agent-library/**/*.yaml",
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary

- force Next.js standalone output tracing to include `@swc/helpers`
- verify Next.js startup dependencies inside the stripped runner image during the Docker build

## Root cause

The Next.js 16.3.1 upgrade produced a pnpm symlink for `@swc/helpers` in `.next/standalone`, but omitted the symlink target. The image built successfully and then crashed at startup with `MODULE_NOT_FOUND`.

## Verification

- `pnpm build`
- `pnpm exec eslint next.config.ts`
- `docker build --progress=plain -t tas-web-swc-fix .`
- started the resulting container and confirmed Next.js reached `Ready`
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/af81dfe0-d1a3-4905-a3fc-1591ffe01949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=af81dfe0-d1a3-4905-a3fc-1591ffe01949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>