### PR TITLE
fix(automations): defer schedules for agents being created

### DIFF
--- a/web/src/lib/improvements-api.test.ts
+++ b/web/src/lib/improvements-api.test.ts
@@ -4,7 +4,10 @@ const { query } = vi.hoisted(() => ({ query: vi.fn() }));
 
 vi.mock("@/lib/db", () => ({ db: { query } }));
 
-import { listImprovementsForAgent } from "./improvements-api";
+import {
+  isAgentCreatePending,
+  listImprovementsForAgent,
+} from "./improvements-api";
 
 function row(id: string, createdAt: string) {
   return {
@@ -56,5 +59,22 @@ describe("listImprovementsForAgent", () => {
       "old",
       "new",
     ]);
+  });
+});
+
+describe("isAgentCreatePending", () => {
+  beforeEach(() => query.mockReset());
+
+  it("matches an in-flight create for the workspace agent", async () => {
+    query.mockResolvedValue({ rows: [{ pending: true }] });
+
+    await expect(
+      isAgentCreatePending("workspace", "daily-report"),
+    ).resolves.toBe(true);
+
+    expect(query.mock.calls[0]?.[0]).toMatch(
+      /kind = 'create'[\s\S]*status IN \('submitted', 'pr_opened'\)/,
+    );
+    expect(query.mock.calls[0]?.[1]).toEqual(["workspace", "daily-report"]);
   });
 });

--- a/web/src/lib/improvements-api.ts
+++ b/web/src/lib/improvements-api.ts
@@ -193,6 +193,27 @@ export async function listPendingCreatesForWorkspace(
   return res.rows.map(rowToImprovement);
 }
 
+export async function isAgentCreatePending(
+  workspaceId: string,
+  agentName: string,
+): Promise<boolean> {
+  const res = await db.query<{ pending: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1
+         FROM improvement
+        WHERE workspace_id = $1
+          AND agent_name = $2
+          AND kind = 'create'
+          AND (
+            status IN ('submitted', 'pr_opened')
+            OR (delivery = 'direct' AND status = 'committed' AND commit_url IS NULL)
+          )
+     ) AS pending`,
+    [workspaceId, agentName],
+  );
+  return res.rows[0]?.pending ?? false;
+}
+
 /**
  * Dismiss a pending agent-create from the inventory: mark the create
  * improvement `closed` so it drops out of listPendingCreatesForWorkspace.

--- a/web/src/lib/scheduler.test.ts
+++ b/web/src/lib/scheduler.test.ts
@@ -30,6 +30,9 @@ vi.mock("@/lib/inbox-api", () => ({
   listUnconsumedSignalsForAgent: vi.fn(),
   markSignalsConsumed: vi.fn(),
 }));
+vi.mock("@/lib/improvements-api", () => ({
+  isAgentCreatePending: vi.fn(),
+}));
 vi.mock("@/lib/tool-reconcile", () => ({
   maybeReconcileToolCaches: vi.fn().mockResolvedValue(undefined),
 }));
@@ -42,6 +45,7 @@ import {
   pauseAutomationsWithMissingOwners,
   recordAutomationFailure,
 } from "@/lib/automation-events";
+import { isAgentCreatePending } from "@/lib/improvements-api";
 import { startScheduler, stopScheduler } from "@/lib/scheduler";
 import { resolveAgentForDispatch } from "@/lib/workspace-agents";
 
@@ -49,6 +53,7 @@ const mockListEnabled = vi.mocked(listEnabledAutomations);
 const mockPauseMissingOwners = vi.mocked(pauseAutomationsWithMissingOwners);
 const mockResolveDispatch = vi.mocked(resolveAgentForDispatch);
 const mockRecordFailure = vi.mocked(recordAutomationFailure);
+const mockIsAgentCreatePending = vi.mocked(isAgentCreatePending);
 
 const automation: Automation = {
   id: "automation-1",
@@ -76,6 +81,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockPauseMissingOwners.mockResolvedValue(0);
   mockListEnabled.mockResolvedValue([automation]);
+  mockIsAgentCreatePending.mockResolvedValue(false);
   vi.spyOn(console, "log").mockImplementation(() => undefined);
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
 });
@@ -128,6 +134,27 @@ describe("scheduler agent-source failures", () => {
       occurredAt: expect.any(Date),
       failure: expect.objectContaining({ code: "not-found" }),
     });
+  });
+
+  it("keeps the firing window due while the agent is being created", async () => {
+    mockResolveDispatch.mockResolvedValue({
+      ok: false,
+      error: {
+        kind: "not-found",
+        message: 'Agent "daily-report" is no longer in the connected repo.',
+      },
+    });
+    mockIsAgentCreatePending.mockResolvedValue(true);
+
+    startScheduler();
+
+    await vi.waitFor(() =>
+      expect(mockIsAgentCreatePending).toHaveBeenCalledWith(
+        automation.workspaceId,
+        automation.agentName,
+      ),
+    );
+    expect(mockRecordFailure).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/lib/scheduler.ts
+++ b/web/src/lib/scheduler.ts
@@ -49,6 +49,7 @@ import {
   type InboxAction,
   type InboxItem,
 } from "@/lib/inbox-api";
+import { isAgentCreatePending } from "@/lib/improvements-api";
 import { resolveAgentForDispatch } from "@/lib/workspace-agents";
 import { maybeReconcileToolCaches } from "@/lib/tool-reconcile";
 
@@ -69,6 +70,10 @@ const MAX_LEARNING_CASES = 20;
 let started = false;
 let timer: NodeJS.Timeout | null = null;
 const sourceRetries = new Map<
+  string,
+  { attempts: number; retryAfter: number }
+>();
+const pendingCreateRetries = new Map<
   string,
   { attempts: number; retryAfter: number }
 >();
@@ -106,6 +111,7 @@ export function stopScheduler() {
   timer = null;
   started = false;
   sourceRetries.clear();
+  pendingCreateRetries.clear();
 }
 
 async function tick() {
@@ -124,6 +130,7 @@ async function tick() {
     } catch (e) {
       console.error("[scheduler] maybeFire threw", a.id, e);
       sourceRetries.delete(a.id);
+      pendingCreateRetries.delete(a.id);
       await recordAutomationFailure({
         kind: "schedule",
         id: a.id,
@@ -146,6 +153,8 @@ async function maybeFire(a: Automation, now: Date) {
   if (!a.lastFireError) sourceRetries.delete(a.id);
   const pendingRetry = sourceRetries.get(a.id);
   if (pendingRetry && pendingRetry.retryAfter > now.getTime()) return;
+  const pendingCreateRetry = pendingCreateRetries.get(a.id);
+  if (pendingCreateRetry && pendingCreateRetry.retryAfter > now.getTime()) return;
 
   // Resolve the agent — the stable snapshot by default, or the live draft
   // when the automation opts in. listEnabledAutomations doesn't pre-fetch
@@ -154,6 +163,28 @@ async function maybeFire(a: Automation, now: Date) {
     preferDraft: a.useDraft,
   });
   if (!dispatch.ok) {
+    if (
+      dispatch.error.kind === "not-found" &&
+      (await isAgentCreatePending(a.workspaceId, a.agentName))
+    ) {
+      const previousAttempts = pendingCreateRetries.get(a.id)?.attempts ?? 0;
+      const attempts = previousAttempts + 1;
+      const delay = Math.min(
+        TICK_MS * 2 ** Math.min(attempts - 1, 10),
+        SOURCE_RETRY_MAX_MS,
+      );
+      pendingCreateRetries.set(a.id, {
+        attempts,
+        retryAfter: now.getTime() + delay,
+      });
+      console.log(
+        "[scheduler] agent creation pending; retrying",
+        a.id,
+        `in ${delay}ms`,
+      );
+      return;
+    }
+    pendingCreateRetries.delete(a.id);
     if (dispatch.error.kind === "source-unavailable" && dispatch.error.retryable) {
       const previousAttempts = sourceRetries.get(a.id)?.attempts ?? 0;
       const attempts = previousAttempts + 1;
@@ -184,6 +215,7 @@ async function maybeFire(a: Automation, now: Date) {
     return;
   }
   sourceRetries.delete(a.id);
+  pendingCreateRetries.delete(a.id);
   const r = dispatch.resolved;
 
   // POST directly to /internal/runs with the new spec_content /
@@ -259,6 +291,7 @@ async function recordSkipAndAdvance(
   failure: AutomationDispatchFailure,
 ): Promise<void> {
   sourceRetries.delete(a.id);
+  pendingCreateRetries.delete(a.id);
   console.warn("[scheduler] skip fire", a.id, failure.code, failure.summary);
   await recordAutomationFailure({
     kind: "schedule",


### PR DESCRIPTION
## Summary

- detect when a scheduled agent is still being created
- keep its current firing window due and retry with bounded backoff
- preserve permanent `not-found` failures for genuinely deleted or renamed agents

Fixes #462.

## Testing

- `pnpm test -- src/lib/scheduler.test.ts src/lib/improvements-api.test.ts` (322 tests passed)
- `pnpm exec eslint src/lib/scheduler.ts src/lib/scheduler.test.ts src/lib/improvements-api.ts src/lib/improvements-api.test.ts`
- `pnpm exec tsc --noEmit`
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/8035d4c1-df68-4c8a-827b-509f31d7e4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=8035d4c1-df68-4c8a-827b-509f31d7e4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>