### PR TITLE
fix(theme): soften dark semantic alerts

### DIFF
--- a/web/src/app/[workspace]/runs/runs-list.tsx
+++ b/web/src/app/[workspace]/runs/runs-list.tsx
@@ -209,7 +209,7 @@ export function RunsList({
               <span className="text-foreground-muted">—</span>
             ) : null}
             {run.errorMessagePreview && (
-              <div className="text-sentiment-negative mt-0.5 line-clamp-2 font-mono text-sm leading-4">
+              <div className="text-foreground-sentiment-negative mt-0.5 line-clamp-2 font-mono text-sm leading-4">
                 {run.errorMessagePreview}
               </div>
             )}

--- a/web/src/app/[workspace]/tool-uses/tool-uses-list.tsx
+++ b/web/src/app/[workspace]/tool-uses/tool-uses-list.tsx
@@ -143,7 +143,7 @@ export function ToolUsesList({
         <>
           <code className="text-foreground text-sm">{t.toolName}</code>
           {t.ok === false && t.errorMessage && (
-            <div className="text-sentiment-negative mt-0.5 line-clamp-2 font-mono text-xs leading-4">
+            <div className="text-foreground-sentiment-negative mt-0.5 line-clamp-2 font-mono text-xs leading-4">
               {t.errorMessage}
             </div>
           )}
@@ -301,7 +301,7 @@ function ExpandedDetail({
           <span className="text-foreground-weak text-xs font-medium uppercase tracking-wide">
             Error
           </span>
-          <pre className="text-sentiment-negative mt-1 whitespace-pre-wrap font-mono text-xs leading-5">
+          <pre className="text-foreground-sentiment-negative mt-1 whitespace-pre-wrap font-mono text-xs leading-5">
             {toolCall.errorMessage}
           </pre>
         </div>

--- a/web/src/components/action-needed.tsx
+++ b/web/src/components/action-needed.tsx
@@ -95,7 +95,7 @@ export function ActionNeeded({
               <span className="font-semibold">{it.agentLabel}</span>
             </span>
             <div className="flex items-center gap-3">
-              <Button asChild variant="orange" size="small">
+              <Button asChild variant="inverted" size="small">
                 <Link href={it.href}>{it.action}</Link>
               </Button>
               <button

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -166,7 +166,7 @@ export async function AppShell({
                         </span>{" "}
                         — add an Anthropic or OpenAI key to run agents
                       </span>
-                      <Button asChild variant="orange" size="small">
+                      <Button asChild variant="inverted" size="small">
                         <Link href={`/${workspace.slug}/settings/providers`}>
                           Add a key
                         </Link>
@@ -191,7 +191,7 @@ export async function AppShell({
                           ? "has changes awaiting promotion"
                           : "are awaiting promotion"}
                       </span>
-                      <Button asChild variant="orange" size="small">
+                      <Button asChild variant="inverted" size="small">
                         <Link
                           href={
                             pendingPromotions.length === 1
@@ -212,14 +212,14 @@ export async function AppShell({
                   >
                     <IconExclamationTriangle
                       size={14}
-                      className="text-sentiment-negative mt-0.5 shrink-0"
+                      className="text-icon-sentiment-negative mt-0.5 shrink-0"
                     />
                     <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
-                      <span className="text-sentiment-negative text-sm leading-tight">
+                      <span className="text-foreground-sentiment-negative text-sm leading-tight">
                         <span className="font-semibold">{automation.name}</span>{" "}
                         did not fire for {automation.agentName}
                       </span>
-                      <Button asChild variant="destructive" size="small">
+                      <Button asChild variant="inverted" size="small">
                         <Link
                           href={`/${workspace.slug}/automations/${automation.id}`}
                         >
@@ -238,16 +238,16 @@ export async function AppShell({
                     >
                       <IconExclamationTriangle
                         size={14}
-                        className="text-sentiment-negative mt-0.5 shrink-0"
+                        className="text-icon-sentiment-negative mt-0.5 shrink-0"
                       />
                       <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
-                        <span className="text-sentiment-negative text-sm leading-tight">
+                        <span className="text-foreground-sentiment-negative text-sm leading-tight">
                           <span className="font-semibold">{f.agentName}</span>{" "}
                           failed{" "}
                           <span className="font-semibold">{f.failures}×</span> in
                           24h
                         </span>
-                        <Button asChild variant="destructive" size="small">
+                        <Button asChild variant="inverted" size="small">
                           <Link href={agentHref}>Open</Link>
                         </Button>
                       </div>

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -28,7 +28,7 @@ const badgeVariants = cva(
         pink: "bg-category-pink text-foreground-category-pink [&_svg]:text-icon-category-pink",
         purple:
           "bg-category-purple text-foreground-category-purple [&_svg]:text-icon-category-purple",
-        red: "bg-category-red text-foreground-category-red [&_svg]:text-icon-category-red",
+        red: "bg-category-red text-foreground-sentiment-negative [&_svg]:text-icon-sentiment-negative",
         teal: "bg-category-teal text-foreground-category-teal [&_svg]:text-icon-category-teal",
         yellow:
           "bg-category-yellow text-foreground-category-yellow [&_svg]:text-icon-category-yellow",

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -18,7 +18,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       className={cn(
         "bg-input text-foreground-strong placeholder:text-foreground-weak hover:bg-input-hover hover:placeholder:text-foreground focus:bg-input-active focus:placeholder:text-foreground-weak focus-visible:shadow-focus-ring disabled:bg-input-disabled disabled:text-foreground-muted disabled:placeholder:text-foreground-muted flex h-8 w-full min-w-0 rounded-lg shadow-[0_0_0_1px_var(--color-border)] py-1 px-3 text-sm font-medium tracking-[-0.1px] file:border-0 file:bg-transparent file:text-sm file:font-medium focus:outline-none transition-[background-color,box-shadow,color] duration-150 disabled:cursor-not-allowed",
         error &&
-          "border-sentiment-negative bg-input-error text-sentiment-negative",
+          "border-sentiment-negative bg-input-error text-foreground-sentiment-negative",
         className,
       )}
       ref={ref}


### PR DESCRIPTION
## Summary

- use the monorepo semantic foreground and icon tokens for dark-mode errors
- replace saturated orange/red actions inside sidebar alerts with neutral inverted actions
- apply the same error foreground treatment to run lists, tool-use details, and invalid inputs

## Validation

- `cd web && pnpm exec tsc --noEmit`
- targeted ESLint on all changed files
- production Docker build
- browser-verified warning cards and failed-run text in dark mode

Follow-up to #448.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/f5c4bbf6-4899-4190-8983-aff8babc1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=f5c4bbf6-4899-4190-8983-aff8babc1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>