### PR TITLE
release: bump compose.release.yaml default to 2026.9.2

### DIFF
--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -43,7 +43,7 @@ services:
       retries: 10
 
   api:
-    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-api:${TAS_VERSION:-2026.8.2}
+    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-api:${TAS_VERSION:-2026.9.2}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -68,7 +68,7 @@ services:
       start_period: 30s
 
   web:
-    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-web:${TAS_VERSION:-2026.8.2}
+    image: ghcr.io/${TAS_IMAGE_OWNER:-tembo}/tas-web:${TAS_VERSION:-2026.9.2}
     restart: unless-stopped
     depends_on:
       api:


### PR DESCRIPTION
Automated release follow-up: keep `compose.release.yaml`'s default pin in lockstep with the `v2026.9.2` release, so customers deploying from published images get the matching version out of the box. The API applies database migrations on boot.

The release workflow created this signed commit but could not open the PR because GitHub Actions is not permitted to create pull requests in the repository settings.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/acfa9fa4-ef6d-4774-ba04-7781d669ef11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=acfa9fa4-ef6d-4774-ba04-7781d669ef11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/opencode:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/opencode:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/opencode:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>